### PR TITLE
feat(codex): add context history and rewrite components

### DIFF
--- a/components/adapters/codex/src/context-history/effective-history.ts
+++ b/components/adapters/codex/src/context-history/effective-history.ts
@@ -1,0 +1,98 @@
+import { readCodexContextHistoryJournalEntries } from "./journal-store.js";
+import { cloneJson, hashJson } from "./shared.js";
+import type { CodexEffectiveHistory, CodexEffectiveHistoryItem, JsonObject } from "./types.js";
+
+function nativeItemId(item: JsonObject, prefix: string, index: number): string {
+  const type = typeof item.type === "string"
+    ? item.type
+    : typeof item.role === "string"
+      ? `message:${item.role}`
+      : "item";
+  if (typeof item.id === "string") return `${type}:id:${item.id}`;
+  if (typeof item.call_id === "string") return `${type}:call:${item.call_id}`;
+  return `${type}:hash:${hashJson({ prefix, index, item })}`;
+}
+
+function isObservationOnlyItem(item: JsonObject): boolean {
+  const type = String(item.type ?? "").toLowerCase();
+  return type === "web_search_call" || type === "event_msg" || type === "turn_context";
+}
+
+function appendEffectiveItem(params: {
+  item: JsonObject;
+  prefix: string;
+  index: number;
+  seen: Set<string>;
+  replayableItems: CodexEffectiveHistoryItem[];
+  observationOnlyItems: CodexEffectiveHistoryItem[];
+}): void {
+  const nativeId = nativeItemId(params.item, params.prefix, params.index);
+  if (params.seen.has(nativeId)) return;
+  params.seen.add(nativeId);
+  const effectiveItem: CodexEffectiveHistoryItem = {
+    stableItemId: `codex-${hashJson(nativeId)}`,
+    nativeId,
+    callId: typeof params.item.call_id === "string" ? params.item.call_id : undefined,
+    item: cloneJson(params.item),
+  };
+  if (isObservationOnlyItem(params.item)) params.observationOnlyItems.push(effectiveItem);
+  else params.replayableItems.push(effectiveItem);
+}
+
+function unresolvedCallIds(items: CodexEffectiveHistoryItem[]): string[] {
+  const calls = new Set<string>();
+  const outputs = new Set<string>();
+  for (const entry of items) {
+    const type = String(entry.item.type ?? "").toLowerCase();
+    if ((type === "function_call" || type === "custom_tool_call") && entry.callId) calls.add(entry.callId);
+    if ((type === "function_call_output" || type === "custom_tool_call_output") && entry.callId) outputs.add(entry.callId);
+  }
+  return Array.from(calls).filter((callId) => !outputs.has(callId)).sort();
+}
+
+export async function buildCodexEffectiveHistory(params: {
+  stateDir: string;
+  sessionId: string;
+  rolloutParserBootstrap?: () => Promise<CodexEffectiveHistory | null>;
+}): Promise<CodexEffectiveHistory> {
+  const journal = await readCodexContextHistoryJournalEntries(params.stateDir, params.sessionId);
+  const hasIncompleteJournal = journal.some((entry) => entry.status === "incomplete");
+  if ((journal.length === 0 || hasIncompleteJournal) && params.rolloutParserBootstrap) {
+    const bootstrapped = await params.rolloutParserBootstrap();
+    if (bootstrapped) return bootstrapped;
+  }
+
+  const replayableItems: CodexEffectiveHistoryItem[] = [];
+  const observationOnlyItems: CodexEffectiveHistoryItem[] = [];
+  const seen = new Set<string>();
+  journal.forEach((entry, entryIndex) => {
+    const items = entry.kind === "request" ? entry.inputItems : entry.outputItems;
+    items.forEach((item, itemIndex) => {
+      appendEffectiveItem({
+        item,
+        prefix: `${entry.kind}:${entryIndex}`,
+        index: itemIndex,
+        seen,
+        replayableItems,
+        observationOnlyItems,
+      });
+    });
+  });
+
+  const unresolved = unresolvedCallIds(replayableItems);
+  const revision = `rev-${hashJson({
+    replayableItems: replayableItems.map((entry) => entry.nativeId),
+    observationOnlyItems: observationOnlyItems.map((entry) => entry.nativeId),
+    unresolved,
+    hasIncompleteJournal,
+  })}`;
+
+  return {
+    revision,
+    replayableItems,
+    observationOnlyItems,
+    unresolvedCallIds: unresolved,
+    source: journal.length > 0 ? "proxy_journal" : "empty",
+    incomplete: hasIncompleteJournal,
+  };
+}

--- a/components/adapters/codex/src/context-history/index.ts
+++ b/components/adapters/codex/src/context-history/index.ts
@@ -1,0 +1,11 @@
+export * from "./types.js";
+export {
+  codexContextHistoryJournalPath,
+  loadCodexContextHistoryJournal,
+} from "./journal-store.js";
+export { appendCodexRequestJournalEntry } from "./request-journal.js";
+export {
+  appendCodexResponseJournalEntry,
+  collectCodexResponseItemsFromStream,
+} from "./response-journal.js";
+export { buildCodexEffectiveHistory } from "./effective-history.js";

--- a/components/adapters/codex/src/context-history/journal-store.ts
+++ b/components/adapters/codex/src/context-history/journal-store.ts
@@ -1,0 +1,45 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  CODEX_CONTEXT_HISTORY_REQUEST_SCHEMA,
+  CODEX_CONTEXT_HISTORY_RESPONSE_SCHEMA,
+  type CodexContextHistoryJournalEntry,
+} from "./types.js";
+
+function encodedSessionId(sessionId: string): string {
+  return encodeURIComponent(sessionId.trim() || "unknown-session");
+}
+
+export function codexContextHistoryJournalPath(stateDir: string, sessionId: string): string {
+  return join(stateDir, "context-history", "codex", "sessions", encodedSessionId(sessionId), "journal.jsonl");
+}
+
+function isContextHistoryJournalEntry(entry: unknown): entry is CodexContextHistoryJournalEntry {
+  return Boolean(entry && typeof entry === "object" && (
+    (entry as { schema?: unknown }).schema === CODEX_CONTEXT_HISTORY_REQUEST_SCHEMA
+    || (entry as { schema?: unknown }).schema === CODEX_CONTEXT_HISTORY_RESPONSE_SCHEMA
+  ));
+}
+
+export async function readCodexContextHistoryJournalEntries(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexContextHistoryJournalEntry[]> {
+  try {
+    const raw = await readFile(codexContextHistoryJournalPath(stateDir, sessionId), "utf8");
+    return raw
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as unknown)
+      .filter(isContextHistoryJournalEntry);
+  } catch {
+    return [];
+  }
+}
+
+export async function loadCodexContextHistoryJournal(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexContextHistoryJournalEntry[]> {
+  return readCodexContextHistoryJournalEntries(stateDir, sessionId);
+}

--- a/components/adapters/codex/src/context-history/request-journal.ts
+++ b/components/adapters/codex/src/context-history/request-journal.ts
@@ -1,0 +1,70 @@
+import { appendJsonl } from "@lightmem2/host-adapter";
+import { codexContextHistoryJournalPath, readCodexContextHistoryJournalEntries } from "./journal-store.js";
+import { cloneJson, hashJson, normalizeStatus, sanitizeValue } from "./shared.js";
+import {
+  CODEX_CONTEXT_HISTORY_REQUEST_SCHEMA,
+  type CodexJournalStatus,
+  type CodexRequestJournalEntry,
+  type JsonObject,
+} from "./types.js";
+
+function sanitizedInputItems(payload: JsonObject): JsonObject[] {
+  return Array.isArray(payload.input)
+    ? cloneJson(sanitizeValue(payload.input)) as JsonObject[]
+    : [];
+}
+
+function requestIdFromPayload(params: {
+  sessionId: string;
+  turnOrdinal?: number;
+  payload: JsonObject;
+}): string {
+  return `req-${hashJson({
+    sessionId: params.sessionId,
+    turnOrdinal: params.turnOrdinal,
+    model: params.payload.model,
+    previousResponseId: params.payload.previous_response_id,
+    input: params.payload.input,
+  })}`;
+}
+
+export async function appendCodexRequestJournalEntry(params: {
+  stateDir: string;
+  sessionId: string;
+  payload: JsonObject;
+  requestId?: string;
+  turnOrdinal?: number;
+  status?: CodexJournalStatus;
+  error?: string;
+  observedAt?: string;
+}): Promise<CodexRequestJournalEntry> {
+  const requestId = params.requestId ?? requestIdFromPayload(params);
+  const current = await readCodexContextHistoryJournalEntries(params.stateDir, params.sessionId);
+  const existing = current.find((entry): entry is CodexRequestJournalEntry =>
+    entry.kind === "request" && entry.requestId === requestId,
+  );
+  if (existing) return existing;
+
+  const requestEntries = current.filter((entry) => entry.kind === "request");
+  const entry: CodexRequestJournalEntry = {
+    schema: CODEX_CONTEXT_HISTORY_REQUEST_SCHEMA,
+    kind: "request",
+    requestId,
+    sessionId: params.sessionId,
+    turnOrdinal: params.turnOrdinal ?? requestEntries.length + 1,
+    model: typeof params.payload.model === "string" ? params.payload.model : undefined,
+    stream: params.payload.stream === true,
+    previousResponseId: typeof params.payload.previous_response_id === "string"
+      ? params.payload.previous_response_id
+      : undefined,
+    promptCacheKey: typeof params.payload.prompt_cache_key === "string"
+      ? params.payload.prompt_cache_key
+      : undefined,
+    inputItems: sanitizedInputItems(params.payload),
+    status: normalizeStatus(params.status, "pending"),
+    error: params.error,
+    observedAt: params.observedAt ?? new Date().toISOString(),
+  };
+  await appendJsonl(codexContextHistoryJournalPath(params.stateDir, params.sessionId), entry);
+  return entry;
+}

--- a/components/adapters/codex/src/context-history/response-journal.ts
+++ b/components/adapters/codex/src/context-history/response-journal.ts
@@ -1,0 +1,219 @@
+import { appendJsonl } from "@lightmem2/host-adapter";
+import { codexContextHistoryJournalPath } from "./journal-store.js";
+import { asJsonObject, cloneJson, normalizeStatus, sanitizeValue } from "./shared.js";
+import {
+  CODEX_CONTEXT_HISTORY_RESPONSE_SCHEMA,
+  type CodexJournalStatus,
+  type CodexResponseJournalEntry,
+  type JsonObject,
+} from "./types.js";
+
+type StreamEvent = {
+  event: string;
+  data: JsonObject;
+};
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseSseEvents(rawStreamText: string): StreamEvent[] {
+  const events: StreamEvent[] = [];
+  for (const chunk of rawStreamText.split(/\r?\n\r?\n/)) {
+    const lines = chunk.split(/\r?\n/);
+    const eventLine = lines.find((line) => line.startsWith("event:"));
+    const event = eventLine?.slice("event:".length).trim() || "message";
+    const dataLines = lines
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice("data:".length).trim())
+      .filter(Boolean);
+    for (const dataText of dataLines) {
+      if (dataText === "[DONE]") continue;
+      const data = asJsonObject(safeJsonParse(dataText));
+      if (data) events.push({ event, data });
+    }
+  }
+  return events;
+}
+
+function outputItemKeyFromEvent(data: JsonObject, fallbackIndex: number): string {
+  const item = asJsonObject(data.item);
+  if (typeof item?.id === "string") return item.id;
+  if (typeof data.item_id === "string") return data.item_id;
+  if (typeof data.output_index === "number") return `output_index:${data.output_index}`;
+  return `event:${fallbackIndex}`;
+}
+
+function deltaText(data: JsonObject): string {
+  const nestedDelta = asJsonObject(data.delta);
+  if (typeof data.delta === "string") return data.delta;
+  if (typeof nestedDelta?.output_text === "string") return nestedDelta.output_text;
+  if (typeof nestedDelta?.text === "string") return nestedDelta.text;
+  return "";
+}
+
+function mergeOutputTextDelta(item: JsonObject, data: JsonObject): void {
+  const delta = deltaText(data);
+  if (!delta) return;
+  if (!Array.isArray(item.content)) {
+    item.content = [{ type: "output_text", text: "" }];
+  }
+  const content = item.content as unknown[];
+  const first = asJsonObject(content[0]);
+  if (!first) {
+    content[0] = { type: "output_text", text: delta };
+    return;
+  }
+  first.text = `${typeof first.text === "string" ? first.text : ""}${delta}`;
+}
+
+function mergeFunctionArgumentsDelta(item: JsonObject, data: JsonObject): void {
+  const delta = typeof data.delta === "string" ? data.delta : "";
+  if (!delta) return;
+  item.arguments = `${typeof item.arguments === "string" ? item.arguments : ""}${delta}`;
+}
+
+function responseMetadata(data: JsonObject): {
+  responseId?: string;
+  previousResponseId?: string;
+  output?: unknown[];
+} {
+  const response = asJsonObject(data.response);
+  return {
+    responseId: typeof response?.id === "string"
+      ? response.id
+      : typeof data.id === "string"
+        ? data.id
+        : undefined,
+    previousResponseId: typeof response?.previous_response_id === "string"
+      ? response.previous_response_id
+      : typeof data.previous_response_id === "string"
+        ? data.previous_response_id
+        : undefined,
+    output: Array.isArray(response?.output) ? response.output : undefined,
+  };
+}
+
+export function collectCodexResponseItemsFromStream(rawStreamText: string): {
+  outputItems: JsonObject[];
+  eventTypeCounts: Record<string, number>;
+  responseId?: string;
+  previousResponseId?: string;
+  status: CodexJournalStatus;
+} {
+  const events = parseSseEvents(rawStreamText);
+  const outputItems = new Map<string, JsonObject>();
+  const eventTypeCounts: Record<string, number> = {};
+  let responseId: string | undefined;
+  let previousResponseId: string | undefined;
+  let status: CodexJournalStatus = "incomplete";
+
+  events.forEach(({ event, data }, index) => {
+    eventTypeCounts[event] = (eventTypeCounts[event] ?? 0) + 1;
+
+    const metadata = responseMetadata(data);
+    responseId = metadata.responseId ?? responseId;
+    previousResponseId = metadata.previousResponseId ?? previousResponseId;
+    if (event === "response.completed") status = "completed";
+    if (event === "response.failed") status = "failed";
+    if (event === "response.incomplete") status = "incomplete";
+
+    for (const item of metadata.output ?? []) {
+      const cloned = asJsonObject(cloneJson(item));
+      if (!cloned) continue;
+      outputItems.set(typeof cloned.id === "string" ? cloned.id : `response-output:${outputItems.size}`, cloned);
+    }
+
+    const addedItem = asJsonObject(data.item);
+    if (addedItem) {
+      const key = outputItemKeyFromEvent(data, index);
+      outputItems.set(key, {
+        ...(outputItems.get(key) ?? {}),
+        ...cloneJson(addedItem),
+      });
+      return;
+    }
+
+    if (event === "response.output_text.delta") {
+      const key = outputItemKeyFromEvent(data, index);
+      const item = outputItems.get(key) ?? {
+        id: typeof data.item_id === "string" ? data.item_id : undefined,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "" }],
+      };
+      mergeOutputTextDelta(item, data);
+      outputItems.set(key, item);
+      return;
+    }
+
+    if (event === "response.function_call_arguments.delta") {
+      const key = outputItemKeyFromEvent(data, index);
+      const item = outputItems.get(key) ?? {
+        id: typeof data.item_id === "string" ? data.item_id : undefined,
+        type: "function_call",
+      };
+      mergeFunctionArgumentsDelta(item, data);
+      outputItems.set(key, item);
+    }
+  });
+
+  return {
+    outputItems: Array.from(outputItems.values()).map((item) => cloneJson(sanitizeValue(item)) as JsonObject),
+    eventTypeCounts,
+    responseId,
+    previousResponseId,
+    status,
+  };
+}
+
+function outputRefs(outputItems: JsonObject[]): CodexResponseJournalEntry["outputItemRefs"] {
+  return outputItems.map((item) => ({
+    type: typeof item.type === "string" ? item.type : undefined,
+    itemId: typeof item.id === "string" ? item.id : undefined,
+    callId: typeof item.call_id === "string" ? item.call_id : undefined,
+  }));
+}
+
+export async function appendCodexResponseJournalEntry(params: {
+  stateDir: string;
+  sessionId: string;
+  requestId?: string;
+  response?: JsonObject;
+  rawStreamText?: string;
+  status?: CodexJournalStatus;
+  error?: string;
+  observedAt?: string;
+}): Promise<CodexResponseJournalEntry> {
+  const streamCollected = typeof params.rawStreamText === "string"
+    ? collectCodexResponseItemsFromStream(params.rawStreamText)
+    : undefined;
+  const response = params.response ?? {};
+  const outputItems = streamCollected
+    ? streamCollected.outputItems
+    : Array.isArray(response.output)
+      ? cloneJson(sanitizeValue(response.output)) as JsonObject[]
+      : [];
+  const entry: CodexResponseJournalEntry = {
+    schema: CODEX_CONTEXT_HISTORY_RESPONSE_SCHEMA,
+    kind: "response",
+    requestId: params.requestId,
+    sessionId: params.sessionId,
+    responseId: streamCollected?.responseId ?? (typeof response.id === "string" ? response.id : undefined),
+    previousResponseId: streamCollected?.previousResponseId
+      ?? (typeof response.previous_response_id === "string" ? response.previous_response_id : undefined),
+    stream: typeof params.rawStreamText === "string",
+    outputItems,
+    outputItemRefs: outputRefs(outputItems),
+    eventTypeCounts: streamCollected?.eventTypeCounts,
+    status: normalizeStatus(params.status, streamCollected?.status ?? "completed"),
+    error: params.error,
+    observedAt: params.observedAt ?? new Date().toISOString(),
+  };
+  await appendJsonl(codexContextHistoryJournalPath(params.stateDir, params.sessionId), entry);
+  return entry;
+}

--- a/components/adapters/codex/src/context-history/shared.ts
+++ b/components/adapters/codex/src/context-history/shared.ts
@@ -1,0 +1,35 @@
+import { createHash } from "node:crypto";
+import type { CodexJournalStatus, JsonObject } from "./types.js";
+
+export function asJsonObject(value: unknown): JsonObject | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : undefined;
+}
+
+export function cloneJson<T>(value: T): T {
+  return value == null ? value : JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function hashJson(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 24);
+}
+
+export function normalizeStatus(status: unknown, fallback: CodexJournalStatus): CodexJournalStatus {
+  return status === "pending" || status === "completed" || status === "failed" || status === "incomplete"
+    ? status
+    : fallback;
+}
+
+export function sanitizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sanitizeValue);
+  const object = asJsonObject(value);
+  if (!object) return value;
+
+  const output: JsonObject = {};
+  for (const [key, child] of Object.entries(object)) {
+    if (/^(authorization|headers?|api[-_]?key)$/i.test(key)) continue;
+    output[key] = sanitizeValue(child);
+  }
+  return output;
+}

--- a/components/adapters/codex/src/context-history/types.ts
+++ b/components/adapters/codex/src/context-history/types.ts
@@ -1,0 +1,64 @@
+export const CODEX_CONTEXT_HISTORY_REQUEST_SCHEMA = "lightmem2.codex.context-history.request/v1";
+export const CODEX_CONTEXT_HISTORY_RESPONSE_SCHEMA = "lightmem2.codex.context-history.response/v1";
+
+export type JsonObject = Record<string, unknown>;
+
+export type CodexJournalStatus = "pending" | "completed" | "failed" | "incomplete";
+
+export type CodexRequestJournalEntry = {
+  schema: typeof CODEX_CONTEXT_HISTORY_REQUEST_SCHEMA;
+  kind: "request";
+  requestId: string;
+  sessionId: string;
+  turnOrdinal: number;
+  model?: string;
+  stream: boolean;
+  previousResponseId?: string;
+  promptCacheKey?: string;
+  inputItems: JsonObject[];
+  status: CodexJournalStatus;
+  error?: string;
+  observedAt: string;
+};
+
+export type CodexResponseOutputRef = {
+  type?: string;
+  itemId?: string;
+  callId?: string;
+};
+
+export type CodexResponseJournalEntry = {
+  schema: typeof CODEX_CONTEXT_HISTORY_RESPONSE_SCHEMA;
+  kind: "response";
+  requestId?: string;
+  sessionId: string;
+  responseId?: string;
+  previousResponseId?: string;
+  stream: boolean;
+  outputItems: JsonObject[];
+  outputItemRefs: CodexResponseOutputRef[];
+  eventTypeCounts?: Record<string, number>;
+  status: CodexJournalStatus;
+  error?: string;
+  observedAt: string;
+};
+
+export type CodexContextHistoryJournalEntry =
+  | CodexRequestJournalEntry
+  | CodexResponseJournalEntry;
+
+export type CodexEffectiveHistoryItem = {
+  stableItemId: string;
+  nativeId?: string;
+  callId?: string;
+  item: JsonObject;
+};
+
+export type CodexEffectiveHistory = {
+  revision: string;
+  replayableItems: CodexEffectiveHistoryItem[];
+  observationOnlyItems: CodexEffectiveHistoryItem[];
+  unresolvedCallIds: string[];
+  source: "proxy_journal" | "rollout_bootstrap" | "empty";
+  incomplete: boolean;
+};

--- a/components/adapters/codex/src/context-rewrite/disabled.ts
+++ b/components/adapters/codex/src/context-rewrite/disabled.ts
@@ -1,0 +1,30 @@
+import { cloneJson } from "./shared.js";
+import type {
+  CodexContextRewriteConfig,
+  CodexContextRewriteResult,
+  CodexEffectiveHistory,
+  CodexMutationPlan,
+  JsonObject,
+} from "./types.js";
+
+export async function applyCodexContextRewrite(params: {
+  config: CodexContextRewriteConfig;
+  sessionId: string;
+  payload: JsonObject;
+  effectiveHistory: CodexEffectiveHistory;
+  mutationPlan: CodexMutationPlan;
+}): Promise<CodexContextRewriteResult> {
+  if (!params.config.enabled) {
+    return {
+      payload: cloneJson(params.payload),
+      outcome: "disabled",
+      rebaseAttempted: false,
+    };
+  }
+
+  return {
+    payload: cloneJson(params.payload),
+    outcome: "deferred",
+    rebaseAttempted: false,
+  };
+}

--- a/components/adapters/codex/src/context-rewrite/fallback.ts
+++ b/components/adapters/codex/src/context-rewrite/fallback.ts
@@ -1,0 +1,41 @@
+import { cloneJson } from "./shared.js";
+import type {
+  CodexRebaseFallbackResult,
+  CodexUpstreamResponse,
+  CodexUpstreamSender,
+  JsonObject,
+} from "./types.js";
+
+function isSuccessfulResponse(response: CodexUpstreamResponse): boolean {
+  return response.status >= 200 && response.status < 300;
+}
+
+export async function executeCodexRebaseWithFallback(params: {
+  sessionId: string;
+  planId: string;
+  epochId: string;
+  originalPayload: JsonObject;
+  rebasedPayload: JsonObject;
+  sendUpstream: CodexUpstreamSender;
+}): Promise<CodexRebaseFallbackResult> {
+  const rebaseResponse = await params.sendUpstream(cloneJson(params.rebasedPayload));
+  if (isSuccessfulResponse(rebaseResponse)) {
+    return {
+      response: rebaseResponse,
+      outcome: "committed",
+      rebaseResponse,
+    };
+  }
+
+  const fallbackResponse = await params.sendUpstream(cloneJson(params.originalPayload));
+  return {
+    response: fallbackResponse,
+    outcome: isSuccessfulResponse(fallbackResponse) ? "bypassed" : "failed",
+    rebaseResponse,
+    cooldown: {
+      planId: params.planId,
+      startedAt: new Date().toISOString(),
+      reason: "rebase_upstream_rejected",
+    },
+  };
+}

--- a/components/adapters/codex/src/context-rewrite/index.ts
+++ b/components/adapters/codex/src/context-rewrite/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export { applyCodexContextRewrite } from "./disabled.js";
+export { executeCodexRebaseWithFallback } from "./fallback.js";
+export { buildCodexRebaseRequest } from "./rebase-request.js";

--- a/components/adapters/codex/src/context-rewrite/rebase-request.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-request.ts
@@ -1,0 +1,57 @@
+import { cloneJson, stableInputKey } from "./shared.js";
+import type {
+  CodexEffectiveHistory,
+  CodexMutationPlan,
+  CodexRebaseRequestResult,
+  JsonObject,
+} from "./types.js";
+
+function evictedStableItemIds(plan: CodexMutationPlan): Set<string> {
+  return new Set(
+    plan.operations
+      .filter((operation) => operation.type === "evict" && typeof operation.stableItemId === "string")
+      .map((operation) => String(operation.stableItemId)),
+  );
+}
+
+function stripServerOwnedResponsesFields(item: JsonObject): JsonObject {
+  const next = cloneJson(item);
+  delete next.id;
+  delete next.status;
+  delete next.created_at;
+  return next;
+}
+
+export function buildCodexRebaseRequest(params: {
+  sessionId: string;
+  planId: string;
+  baseRevision: string;
+  originalPayload: JsonObject;
+  effectiveHistory: CodexEffectiveHistory;
+  currentInput: unknown;
+  mutationPlan: CodexMutationPlan;
+}): CodexRebaseRequestResult {
+  const payload = cloneJson(params.originalPayload);
+  delete payload.previous_response_id;
+
+  const evicted = evictedStableItemIds(params.mutationPlan);
+  const currentInput = Array.isArray(params.currentInput)
+    ? cloneJson(params.currentInput)
+    : [];
+  const currentInputKeys = new Set(currentInput.map(stableInputKey));
+  const retainedHistory = params.effectiveHistory.replayableItems
+    .filter((entry) => !evicted.has(entry.stableItemId))
+    .map((entry) => stripServerOwnedResponsesFields(entry.item))
+    .filter((item) => !currentInputKeys.has(stableInputKey(item)));
+
+  payload.input = [
+    ...retainedHistory,
+    ...currentInput,
+  ];
+
+  return {
+    payload,
+    oldRevision: params.baseRevision,
+    rebaseRevision: `${params.baseRevision}:${params.planId}:rebase`,
+  };
+}

--- a/components/adapters/codex/src/context-rewrite/shared.ts
+++ b/components/adapters/codex/src/context-rewrite/shared.ts
@@ -1,0 +1,7 @@
+export function cloneJson<T>(value: T): T {
+  return value == null ? value : JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function stableInputKey(item: unknown): string {
+  return JSON.stringify(item);
+}

--- a/components/adapters/codex/src/context-rewrite/types.ts
+++ b/components/adapters/codex/src/context-rewrite/types.ts
@@ -1,0 +1,59 @@
+export type JsonObject = Record<string, unknown>;
+
+export type CodexContextRewriteConfig = {
+  enabled: boolean;
+  mode: "response_chain_rebase";
+  failureMode: "bypass";
+  retryOriginalRequest: boolean;
+  cooldownMs: number;
+};
+
+export type CodexEffectiveHistoryItem = {
+  stableItemId: string;
+  nativeId?: string;
+  item: JsonObject;
+};
+
+export type CodexEffectiveHistory = {
+  revision: string;
+  replayableItems: CodexEffectiveHistoryItem[];
+  observationOnlyItems?: CodexEffectiveHistoryItem[];
+};
+
+export type CodexMutationPlan = {
+  operations: Array<{
+    type: string;
+    stableItemId?: string;
+  }>;
+};
+
+export type CodexRebaseRequestResult = {
+  payload: JsonObject;
+  oldRevision: string;
+  rebaseRevision: string;
+};
+
+export type CodexUpstreamResponse = {
+  status: number;
+  headers: Record<string, string>;
+  text: string;
+};
+
+export type CodexRebaseFallbackResult = {
+  response: CodexUpstreamResponse;
+  outcome: "committed" | "bypassed" | "failed";
+  rebaseResponse?: CodexUpstreamResponse;
+  cooldown?: {
+    planId: string;
+    startedAt: string;
+    reason: string;
+  };
+};
+
+export type CodexContextRewriteResult = {
+  payload: JsonObject;
+  outcome: "disabled" | "deferred";
+  rebaseAttempted: boolean;
+};
+
+export type CodexUpstreamSender = (payload: JsonObject) => Promise<CodexUpstreamResponse>;

--- a/components/adapters/codex/tests/context-history-journal.test.ts
+++ b/components/adapters/codex/tests/context-history-journal.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendCodexRequestJournalEntry,
+  appendCodexResponseJournalEntry,
+  buildCodexEffectiveHistory,
+  collectCodexResponseItemsFromStream,
+  loadCodexContextHistoryJournal,
+} from "../src/context-history/index.js";
+
+async function withTempState(
+  fn: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-context-history-"));
+  try {
+    await fn(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+test("CDH-01 request journal stores sanitized input metadata and deduplicates request retries", async () => {
+  await withTempState(async (stateDir) => {
+    const payload = {
+      model: "gpt-5.4-mini",
+      stream: false,
+      previous_response_id: "resp-prev-1",
+      prompt_cache_key: "pk-session-1",
+      api_key: "sk-should-not-persist",
+      input: [
+        {
+          role: "developer",
+          content: "stable instructions",
+          headers: { authorization: "Bearer secret" },
+        },
+        {
+          role: "user",
+          content: [{ type: "input_text", text: "continue" }],
+        },
+      ],
+    };
+
+    const first = await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      turnOrdinal: 7,
+      payload,
+      status: "completed",
+      observedAt: "2026-07-24T10:00:00.000Z",
+    });
+    const retry = await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      turnOrdinal: 7,
+      payload,
+      status: "completed",
+      observedAt: "2026-07-24T10:00:01.000Z",
+    });
+
+    const journal = await loadCodexContextHistoryJournal(stateDir, "codex-session-1");
+    assert.equal(first.requestId, retry.requestId);
+    assert.equal(journal.length, 1);
+    assert.equal(journal[0]?.kind, "request");
+    assert.equal(journal[0]?.model, "gpt-5.4-mini");
+    assert.equal(journal[0]?.previousResponseId, "resp-prev-1");
+    assert.equal(journal[0]?.turnOrdinal, 7);
+    assert.equal(journal[0]?.inputItems.length, 2);
+    assert.doesNotMatch(JSON.stringify(journal[0]), /authorization|headers|sk-should-not-persist|Bearer secret/i);
+  });
+});
+
+test("CDH-02 response journal stores full non-stream output items and native refs", async () => {
+  await withTempState(async (stateDir) => {
+    const entry = await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: {
+        id: "resp-1",
+        previous_response_id: "resp-prev-1",
+        output: [
+          { id: "rs-1", type: "reasoning", encrypted_content: "opaque" },
+          {
+            id: "msg-1",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "done" }],
+          },
+          { id: "fc-1", type: "function_call", call_id: "call-1", name: "run_tests", arguments: "{\"ok\":true}" },
+          { id: "cc-1", type: "custom_tool_call", call_id: "custom-1", name: "custom", input: "payload" },
+          { id: "ws-1", type: "web_search_call", query: "observation only" },
+        ],
+      },
+      observedAt: "2026-07-24T10:00:02.000Z",
+    });
+
+    assert.equal(entry.responseId, "resp-1");
+    assert.equal(entry.previousResponseId, "resp-prev-1");
+    assert.equal(entry.outputItems.length, 5);
+    assert.deepEqual(
+      entry.outputItems.map((item) => item.type),
+      ["reasoning", "message", "function_call", "custom_tool_call", "web_search_call"],
+    );
+    assert.deepEqual(
+      entry.outputItemRefs.map((ref) => ref.callId).filter(Boolean),
+      ["call-1", "custom-1"],
+    );
+  });
+});
+
+test("CDH-02 stream collector aggregates output items and marks incomplete streams", () => {
+  const completeStream = [
+    "event: response.created",
+    "data: {\"response\":{\"id\":\"resp-stream-1\",\"previous_response_id\":\"resp-prev-1\"}}",
+    "",
+    "event: response.output_item.added",
+    "data: {\"output_index\":0,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"\"}]}}",
+    "",
+    "event: response.output_text.delta",
+    "data: {\"item_id\":\"msg-1\",\"output_index\":0,\"delta\":\"hello\"}",
+    "",
+    "event: response.output_item.added",
+    "data: {\"output_index\":1,\"item\":{\"id\":\"fc-1\",\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"run_tests\",\"arguments\":\"\"}}",
+    "",
+    "event: response.function_call_arguments.delta",
+    "data: {\"item_id\":\"fc-1\",\"output_index\":1,\"delta\":\"{\\\"command\\\":\"}",
+    "",
+    "event: response.function_call_arguments.delta",
+    "data: {\"item_id\":\"fc-1\",\"output_index\":1,\"delta\":\"\\\"npm test\\\"}\"}",
+    "",
+    "event: response.completed",
+    "data: {\"response\":{\"id\":\"resp-stream-1\"}}",
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n");
+
+  const complete = collectCodexResponseItemsFromStream(completeStream);
+  assert.equal(complete.status, "completed");
+  assert.equal(complete.responseId, "resp-stream-1");
+  assert.equal(complete.previousResponseId, "resp-prev-1");
+  assert.equal(complete.outputItems.length, 2);
+  assert.match(JSON.stringify(complete.outputItems), /hello/);
+  assert.match(JSON.stringify(complete.outputItems), /npm test/);
+  assert.equal(complete.eventTypeCounts["response.output_text.delta"], 1);
+
+  const incomplete = collectCodexResponseItemsFromStream(completeStream.replace("event: response.completed", "event: response.output_text.delta"));
+  assert.equal(incomplete.status, "incomplete");
+});
+
+test("CDH-04 builds effective history from proxy journal in strict order with replay and observation split", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: {
+        model: "gpt-5.4-mini",
+        input: [
+          { role: "developer", content: "stable instructions" },
+          { role: "user", content: "turn one" },
+        ],
+      },
+      status: "completed",
+      observedAt: "2026-07-24T10:00:00.000Z",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: {
+        id: "resp-1",
+        output: [
+          { id: "msg-1", type: "message", role: "assistant", content: [{ type: "output_text", text: "need tool" }] },
+          { id: "fc-1", type: "function_call", call_id: "call-1", name: "run_tests", arguments: "{}" },
+          { id: "ws-1", type: "web_search_call", query: "observed but not replayed" },
+        ],
+      },
+      observedAt: "2026-07-24T10:00:01.000Z",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      payload: {
+        model: "gpt-5.4-mini",
+        previous_response_id: "resp-1",
+        input: [
+          { type: "function_call_output", call_id: "call-1", output: "{\"passed\":true}" },
+          { role: "user", content: "turn two" },
+        ],
+      },
+      status: "completed",
+      observedAt: "2026-07-24T10:00:02.000Z",
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+    });
+
+    assert.equal(history.source, "proxy_journal");
+    assert.equal(history.incomplete, false);
+    assert.equal(history.unresolvedCallIds.length, 0);
+    assert.equal(history.observationOnlyItems.length, 1);
+    assert.equal(history.observationOnlyItems[0]?.item.type, "web_search_call");
+    assert.deepEqual(
+      history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
+      ["developer", "user", "message", "function_call", "function_call_output", "user"],
+    );
+    assert.match(history.revision, /^rev-[0-9a-f]+$/);
+  });
+});
+
+test("CDH-04 delegates to rollout parser bootstrap when proxy journal is incomplete", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      rawStreamText: [
+        "event: response.created",
+        "data: {\"response\":{\"id\":\"resp-incomplete\"}}",
+        "",
+        "event: response.output_text.delta",
+        "data: {\"item_id\":\"msg-1\",\"delta\":\"partial\"}",
+        "",
+      ].join("\n"),
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      async rolloutParserBootstrap() {
+        return {
+          revision: "rollout-rev-1",
+          replayableItems: [
+            {
+              stableItemId: "rollout-user-1",
+              nativeId: "rollout-msg-1",
+              item: { role: "user", content: "bootstrapped from rollout parser fake" },
+            },
+          ],
+          observationOnlyItems: [],
+          unresolvedCallIds: [],
+          source: "rollout_bootstrap",
+          incomplete: false,
+        };
+      },
+    });
+
+    assert.equal(history.source, "rollout_bootstrap");
+    assert.equal(history.revision, "rollout-rev-1");
+    assert.equal(history.replayableItems[0]?.item.content, "bootstrapped from rollout parser fake");
+  });
+});

--- a/components/adapters/codex/tests/context-rebase-behavior.test.ts
+++ b/components/adapters/codex/tests/context-rebase-behavior.test.ts
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyCodexContextRewrite,
+  buildCodexRebaseRequest,
+  executeCodexRebaseWithFallback,
+  type CodexEffectiveHistory,
+  type JsonObject,
+} from "../src/context-rewrite/index.js";
+
+const EVICTED_SENTINEL = "EVICT_ME_cdr02_behavior";
+const RETAINED_SENTINEL = "KEEP_ME_cdr02_behavior";
+const CURRENT_SENTINEL = "CURRENT_INPUT_cdr02_behavior";
+
+type ResponsesPayload = JsonObject & {
+  model?: string;
+  stream?: boolean;
+  previous_response_id?: string;
+  prompt_cache_key?: string;
+  instructions?: string;
+  tools?: unknown[];
+  input?: unknown[];
+};
+
+function asObject(value: unknown): JsonObject {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : {};
+}
+
+function textFromResponsesInput(input: unknown): string {
+  if (!Array.isArray(input)) return "";
+  const parts: string[] = [];
+  for (const item of input) {
+    const entry = asObject(item);
+    if (typeof entry.content === "string") parts.push(entry.content);
+    if (typeof entry.output === "string") parts.push(entry.output);
+    if (typeof entry.arguments === "string") parts.push(entry.arguments);
+    if (Array.isArray(entry.content)) {
+      for (const block of entry.content) {
+        if (!block || typeof block !== "object") continue;
+        if (typeof block.text === "string") parts.push(block.text);
+        if (typeof block.content === "string") parts.push(block.content);
+      }
+    }
+  }
+  return parts.join("\n");
+}
+
+function occurrences(text: string, needle: string): number {
+  return text.split(needle).length - 1;
+}
+
+function baseResponsesPayload(): ResponsesPayload {
+  return {
+    model: "gpt-5.4-mini",
+    stream: true,
+    previous_response_id: "resp-old-chain",
+    prompt_cache_key: "pk-stable-codex-session",
+    instructions: "Follow the repo instructions.",
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "run_tests",
+          parameters: { type: "object", properties: { command: { type: "string" } } },
+        },
+      },
+    ],
+    input: [
+      {
+        role: "user",
+        content: [{ type: "input_text", text: `${CURRENT_SENTINEL}: continue the migration` }],
+      },
+    ],
+  };
+}
+
+function effectiveHistoryFixture(): CodexEffectiveHistory {
+  return {
+    revision: "history-rev-1",
+    replayableItems: [
+      {
+        stableItemId: "developer-1",
+        nativeId: "msg-dev-1",
+        item: { role: "developer", content: "Shared stable instructions" },
+      },
+      {
+        stableItemId: "evicted-user-1",
+        nativeId: "msg-user-evict",
+        item: { role: "user", content: `obsolete details ${EVICTED_SENTINEL}` },
+      },
+      {
+        stableItemId: "retained-user-1",
+        nativeId: "msg-user-keep",
+        item: { role: "user", content: `important details ${RETAINED_SENTINEL}` },
+      },
+      {
+        stableItemId: "call-1",
+        nativeId: "fc-1",
+        item: { type: "function_call", call_id: "call-1", name: "run_tests", arguments: "{\"command\":\"npm test\"}" },
+      },
+      {
+        stableItemId: "result-1",
+        nativeId: "fco-1",
+        item: { type: "function_call_output", call_id: "call-1", output: "{\"ok\":true}" },
+      },
+    ],
+    observationOnlyItems: [
+      {
+        stableItemId: "web-search-1",
+        nativeId: "ws-1",
+        item: { type: "web_search_call", query: "not replayable by default" },
+      },
+    ],
+  };
+}
+
+test("CDR-02 builds a rebase request that removes previous_response_id and evicted history", async () => {
+  const originalPayload = baseResponsesPayload();
+
+  const result = buildCodexRebaseRequest({
+    sessionId: "codex-session-1",
+    planId: "plan-evict-obsolete-details",
+    baseRevision: "history-rev-1",
+    originalPayload,
+    effectiveHistory: effectiveHistoryFixture(),
+    currentInput: originalPayload.input,
+    mutationPlan: {
+      operations: [{ type: "evict", stableItemId: "evicted-user-1" }],
+    },
+  });
+
+  const payload = result.payload as ResponsesPayload;
+  assert.equal("previous_response_id" in payload, false);
+  assert.equal(payload.model, originalPayload.model);
+  assert.equal(payload.stream, originalPayload.stream);
+  assert.equal(payload.instructions, originalPayload.instructions);
+  assert.deepEqual(payload.tools, originalPayload.tools);
+  assert.equal(payload.prompt_cache_key, originalPayload.prompt_cache_key);
+
+  const forwardedText = textFromResponsesInput(payload.input);
+  assert.equal(forwardedText.includes(EVICTED_SENTINEL), false);
+  assert.equal(forwardedText.includes(RETAINED_SENTINEL), true);
+  assert.equal(occurrences(forwardedText, CURRENT_SENTINEL), 1);
+  const inputItems = Array.isArray(payload.input) ? payload.input : [];
+  assert.equal(
+    inputItems.some((item) => asObject(item).type === "web_search_call"),
+    false,
+  );
+});
+
+test("CDR-04 retries the original request once when rebase replay is rejected upstream", async () => {
+  const originalPayload = baseResponsesPayload();
+  const rebasedPayload: ResponsesPayload = {
+    ...originalPayload,
+    input: [{ role: "user", content: `rebased ${RETAINED_SENTINEL} ${CURRENT_SENTINEL}` }],
+  };
+  delete rebasedPayload.previous_response_id;
+  const sentPayloads: JsonObject[] = [];
+
+  const result = await executeCodexRebaseWithFallback({
+    sessionId: "codex-session-1",
+    planId: "plan-evict-obsolete-details",
+    epochId: "epoch-1",
+    originalPayload,
+    rebasedPayload,
+    async sendUpstream(payload: JsonObject) {
+      sentPayloads.push(payload);
+      if (sentPayloads.length === 1) {
+        return {
+          status: 400,
+          headers: { "content-type": "application/json" },
+          text: JSON.stringify({ error: { message: "unsupported replay item", code: "invalid_request_error" } }),
+        };
+      }
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({ id: "resp-original-fallback", output: [] }),
+      };
+    },
+  });
+
+  assert.equal(sentPayloads.length, 2);
+  assert.equal("previous_response_id" in (sentPayloads[0] ?? {}), false);
+  assert.equal(sentPayloads[1]?.previous_response_id, "resp-old-chain");
+  assert.equal(result.response.status, 200);
+  assert.match(result.response.text, /resp-original-fallback/);
+  assert.equal(result.outcome, "bypassed");
+  assert.equal(result.cooldown?.planId, "plan-evict-obsolete-details");
+});
+
+test("CDR-07 leaves the Codex payload equivalent when context rewrite is disabled", async () => {
+  const originalPayload = baseResponsesPayload();
+  const before = JSON.parse(JSON.stringify(originalPayload));
+
+  const result = await applyCodexContextRewrite({
+    config: {
+      enabled: false,
+      mode: "response_chain_rebase",
+      failureMode: "bypass",
+      retryOriginalRequest: true,
+      cooldownMs: 300_000,
+    },
+    sessionId: "codex-session-1",
+    payload: originalPayload,
+    effectiveHistory: effectiveHistoryFixture(),
+    mutationPlan: {
+      operations: [{ type: "evict", stableItemId: "evicted-user-1" }],
+    },
+  });
+
+  assert.deepEqual(result.payload, before);
+  assert.equal(result.outcome, "disabled");
+  assert.equal(result.rebaseAttempted, false);
+});


### PR DESCRIPTION
## Summary


First Draft PR for Codex pure components.

Done:

- CDH-01 request journal
- CDH-02 response journal + basic stream collector
- thin CDH-04 effective history builder
- CDR-02 / CDR-04 / CDR-07 behavior baseline

Scope:

- only touched Codex-owned `context-history/**`, `context-rewrite/**`, and related tests
- no proxy-runtime integration yet
- no rollout parser implementation

Tests:

- CDH tests: 5 pass
- CDR tests: 3 pass
- typecheck: pass
- build: pass