### PR TITLE
feat(codex): split SSE item collection and history checks

### DIFF
--- a/components/adapters/codex/src/context-history/effective-history.ts
+++ b/components/adapters/codex/src/context-history/effective-history.ts
@@ -1,4 +1,5 @@
 import { readCodexContextHistoryJournal } from "./journal-store.js";
+import { isCodexObservationOnlyItem } from "./replayability.js";
 import { cloneJson, hashJson } from "./shared.js";
 import type {
   CodexContextHistoryJournalEntry,
@@ -42,13 +43,20 @@ function latestResponsesById(journal: CodexContextHistoryJournalEntry[]): Map<st
   return responses;
 }
 
+function isCommittedResponseEntry(entry: CodexResponseJournalEntry): boolean {
+  if (entry.status === "completed") return true;
+  return entry.status === "incomplete"
+    && (entry.malformedEventCount ?? 0) > 0
+    && (entry.eventTypeCounts?.["response.completed"] ?? 0) > 0;
+}
+
 function committedResponses(
   responses: Map<string, IndexedResponse>,
   requests: Map<string, IndexedRequest>,
 ): IndexedResponse[] {
   return Array.from(responses.values())
     .filter(({ entry }) => {
-      if (entry.status !== "completed" || !entry.requestId) return false;
+      if (!isCommittedResponseEntry(entry) || !entry.requestId) return false;
       return requests.get(entry.requestId)?.entry.status === "completed";
     })
     .sort((left, right) => left.journalIndex - right.journalIndex);
@@ -77,7 +85,7 @@ function buildCommittedChain(params: {
   while (cursor) {
     const responseId = cursor.entry.responseId;
     const requestId = cursor.entry.requestId;
-    if (!responseId || !requestId || cursor.entry.status !== "completed") {
+    if (!responseId || !requestId || !isCommittedResponseEntry(cursor.entry)) {
       return { chain: [], complete: false };
     }
     if (seenResponseIds.has(responseId)) return { chain: [], complete: false };
@@ -122,11 +130,6 @@ function itemIdentity(params: {
   })}`;
 }
 
-function isObservationOnlyItem(item: JsonObject): boolean {
-  const type = String(item.type ?? "").toLowerCase();
-  return type === "web_search_call" || type === "event_msg" || type === "turn_context";
-}
-
 function appendEffectiveItem(params: {
   item: JsonObject;
   sessionId: string;
@@ -146,7 +149,7 @@ function appendEffectiveItem(params: {
     callId: typeof params.item.call_id === "string" ? params.item.call_id : undefined,
     item: cloneJson(params.item),
   };
-  if (isObservationOnlyItem(params.item)) params.observationOnlyItems.push(effectiveItem);
+  if (isCodexObservationOnlyItem(params.item)) params.observationOnlyItems.push(effectiveItem);
   else params.replayableItems.push(effectiveItem);
 }
 
@@ -195,6 +198,10 @@ function hasUncommittedResponseWork(params: {
   });
 }
 
+function hasMalformedStreamEvents(chain: CommittedTurn[]): boolean {
+  return chain.some((turn) => (turn.response.entry.malformedEventCount ?? 0) > 0);
+}
+
 export async function buildCodexEffectiveHistory(params: {
   stateDir: string;
   sessionId: string;
@@ -213,6 +220,7 @@ export async function buildCodexEffectiveHistory(params: {
   const journalIncomplete = Boolean(
     journalRead.readError
     || journalRead.malformedLineCount > 0
+    || hasMalformedStreamEvents(committedChain.chain)
     || !committedChain.complete
     || (
       committedChain.chain.length === 0

--- a/components/adapters/codex/src/context-history/index.ts
+++ b/components/adapters/codex/src/context-history/index.ts
@@ -6,10 +6,14 @@ export {
 } from "./journal-store.js";
 export type { CodexContextHistoryJournalReadResult } from "./journal-store.js";
 export { appendCodexRequestJournalEntry } from "./request-journal.js";
-export {
-  appendCodexResponseJournalEntry,
-  collectCodexResponseItemsFromStream,
-} from "./response-journal.js";
+export { appendCodexResponseJournalEntry } from "./response-journal.js";
+export { collectCodexResponseItemsFromStream } from "./sse-item-collector.js";
+export { codexReplayabilityForItem, isCodexObservationOnlyItem } from "./replayability.js";
+export type {
+  CodexItemReplayability,
+  CodexReplayabilityMode,
+  CodexReplayabilityReason,
+} from "./replayability.js";
 export { buildCodexEffectiveHistory } from "./effective-history.js";
 export {
   parseCodexRollout,

--- a/components/adapters/codex/src/context-history/replayability.ts
+++ b/components/adapters/codex/src/context-history/replayability.ts
@@ -1,0 +1,41 @@
+import type { JsonObject } from "./types.js";
+
+export type CodexReplayabilityMode = "replayable" | "observation_only";
+
+export type CodexReplayabilityReason =
+  | "default_replayable"
+  | "tool_closure_required"
+  | "exact_payload_required"
+  | "provider_observation"
+  | "turn_context_instruction";
+
+export type CodexItemReplayability = {
+  mode: CodexReplayabilityMode;
+  reason: CodexReplayabilityReason;
+};
+
+export function codexReplayabilityForItem(item: JsonObject): CodexItemReplayability {
+  const type = String(item.type ?? "").toLowerCase();
+  if (type === "web_search_call" || type === "event_msg") {
+    return { mode: "observation_only", reason: "provider_observation" };
+  }
+  if (type === "turn_context") {
+    return { mode: "observation_only", reason: "turn_context_instruction" };
+  }
+  if (
+    type === "function_call"
+    || type === "custom_tool_call"
+    || type === "function_call_output"
+    || type === "custom_tool_call_output"
+  ) {
+    return { mode: "replayable", reason: "tool_closure_required" };
+  }
+  if (type === "reasoning") {
+    return { mode: "replayable", reason: "exact_payload_required" };
+  }
+  return { mode: "replayable", reason: "default_replayable" };
+}
+
+export function isCodexObservationOnlyItem(item: JsonObject): boolean {
+  return codexReplayabilityForItem(item).mode === "observation_only";
+}

--- a/components/adapters/codex/src/context-history/request-journal.ts
+++ b/components/adapters/codex/src/context-history/request-journal.ts
@@ -24,7 +24,7 @@ function requestIdFromPayload(params: {
     turnOrdinal: params.turnOrdinal,
     model: params.payload.model,
     previousResponseId: params.payload.previous_response_id,
-    input: params.payload.input,
+    input: sanitizedInputItems(params.payload),
   })}`;
 }
 

--- a/components/adapters/codex/src/context-history/response-journal.ts
+++ b/components/adapters/codex/src/context-history/response-journal.ts
@@ -1,6 +1,7 @@
 import { appendJsonl } from "@lightmem2/host-adapter";
 import { codexContextHistoryJournalPath } from "./journal-store.js";
-import { asJsonObject, cloneJson, normalizeStatus, sanitizeValue } from "./shared.js";
+import { collectCodexResponseItemsFromStream } from "./sse-item-collector.js";
+import { cloneJson, normalizeStatus, sanitizeValue } from "./shared.js";
 import {
   CODEX_CONTEXT_HISTORY_RESPONSE_SCHEMA,
   type CodexJournalStatus,
@@ -8,175 +9,23 @@ import {
   type JsonObject,
 } from "./types.js";
 
-type StreamEvent = {
-  event: string;
-  data: JsonObject;
-};
-
-function safeJsonParse(text: string): unknown {
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    return undefined;
-  }
-}
-
-function parseSseEvents(rawStreamText: string): StreamEvent[] {
-  const events: StreamEvent[] = [];
-  for (const chunk of rawStreamText.split(/\r?\n\r?\n/)) {
-    const lines = chunk.split(/\r?\n/);
-    const eventLine = lines.find((line) => line.startsWith("event:"));
-    const event = eventLine?.slice("event:".length).trim() || "message";
-    const dataLines = lines
-      .filter((line) => line.startsWith("data:"))
-      .map((line) => line.slice("data:".length).trim())
-      .filter(Boolean);
-    for (const dataText of dataLines) {
-      if (dataText === "[DONE]") continue;
-      const data = asJsonObject(safeJsonParse(dataText));
-      if (data) events.push({ event, data });
-    }
-  }
-  return events;
-}
-
-function outputItemKeyFromEvent(data: JsonObject, fallbackIndex: number): string {
-  const item = asJsonObject(data.item);
-  if (typeof item?.id === "string") return item.id;
-  if (typeof data.item_id === "string") return data.item_id;
-  if (typeof data.output_index === "number") return `output_index:${data.output_index}`;
-  return `event:${fallbackIndex}`;
-}
-
-function deltaText(data: JsonObject): string {
-  const nestedDelta = asJsonObject(data.delta);
-  if (typeof data.delta === "string") return data.delta;
-  if (typeof nestedDelta?.output_text === "string") return nestedDelta.output_text;
-  if (typeof nestedDelta?.text === "string") return nestedDelta.text;
-  return "";
-}
-
-function mergeOutputTextDelta(item: JsonObject, data: JsonObject): void {
-  const delta = deltaText(data);
-  if (!delta) return;
-  if (!Array.isArray(item.content)) {
-    item.content = [{ type: "output_text", text: "" }];
-  }
-  const content = item.content as unknown[];
-  const first = asJsonObject(content[0]);
-  if (!first) {
-    content[0] = { type: "output_text", text: delta };
-    return;
-  }
-  first.text = `${typeof first.text === "string" ? first.text : ""}${delta}`;
-}
-
-function mergeFunctionArgumentsDelta(item: JsonObject, data: JsonObject): void {
-  const delta = typeof data.delta === "string" ? data.delta : "";
-  if (!delta) return;
-  item.arguments = `${typeof item.arguments === "string" ? item.arguments : ""}${delta}`;
-}
-
-function responseMetadata(data: JsonObject): {
-  responseId?: string;
-  previousResponseId?: string;
-  output?: unknown[];
-} {
-  const response = asJsonObject(data.response);
-  return {
-    responseId: typeof response?.id === "string"
-      ? response.id
-      : typeof data.id === "string"
-        ? data.id
-        : undefined,
-    previousResponseId: typeof response?.previous_response_id === "string"
-      ? response.previous_response_id
-      : typeof data.previous_response_id === "string"
-        ? data.previous_response_id
-        : undefined,
-    output: Array.isArray(response?.output) ? response.output : undefined,
-  };
-}
-
-export function collectCodexResponseItemsFromStream(rawStreamText: string): {
-  outputItems: JsonObject[];
-  eventTypeCounts: Record<string, number>;
-  responseId?: string;
-  previousResponseId?: string;
-  status: CodexJournalStatus;
-} {
-  const events = parseSseEvents(rawStreamText);
-  const outputItems = new Map<string, JsonObject>();
-  const eventTypeCounts: Record<string, number> = {};
-  let responseId: string | undefined;
-  let previousResponseId: string | undefined;
-  let status: CodexJournalStatus = "incomplete";
-
-  events.forEach(({ event, data }, index) => {
-    eventTypeCounts[event] = (eventTypeCounts[event] ?? 0) + 1;
-
-    const metadata = responseMetadata(data);
-    responseId = metadata.responseId ?? responseId;
-    previousResponseId = metadata.previousResponseId ?? previousResponseId;
-    if (event === "response.completed") status = "completed";
-    if (event === "response.failed") status = "failed";
-    if (event === "response.incomplete") status = "incomplete";
-
-    for (const item of metadata.output ?? []) {
-      const cloned = asJsonObject(cloneJson(item));
-      if (!cloned) continue;
-      outputItems.set(typeof cloned.id === "string" ? cloned.id : `response-output:${outputItems.size}`, cloned);
-    }
-
-    const addedItem = asJsonObject(data.item);
-    if (addedItem) {
-      const key = outputItemKeyFromEvent(data, index);
-      outputItems.set(key, {
-        ...(outputItems.get(key) ?? {}),
-        ...cloneJson(addedItem),
-      });
-      return;
-    }
-
-    if (event === "response.output_text.delta") {
-      const key = outputItemKeyFromEvent(data, index);
-      const item = outputItems.get(key) ?? {
-        id: typeof data.item_id === "string" ? data.item_id : undefined,
-        type: "message",
-        role: "assistant",
-        content: [{ type: "output_text", text: "" }],
-      };
-      mergeOutputTextDelta(item, data);
-      outputItems.set(key, item);
-      return;
-    }
-
-    if (event === "response.function_call_arguments.delta") {
-      const key = outputItemKeyFromEvent(data, index);
-      const item = outputItems.get(key) ?? {
-        id: typeof data.item_id === "string" ? data.item_id : undefined,
-        type: "function_call",
-      };
-      mergeFunctionArgumentsDelta(item, data);
-      outputItems.set(key, item);
-    }
-  });
-
-  return {
-    outputItems: Array.from(outputItems.values()).map((item) => cloneJson(sanitizeValue(item)) as JsonObject),
-    eventTypeCounts,
-    responseId,
-    previousResponseId,
-    status,
-  };
-}
-
 function outputRefs(outputItems: JsonObject[]): CodexResponseJournalEntry["outputItemRefs"] {
   return outputItems.map((item) => ({
     type: typeof item.type === "string" ? item.type : undefined,
     itemId: typeof item.id === "string" ? item.id : undefined,
     callId: typeof item.call_id === "string" ? item.call_id : undefined,
   }));
+}
+
+function responseStatus(params: {
+  status?: CodexJournalStatus;
+  streamStatus?: CodexJournalStatus;
+  malformedEventCount?: number;
+}): CodexJournalStatus {
+  const status = normalizeStatus(params.status, params.streamStatus ?? "completed");
+  return status === "completed" && (params.malformedEventCount ?? 0) > 0
+    ? "incomplete"
+    : status;
 }
 
 export async function appendCodexResponseJournalEntry(params: {
@@ -210,7 +59,13 @@ export async function appendCodexResponseJournalEntry(params: {
     outputItems,
     outputItemRefs: outputRefs(outputItems),
     eventTypeCounts: streamCollected?.eventTypeCounts,
-    status: normalizeStatus(params.status, streamCollected?.status ?? "completed"),
+    malformedEventCount: streamCollected?.malformedEventCount,
+    malformedEventTypeCounts: streamCollected?.malformedEventTypeCounts,
+    status: responseStatus({
+      status: params.status,
+      streamStatus: streamCollected?.status,
+      malformedEventCount: streamCollected?.malformedEventCount,
+    }),
     error: params.error,
     observedAt: params.observedAt ?? new Date().toISOString(),
   };

--- a/components/adapters/codex/src/context-history/sse-item-collector.ts
+++ b/components/adapters/codex/src/context-history/sse-item-collector.ts
@@ -1,0 +1,516 @@
+import { asJsonObject, cloneJson, sanitizeValue } from "./shared.js";
+import type { CodexJournalStatus, JsonObject } from "./types.js";
+
+type StreamEvent = {
+  event: string;
+  data: JsonObject;
+};
+
+type OutputItemAliases = {
+  byItemId: Map<string, string>;
+  byOutputIndex: Map<number, string>;
+};
+
+type CollectorState = {
+  outputItems: Map<string, JsonObject>;
+  aliases: OutputItemAliases;
+  eventTypeCounts: Record<string, number>;
+  responseId?: string;
+  previousResponseId?: string;
+  status: CodexJournalStatus;
+};
+
+type EventHandler = (state: CollectorState, data: JsonObject, index: number) => void;
+
+export type CodexSseItemCollectorResult = {
+  outputItems: JsonObject[];
+  eventTypeCounts: Record<string, number>;
+  malformedEventCount: number;
+  malformedEventTypeCounts: Record<string, number>;
+  responseId?: string;
+  previousResponseId?: string;
+  status: CodexJournalStatus;
+};
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function sseFieldValue(line: string, prefix: string): string {
+  const value = line.slice(prefix.length);
+  return value.startsWith(" ") ? value.slice(1) : value;
+}
+
+function parseSseEvents(rawStreamText: string): {
+  events: StreamEvent[];
+  malformedEventCount: number;
+  malformedEventTypeCounts: Record<string, number>;
+} {
+  const events: StreamEvent[] = [];
+  let malformedEventCount = 0;
+  const malformedEventTypeCounts: Record<string, number> = {};
+
+  for (const chunk of rawStreamText.split(/\r?\n\r?\n/)) {
+    let event = "message";
+    const dataLines: string[] = [];
+    for (const line of chunk.split(/\r?\n/)) {
+      if (line.startsWith("event:")) event = sseFieldValue(line, "event:").trim();
+      else if (line.startsWith("data:")) dataLines.push(sseFieldValue(line, "data:"));
+    }
+
+    if (dataLines.length === 0) continue;
+    const dataText = dataLines.join("\n").trim();
+    if (!dataText || dataText === "[DONE]") continue;
+
+    const data = asJsonObject(safeJsonParse(dataText));
+    if (data) events.push({ event, data });
+    else {
+      malformedEventCount += 1;
+      malformedEventTypeCounts[event] = (malformedEventTypeCounts[event] ?? 0) + 1;
+    }
+  }
+
+  return { events, malformedEventCount, malformedEventTypeCounts };
+}
+
+function outputIndexFromData(data: JsonObject): number | undefined {
+  return typeof data.output_index === "number" && Number.isInteger(data.output_index) && data.output_index >= 0
+    ? data.output_index
+    : undefined;
+}
+
+function outputItemIdFromData(data: JsonObject): string | undefined {
+  const item = asJsonObject(data.item);
+  if (typeof item?.id === "string") return item.id;
+  return typeof data.item_id === "string" ? data.item_id : undefined;
+}
+
+function resolveOutputItemKey(data: JsonObject, fallbackIndex: number, aliases: OutputItemAliases): string {
+  const itemId = outputItemIdFromData(data);
+  if (itemId && aliases.byItemId.has(itemId)) return aliases.byItemId.get(itemId) as string;
+
+  const outputIndex = outputIndexFromData(data);
+  if (outputIndex !== undefined && aliases.byOutputIndex.has(outputIndex)) {
+    return aliases.byOutputIndex.get(outputIndex) as string;
+  }
+
+  if (itemId) return itemId;
+  if (outputIndex !== undefined) return `output_index:${outputIndex}`;
+  return `event:${fallbackIndex}`;
+}
+
+function eventTypeFromData(event: string, data: JsonObject): string {
+  return typeof data.type === "string" && data.type.startsWith("response.")
+    ? data.type
+    : event;
+}
+
+function rememberOutputItemKey(key: string, data: JsonObject, item: JsonObject, aliases: OutputItemAliases): void {
+  const itemId = typeof item.id === "string" ? item.id : outputItemIdFromData(data);
+  if (itemId) aliases.byItemId.set(itemId, key);
+  const outputIndex = outputIndexFromData(data);
+  if (outputIndex !== undefined) aliases.byOutputIndex.set(outputIndex, key);
+}
+
+function mergeOutputItem(existing: JsonObject | undefined, incoming: JsonObject): JsonObject {
+  if (!existing) return incoming;
+  const merged = { ...existing, ...incoming };
+  mergeIndexedObjectArray(merged, existing, incoming, "content");
+  mergeIndexedObjectArray(merged, existing, incoming, "summary");
+  preserveNonEmptyString(merged, existing, incoming, "arguments");
+  preserveNonEmptyString(merged, existing, incoming, "input");
+  preserveNonEmptyString(merged, existing, incoming, "text");
+  return merged;
+}
+
+function mergeIndexedObjectArray(
+  target: JsonObject,
+  existing: JsonObject,
+  incoming: JsonObject,
+  field: string,
+): void {
+  const existingValue = existing[field];
+  const incomingValue = incoming[field];
+  if (!Array.isArray(existingValue) || !Array.isArray(incomingValue)) return;
+
+  const merged = incomingValue.slice();
+  existingValue.forEach((existingItem, index) => {
+    const incomingItem = merged[index];
+    if (incomingItem === undefined) {
+      merged[index] = existingItem;
+      return;
+    }
+
+    const existingObject = asJsonObject(existingItem);
+    const incomingObject = asJsonObject(incomingItem);
+    if (!existingObject || !incomingObject) return;
+
+    const mergedObject = { ...existingObject, ...incomingObject };
+    preserveNonEmptyString(mergedObject, existingObject, incomingObject, "text");
+    merged[index] = mergedObject;
+  });
+  target[field] = merged;
+}
+
+function preserveNonEmptyString(
+  target: JsonObject,
+  existing: JsonObject,
+  incoming: JsonObject,
+  field: string,
+): void {
+  const existingValue = existing[field];
+  const incomingValue = incoming[field];
+  if (typeof existingValue === "string" && existingValue.length > 0 && incomingValue === "") {
+    target[field] = existingValue;
+  }
+}
+
+function outputTextDelta(data: JsonObject): string {
+  const nestedDelta = asJsonObject(data.delta);
+  if (typeof data.delta === "string") return data.delta;
+  if (typeof nestedDelta?.output_text === "string") return nestedDelta.output_text;
+  if (typeof nestedDelta?.text === "string") return nestedDelta.text;
+  return "";
+}
+
+function outputTextDone(data: JsonObject): string | undefined {
+  const nestedText = asJsonObject(data.text);
+  if (typeof data.text === "string") return data.text;
+  if (typeof data.output_text === "string") return data.output_text;
+  if (typeof nestedText?.value === "string") return nestedText.value;
+  return undefined;
+}
+
+function contentIndexFromData(data: JsonObject): number {
+  return typeof data.content_index === "number" && Number.isInteger(data.content_index) && data.content_index >= 0
+    ? data.content_index
+    : 0;
+}
+
+function contentPartFromData(data: JsonObject): JsonObject | undefined {
+  const part = asJsonObject(data.part) ?? asJsonObject(data.content_part);
+  return part ? cloneJson(part) : undefined;
+}
+
+function ensureContentPart(item: JsonObject, data: JsonObject): JsonObject {
+  if (!Array.isArray(item.content)) item.content = [];
+  const content = item.content as unknown[];
+  const index = contentIndexFromData(data);
+  const existing = asJsonObject(content[index]);
+  if (existing) return existing;
+
+  const created: JsonObject = { type: "output_text", text: "" };
+  content[index] = created;
+  return created;
+}
+
+function mergeContentPart(item: JsonObject, data: JsonObject): void {
+  const part = contentPartFromData(data);
+  if (!part) return;
+
+  const existing = ensureContentPart(item, data);
+  Object.assign(existing, part);
+}
+
+function appendOutputText(item: JsonObject, data: JsonObject): void {
+  const delta = outputTextDelta(data);
+  if (!delta) return;
+
+  const part = ensureContentPart(item, data);
+  if (typeof part.type !== "string") part.type = "output_text";
+  part.text = `${typeof part.text === "string" ? part.text : ""}${delta}`;
+}
+
+function setOutputText(item: JsonObject, data: JsonObject): void {
+  const text = outputTextDone(data);
+  if (text === undefined) return;
+
+  const part = ensureContentPart(item, data);
+  if (typeof part.type !== "string") part.type = "output_text";
+  part.text = text;
+}
+
+function appendStringField(item: JsonObject, field: string, delta: unknown): void {
+  if (typeof delta !== "string") return;
+  if (!delta) return;
+  item[field] = `${typeof item[field] === "string" ? item[field] : ""}${delta}`;
+}
+
+function setStringField(item: JsonObject, field: string, value: unknown): void {
+  if (typeof value === "string") item[field] = value;
+}
+
+function reasoningText(data: JsonObject): string | undefined {
+  if (typeof data.delta === "string") return data.delta;
+  if (typeof data.text === "string") return data.text;
+  return undefined;
+}
+
+function summaryIndexFromData(data: JsonObject): number {
+  return typeof data.summary_index === "number" && Number.isInteger(data.summary_index) && data.summary_index >= 0
+    ? data.summary_index
+    : contentIndexFromData(data);
+}
+
+function ensureReasoningSummaryPart(item: JsonObject, data: JsonObject): JsonObject {
+  if (!Array.isArray(item.summary)) item.summary = [];
+  const summary = item.summary as unknown[];
+  const index = summaryIndexFromData(data);
+  const existing = asJsonObject(summary[index]);
+  if (existing) return existing;
+
+  const created: JsonObject = { type: "summary_text", text: "" };
+  summary[index] = created;
+  return created;
+}
+
+function mergeReasoningSummaryPart(item: JsonObject, data: JsonObject): void {
+  const part = contentPartFromData(data);
+  if (!part) return;
+
+  const existing = ensureReasoningSummaryPart(item, data);
+  Object.assign(existing, part);
+}
+
+function appendReasoningSummaryText(item: JsonObject, data: JsonObject): void {
+  const delta = reasoningText(data);
+  if (!delta) return;
+
+  const part = ensureReasoningSummaryPart(item, data);
+  if (typeof part.type !== "string") part.type = "summary_text";
+  part.text = `${typeof part.text === "string" ? part.text : ""}${delta}`;
+}
+
+function setReasoningSummaryText(item: JsonObject, data: JsonObject): void {
+  const text = reasoningText(data);
+  if (text === undefined) return;
+
+  const part = ensureReasoningSummaryPart(item, data);
+  if (typeof part.type !== "string") part.type = "summary_text";
+  part.text = text;
+}
+
+function appendReasoningText(item: JsonObject, data: JsonObject): void {
+  appendStringField(item, "text", reasoningText(data));
+}
+
+function setReasoningText(item: JsonObject, data: JsonObject): void {
+  setStringField(item, "text", reasoningText(data));
+}
+
+function responseMetadata(data: JsonObject): {
+  responseId?: string;
+  previousResponseId?: string;
+  output?: unknown[];
+} {
+  const response = asJsonObject(data.response);
+  return {
+    responseId: typeof response?.id === "string"
+      ? response.id
+      : typeof data.id === "string"
+        ? data.id
+        : undefined,
+    previousResponseId: typeof response?.previous_response_id === "string"
+      ? response.previous_response_id
+      : typeof data.previous_response_id === "string"
+        ? data.previous_response_id
+        : undefined,
+    output: Array.isArray(response?.output) ? response.output : undefined,
+  };
+}
+
+function outputItemForEvent(
+  state: CollectorState,
+  data: JsonObject,
+  index: number,
+  fallback: JsonObject,
+): { key: string; item: JsonObject } {
+  const key = resolveOutputItemKey(data, index, state.aliases);
+  return { key, item: state.outputItems.get(key) ?? fallback };
+}
+
+function commitOutputItem(state: CollectorState, key: string, data: JsonObject, item: JsonObject): void {
+  state.outputItems.set(key, item);
+  rememberOutputItemKey(key, data, item, state.aliases);
+}
+
+function updateResponseState(state: CollectorState, data: JsonObject, eventType: string): void {
+  const metadata = responseMetadata(data);
+  state.responseId = metadata.responseId ?? state.responseId;
+  state.previousResponseId = metadata.previousResponseId ?? state.previousResponseId;
+  if (eventType === "response.completed") state.status = "completed";
+  if (eventType === "response.failed") state.status = "failed";
+  if (eventType === "response.incomplete") state.status = "incomplete";
+
+  metadata.output?.forEach((item, outputIndex) => {
+    const cloned = asJsonObject(cloneJson(item));
+    if (!cloned) return;
+
+    const dataWithIndex: JsonObject = { output_index: outputIndex, item: cloned };
+    const key = resolveOutputItemKey(dataWithIndex, state.outputItems.size, state.aliases);
+    const merged = mergeOutputItem(state.outputItems.get(key), cloned);
+    commitOutputItem(state, key, dataWithIndex, merged);
+  });
+}
+
+function handleOutputItem(state: CollectorState, data: JsonObject, index: number): void {
+  const eventItem = asJsonObject(data.item);
+  if (!eventItem) return;
+
+  const key = resolveOutputItemKey(data, index, state.aliases);
+  const item = mergeOutputItem(state.outputItems.get(key), cloneJson(eventItem));
+  commitOutputItem(state, key, data, item);
+}
+
+function messageFallback(data: JsonObject): JsonObject {
+  return {
+    id: typeof data.item_id === "string" ? data.item_id : undefined,
+    type: "message",
+    role: "assistant",
+  };
+}
+
+function handleOutputTextDelta(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, messageFallback(data));
+  appendOutputText(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleOutputTextDone(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, messageFallback(data));
+  setOutputText(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleContentPart(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, messageFallback(data));
+  mergeContentPart(item, data);
+  setOutputText(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+function functionCallFallback(data: JsonObject): JsonObject {
+  return {
+    id: typeof data.item_id === "string" ? data.item_id : undefined,
+    type: "function_call",
+  };
+}
+
+function handleFunctionArgumentsDelta(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, functionCallFallback(data));
+  appendStringField(item, "arguments", data.delta);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleFunctionArgumentsDone(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, functionCallFallback(data));
+  setStringField(item, "arguments", data.arguments);
+  commitOutputItem(state, key, data, item);
+}
+
+function customToolFallback(data: JsonObject): JsonObject {
+  return {
+    id: typeof data.item_id === "string" ? data.item_id : undefined,
+    type: "custom_tool_call",
+  };
+}
+
+function handleCustomToolInputDelta(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, customToolFallback(data));
+  appendStringField(item, "input", data.delta);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleCustomToolInputDone(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, customToolFallback(data));
+  setStringField(item, "input", data.input);
+  commitOutputItem(state, key, data, item);
+}
+
+function reasoningFallback(data: JsonObject): JsonObject {
+  return {
+    id: typeof data.item_id === "string" ? data.item_id : undefined,
+    type: "reasoning",
+  };
+}
+
+function handleReasoningSummaryPart(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, reasoningFallback(data));
+  mergeReasoningSummaryPart(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleReasoningSummaryDelta(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, reasoningFallback(data));
+  appendReasoningSummaryText(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleReasoningSummaryDone(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, reasoningFallback(data));
+  setReasoningSummaryText(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleReasoningTextDelta(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, reasoningFallback(data));
+  appendReasoningText(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+function handleReasoningTextDone(state: CollectorState, data: JsonObject, index: number): void {
+  const { key, item } = outputItemForEvent(state, data, index, reasoningFallback(data));
+  setReasoningText(item, data);
+  commitOutputItem(state, key, data, item);
+}
+
+const EVENT_HANDLERS: Record<string, EventHandler | undefined> = {
+  "response.output_item.added": handleOutputItem,
+  "response.output_item.done": handleOutputItem,
+  "response.output_text.delta": handleOutputTextDelta,
+  "response.content_part.delta": handleOutputTextDelta,
+  "response.output_text.done": handleOutputTextDone,
+  "response.content_part.added": handleContentPart,
+  "response.content_part.done": handleContentPart,
+  "response.function_call_arguments.delta": handleFunctionArgumentsDelta,
+  "response.function_call_arguments.done": handleFunctionArgumentsDone,
+  "response.custom_tool_call_input.delta": handleCustomToolInputDelta,
+  "response.custom_tool_call_input.done": handleCustomToolInputDone,
+  "response.reasoning_summary_part.added": handleReasoningSummaryPart,
+  "response.reasoning_summary_part.done": handleReasoningSummaryPart,
+  "response.reasoning_summary_text.delta": handleReasoningSummaryDelta,
+  "response.reasoning_summary_text.done": handleReasoningSummaryDone,
+  "response.reasoning_text.delta": handleReasoningTextDelta,
+  "response.reasoning_text.done": handleReasoningTextDone,
+};
+
+export function collectCodexResponseItemsFromStream(rawStreamText: string): CodexSseItemCollectorResult {
+  const parsed = parseSseEvents(rawStreamText);
+  const state: CollectorState = {
+    outputItems: new Map(),
+    aliases: { byItemId: new Map(), byOutputIndex: new Map() },
+    eventTypeCounts: {},
+    status: "incomplete",
+  };
+
+  parsed.events.forEach(({ event, data }, index) => {
+    const eventType = eventTypeFromData(event, data);
+    state.eventTypeCounts[eventType] = (state.eventTypeCounts[eventType] ?? 0) + 1;
+    updateResponseState(state, data, eventType);
+    EVENT_HANDLERS[eventType]?.(state, data, index);
+  });
+
+  return {
+    outputItems: Array.from(state.outputItems.values()).map((item) => cloneJson(sanitizeValue(item)) as JsonObject),
+    eventTypeCounts: state.eventTypeCounts,
+    malformedEventCount: parsed.malformedEventCount,
+    malformedEventTypeCounts: parsed.malformedEventTypeCounts,
+    responseId: state.responseId,
+    previousResponseId: state.previousResponseId,
+    status: state.status,
+  };
+}

--- a/components/adapters/codex/src/context-history/types.ts
+++ b/components/adapters/codex/src/context-history/types.ts
@@ -38,6 +38,8 @@ export type CodexResponseJournalEntry = {
   outputItems: JsonObject[];
   outputItemRefs: CodexResponseOutputRef[];
   eventTypeCounts?: Record<string, number>;
+  malformedEventCount?: number;
+  malformedEventTypeCounts?: Record<string, number>;
   status: CodexJournalStatus;
   error?: string;
   observedAt: string;

--- a/components/adapters/codex/tests/context-history-effective-history.test.ts
+++ b/components/adapters/codex/tests/context-history-effective-history.test.ts
@@ -1,0 +1,531 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendCodexRequestJournalEntry,
+  appendCodexResponseJournalEntry,
+  buildCodexEffectiveHistory,
+  type JsonObject,
+} from "../src/context-history/index.js";
+
+async function withTempState(
+  fn: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-effective-history-"));
+  try {
+    await fn(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function sseBlock(event: string | undefined, data: JsonObject | string): string {
+  const lines = event ? [`event: ${event}`] : [];
+  const text = typeof data === "string" ? data : JSON.stringify(data);
+  for (const line of text.split("\n")) lines.push(`data: ${line}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function sseStream(...blocks: string[]): string {
+  return blocks.join("\n");
+}
+
+test("CDH-04 Effective History Builder marks an orphan incomplete response after the committed head as incomplete", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "root" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: { id: "resp-1", output: [] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      rawStreamText: sseStream(
+        sseBlock("response.created", { response: { id: "resp-orphan" } }),
+      ),
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+    });
+
+    assert.equal(history.incomplete, true);
+    assert.equal(history.replayableItems.length, 1);
+  });
+});
+
+test("CDH-04 Effective History Builder builds proxy journal history in strict order with replay and observation split", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: {
+        model: "gpt-5.4-mini",
+        input: [
+          { role: "developer", content: "stable instructions" },
+          { role: "user", content: "turn one" },
+        ],
+      },
+      status: "completed",
+      observedAt: "2026-07-24T10:00:00.000Z",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: {
+        id: "resp-1",
+        output: [
+          { id: "msg-1", type: "message", role: "assistant", content: [{ type: "output_text", text: "need tool" }] },
+          { id: "fc-1", type: "function_call", call_id: "call-1", name: "run_tests", arguments: "{}" },
+          { id: "ws-1", type: "web_search_call", query: "observed but not replayed" },
+        ],
+      },
+      observedAt: "2026-07-24T10:00:01.000Z",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      payload: {
+        model: "gpt-5.4-mini",
+        previous_response_id: "resp-1",
+        input: [
+          { type: "function_call_output", call_id: "call-1", output: "{\"passed\":true}" },
+          { role: "user", content: "turn two" },
+        ],
+      },
+      status: "completed",
+      observedAt: "2026-07-24T10:00:02.000Z",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      response: {
+        id: "resp-2",
+        previous_response_id: "resp-1",
+        output: [
+          { id: "msg-2", type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
+        ],
+      },
+      status: "completed",
+      observedAt: "2026-07-24T10:00:03.000Z",
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-2",
+    });
+
+    assert.equal(history.source, "proxy_journal");
+    assert.equal(history.incomplete, false);
+    assert.equal(history.unresolvedCallIds.length, 0);
+    assert.equal(history.observationOnlyItems.length, 1);
+    assert.equal(history.observationOnlyItems[0]?.item.type, "web_search_call");
+    assert.deepEqual(
+      history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
+      ["developer", "user", "message", "function_call", "function_call_output", "user", "message"],
+    );
+    assert.match(history.revision, /^rev-[0-9a-f]+$/);
+  });
+});
+
+test("CDH-04 Effective History Builder excludes failed requests and abandoned response branches", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "root-request",
+      turnOrdinal: 1,
+      payload: { input: [{ role: "user", content: "root" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "root-request",
+      response: { id: "resp-root", output: [] },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "failed-request",
+      turnOrdinal: 2,
+      payload: {
+        previous_response_id: "resp-root",
+        input: [{ role: "user", content: "FAILED_BRANCH_SENTINEL" }],
+      },
+      status: "failed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "branch-a-request",
+      turnOrdinal: 3,
+      payload: {
+        previous_response_id: "resp-root",
+        input: [{ role: "user", content: "BRANCH_A_SENTINEL" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "branch-a-request",
+      response: { id: "resp-a", previous_response_id: "resp-root", output: [] },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "branch-b-request",
+      turnOrdinal: 4,
+      payload: {
+        previous_response_id: "resp-root",
+        input: [{ role: "user", content: "BRANCH_B_SENTINEL" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "branch-b-request",
+      response: { id: "resp-b", previous_response_id: "resp-root", output: [] },
+      status: "completed",
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-a",
+    });
+    const replayed = JSON.stringify(history.replayableItems);
+
+    assert.match(replayed, /BRANCH_A_SENTINEL/);
+    assert.doesNotMatch(replayed, /BRANCH_B_SENTINEL|FAILED_BRANCH_SENTINEL/);
+    assert.equal(history.incomplete, false);
+  });
+});
+
+test("CDH-04 Effective History Builder keeps synthetic item ids stable across request state events", async () => {
+  async function buildWithStates(states: Array<"pending" | "completed">): Promise<string[]> {
+    let ids: string[] = [];
+    await withTempState(async (stateDir) => {
+      for (const status of states) {
+        await appendCodexRequestJournalEntry({
+          stateDir,
+          sessionId: "codex-session-1",
+          requestId: "request-1",
+          turnOrdinal: 1,
+          payload: { input: [{ role: "user", content: "stable synthetic item" }] },
+          status,
+        });
+      }
+      await appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId: "codex-session-1",
+        requestId: "request-1",
+        response: { id: "resp-1", output: [] },
+        status: "completed",
+      });
+      ids = (await buildCodexEffectiveHistory({
+        stateDir,
+        sessionId: "codex-session-1",
+        headResponseId: "resp-1",
+      })).replayableItems.map((entry) => entry.stableItemId);
+    });
+    return ids;
+  }
+
+  assert.deepEqual(await buildWithStates(["completed"]), await buildWithStates(["pending", "completed"]));
+});
+
+test("CDH-04 Effective History Builder delegates to rollout parser bootstrap when proxy journal is incomplete", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      rawStreamText: sseStream(
+        sseBlock("response.created", { response: { id: "resp-incomplete" } }),
+        sseBlock("response.output_text.delta", { item_id: "msg-1", delta: "partial" }),
+      ),
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      async rolloutParserBootstrap() {
+        return {
+          revision: "rollout-rev-1",
+          replayableItems: [
+            {
+              stableItemId: "rollout-user-1",
+              nativeId: "rollout-msg-1",
+              item: { role: "user", content: "bootstrapped from rollout parser fake" },
+            },
+          ],
+          observationOnlyItems: [],
+          unresolvedCallIds: [],
+          source: "rollout_bootstrap",
+          incomplete: false,
+        };
+      },
+    });
+
+    assert.equal(history.source, "rollout_bootstrap");
+    assert.equal(history.revision, "rollout-rev-1");
+    assert.equal(history.replayableItems[0]?.item.content, "bootstrapped from rollout parser fake");
+  });
+});
+
+test("CDH-04 Effective History Builder marks malformed SSE journals incomplete without dropping valid items", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: { stream: true, input: [{ role: "user", content: "malformed but usable" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      rawStreamText: sseStream(
+        sseBlock("response.created", { response: { id: "resp-malformed" } }),
+        sseBlock("response.output_item.done", {
+          output_index: 0,
+          item: {
+            id: "msg-1",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "kept" }],
+          },
+        }),
+        sseBlock("response.output_text.delta", "{\"truncated\":"),
+        sseBlock("response.completed", { response: { id: "resp-malformed" } }),
+      ),
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-malformed",
+    });
+
+    assert.equal(history.incomplete, true);
+    assert.deepEqual(
+      history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
+      ["user", "message"],
+    );
+    assert.match(JSON.stringify(history.replayableItems), /kept/);
+  });
+});
+
+test("CDH-04 Effective History Builder ignores malformed SSE outside the selected response chain", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "root-request",
+      payload: { input: [{ role: "user", content: "root" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "root-request",
+      response: { id: "resp-root", output: [] },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "selected-request",
+      payload: {
+        previous_response_id: "resp-root",
+        input: [{ role: "user", content: "selected branch" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "selected-request",
+      response: { id: "resp-selected", previous_response_id: "resp-root", output: [] },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "abandoned-request",
+      payload: {
+        previous_response_id: "resp-root",
+        input: [{ role: "user", content: "abandoned branch" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "abandoned-request",
+      rawStreamText: sseStream(
+        sseBlock("response.created", { response: { id: "resp-abandoned", previous_response_id: "resp-root" } }),
+        sseBlock("response.output_text.delta", "{\"truncated\":"),
+        sseBlock("response.completed", { response: { id: "resp-abandoned" } }),
+      ),
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-selected",
+    });
+
+    assert.equal(history.incomplete, false);
+    assert.doesNotMatch(JSON.stringify(history.replayableItems), /abandoned branch/);
+  });
+});
+
+test("CDH-04 Effective History Builder consumes SSE-collected response items", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: {
+        stream: true,
+        input: [{ role: "user", content: "collect stream" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      rawStreamText: sseStream(
+        sseBlock("response.created", { response: { id: "resp-sse" } }),
+        sseBlock("response.output_item.done", {
+          output_index: 0,
+          item: { id: "rs-1", type: "reasoning", encrypted_content: "opaque" },
+        }),
+        sseBlock("response.output_item.added", {
+          output_index: 1,
+          item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+        }),
+        sseBlock("response.content_part.added", {
+          item_id: "msg-1",
+          output_index: 1,
+          content_index: 0,
+          part: { type: "output_text", text: "SSE" },
+        }),
+        sseBlock("response.output_text.done", {
+          item_id: "msg-1",
+          output_index: 1,
+          content_index: 0,
+          text: "SSE done",
+        }),
+        sseBlock("response.output_item.added", {
+          output_index: 2,
+          item: {
+            id: "fc-1",
+            type: "function_call",
+            call_id: "call-1",
+            name: "run_tests",
+            arguments: "",
+          },
+        }),
+        sseBlock("response.function_call_arguments.done", {
+          item_id: "fc-1",
+          output_index: 2,
+          arguments: "{}",
+        }),
+        sseBlock("response.output_item.added", {
+          output_index: 3,
+          item: {
+            id: "cc-1",
+            type: "custom_tool_call",
+            call_id: "custom-1",
+            name: "edit",
+            input: "",
+          },
+        }),
+        sseBlock("response.custom_tool_call_input.done", {
+          item_id: "cc-1",
+          output_index: 3,
+          input: "payload",
+        }),
+        sseBlock("response.completed", { response: { id: "resp-sse" } }),
+      ),
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      payload: {
+        previous_response_id: "resp-sse",
+        input: [
+          { type: "function_call_output", call_id: "call-1", output: "{\"passed\":true}" },
+          { type: "custom_tool_call_output", call_id: "custom-1", output: "{\"edited\":true}" },
+          { role: "user", content: "continue" },
+        ],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      response: {
+        id: "resp-2",
+        previous_response_id: "resp-sse",
+        output: [
+          { id: "msg-2", type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
+        ],
+      },
+      status: "completed",
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-2",
+    });
+
+    assert.equal(history.incomplete, false);
+    assert.equal(history.unresolvedCallIds.length, 0);
+    assert.deepEqual(
+      history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
+      [
+        "user",
+        "reasoning",
+        "message",
+        "function_call",
+        "custom_tool_call",
+        "function_call_output",
+        "custom_tool_call_output",
+        "user",
+        "message",
+      ],
+    );
+    assert.match(JSON.stringify(history.replayableItems), /SSE done/);
+  });
+});

--- a/components/adapters/codex/tests/context-history-fixtures.test.ts
+++ b/components/adapters/codex/tests/context-history-fixtures.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendCodexRequestJournalEntry,
+  appendCodexResponseJournalEntry,
+  buildCodexEffectiveHistory,
+  codexContextHistoryJournalPath,
+  readCodexContextHistoryJournal,
+  type JsonObject,
+} from "../src/context-history/index.js";
+
+async function withTempState(
+  fn: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-history-fixtures-"));
+  try {
+    await fn(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function sseBlock(event: string | undefined, data: JsonObject | string): string {
+  const lines = event ? [`event: ${event}`] : [];
+  const text = typeof data === "string" ? data : JSON.stringify(data);
+  for (const line of text.split("\n")) lines.push(`data: ${line}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function sseStream(...blocks: string[]): string {
+  return blocks.join("\n");
+}
+
+function completeStreamJournalFixture(responseId: string): string {
+  return sseStream(
+    sseBlock("response.created", { response: { id: responseId } }),
+    sseBlock("response.output_item.added", {
+      output_index: 0,
+      item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.output_text.delta", {
+      item_id: "msg-1",
+      output_index: 0,
+      delta: "stream",
+    }),
+    sseBlock("response.output_text.done", {
+      item_id: "msg-1",
+      output_index: 0,
+      text: "stream done",
+    }),
+    sseBlock("response.completed", { response: { id: responseId } }),
+  );
+}
+
+async function appendLegacySchemaRecord(stateDir: string, sessionId: string): Promise<void> {
+  await appendFile(
+    codexContextHistoryJournalPath(stateDir, sessionId),
+    `${JSON.stringify({
+      schema: "lightmem2.codex.context-history.response/v0",
+      kind: "response",
+      sessionId,
+      status: "completed",
+      stream: false,
+      observedAt: "2026-07-24T10:00:00.000Z",
+      outputItems: [{ type: "message", role: "assistant", content: "legacy" }],
+      outputItemRefs: [],
+    })}\n`,
+    "utf8",
+  );
+}
+
+test("CDH-06 History fixtures rebuild a complete stream journal after restart", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: {
+        stream: true,
+        input: [{ role: "user", content: "stream fixture" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      rawStreamText: completeStreamJournalFixture("resp-stream-fixture"),
+    });
+
+    const first = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-stream-fixture",
+    });
+    const afterRestart = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-stream-fixture",
+    });
+
+    assert.equal(afterRestart.incomplete, false);
+    assert.equal(afterRestart.revision, first.revision);
+    assert.deepEqual(afterRestart.replayableItems, first.replayableItems);
+    assert.match(JSON.stringify(afterRestart.replayableItems), /stream done/);
+  });
+});
+
+test("CDH-06 History fixtures keep function and custom call closure resolved after restart", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "call tools" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: {
+        id: "resp-1",
+        output: [
+          { id: "fc-1", type: "function_call", call_id: "call-1", name: "run_tests", arguments: "{}" },
+          { id: "cc-1", type: "custom_tool_call", call_id: "custom-1", name: "edit", input: "payload" },
+        ],
+      },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      payload: {
+        previous_response_id: "resp-1",
+        input: [
+          { type: "function_call_output", call_id: "call-1", output: "{\"ok\":true}" },
+          { type: "custom_tool_call_output", call_id: "custom-1", output: "{\"edited\":true}" },
+          { role: "user", content: "continue" },
+        ],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      response: {
+        id: "resp-2",
+        previous_response_id: "resp-1",
+        output: [{ id: "msg-2", type: "message", role: "assistant", content: [] }],
+      },
+      status: "completed",
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-2",
+    });
+
+    assert.deepEqual(history.unresolvedCallIds, []);
+    assert.match(JSON.stringify(history.replayableItems), /function_call_output/);
+    assert.match(JSON.stringify(history.replayableItems), /custom_tool_call_output/);
+  });
+});
+
+test("CDH-06 History fixtures isolate old schema records without dropping valid history", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "valid history" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: {
+        id: "resp-1",
+        output: [{ id: "msg-1", type: "message", role: "assistant", content: [] }],
+      },
+      status: "completed",
+    });
+    await appendLegacySchemaRecord(stateDir, "codex-session-1");
+
+    const journal = await readCodexContextHistoryJournal(stateDir, "codex-session-1");
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-1",
+      headResponseId: "resp-1",
+    });
+
+    assert.equal(journal.entries.length, 2);
+    assert.equal(journal.malformedLineCount, 1);
+    assert.equal(history.incomplete, true);
+    assert.match(JSON.stringify(history.replayableItems), /valid history/);
+    assert.doesNotMatch(JSON.stringify(history.replayableItems), /legacy/);
+  });
+});

--- a/components/adapters/codex/tests/context-history-journal.test.ts
+++ b/components/adapters/codex/tests/context-history-journal.test.ts
@@ -7,9 +7,7 @@ import test from "node:test";
 import {
   appendCodexRequestJournalEntry,
   appendCodexResponseJournalEntry,
-  buildCodexEffectiveHistory,
   codexContextHistoryJournalPath,
-  collectCodexResponseItemsFromStream,
   loadCodexContextHistoryJournal,
   readCodexContextHistoryJournal,
 } from "../src/context-history/index.js";
@@ -77,6 +75,49 @@ test("CDH-01 request journal stores sanitized input metadata and deduplicates re
   });
 });
 
+test("CDH-01 request journal deduplicates retries after sanitizing volatile input metadata", async () => {
+  await withTempState(async (stateDir) => {
+    const first = await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      payload: {
+        model: "gpt-5.4-mini",
+        previous_response_id: "resp-prev-1",
+        input: [
+          {
+            role: "user",
+            content: "same request body",
+            headers: { authorization: "Bearer first-token" },
+          },
+        ],
+      },
+      status: "completed",
+    });
+    const retry = await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      payload: {
+        model: "gpt-5.4-mini",
+        previous_response_id: "resp-prev-1",
+        input: [
+          {
+            role: "user",
+            content: "same request body",
+            headers: { authorization: "Bearer second-token" },
+          },
+        ],
+      },
+      status: "completed",
+    });
+
+    const journal = await loadCodexContextHistoryJournal(stateDir, "codex-session-1");
+
+    assert.equal(first.requestId, retry.requestId);
+    assert.equal(journal.length, 1);
+    assert.doesNotMatch(JSON.stringify(journal[0]), /authorization|Bearer first-token|Bearer second-token/i);
+  });
+});
+
 test("CDH-01 request journal advances pending requests to a terminal state", async () => {
   await withTempState(async (stateDir) => {
     const params = {
@@ -125,41 +166,6 @@ test("CDH-01 isolates malformed JSONL records without discarding valid history",
   });
 });
 
-test("CDH-04 marks an orphan incomplete response after the committed head as incomplete", async () => {
-  await withTempState(async (stateDir) => {
-    await appendCodexRequestJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "request-1",
-      payload: { input: [{ role: "user", content: "root" }] },
-      status: "completed",
-    });
-    await appendCodexResponseJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "request-1",
-      response: { id: "resp-1", output: [] },
-      status: "completed",
-    });
-    await appendCodexResponseJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      rawStreamText: [
-        "event: response.created",
-        "data: {\"response\":{\"id\":\"resp-orphan\"}}",
-        "",
-      ].join("\n"),
-    });
-
-    const history = await buildCodexEffectiveHistory({
-      stateDir,
-      sessionId: "codex-session-1",
-    });
-    assert.equal(history.incomplete, true);
-    assert.equal(history.replayableItems.length, 1);
-  });
-});
-
 test("CDH-02 response journal stores full non-stream output items and native refs", async () => {
   await withTempState(async (stateDir) => {
     const entry = await appendCodexResponseJournalEntry({
@@ -199,273 +205,87 @@ test("CDH-02 response journal stores full non-stream output items and native ref
   });
 });
 
-test("CDH-02 stream collector aggregates output items and marks incomplete streams", () => {
-  const completeStream = [
-    "event: response.created",
-    "data: {\"response\":{\"id\":\"resp-stream-1\",\"previous_response_id\":\"resp-prev-1\"}}",
-    "",
-    "event: response.output_item.added",
-    "data: {\"output_index\":0,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"\"}]}}",
-    "",
-    "event: response.output_text.delta",
-    "data: {\"item_id\":\"msg-1\",\"output_index\":0,\"delta\":\"hello\"}",
-    "",
-    "event: response.output_item.added",
-    "data: {\"output_index\":1,\"item\":{\"id\":\"fc-1\",\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"run_tests\",\"arguments\":\"\"}}",
-    "",
-    "event: response.function_call_arguments.delta",
-    "data: {\"item_id\":\"fc-1\",\"output_index\":1,\"delta\":\"{\\\"command\\\":\"}",
-    "",
-    "event: response.function_call_arguments.delta",
-    "data: {\"item_id\":\"fc-1\",\"output_index\":1,\"delta\":\"\\\"npm test\\\"}\"}",
-    "",
-    "event: response.completed",
-    "data: {\"response\":{\"id\":\"resp-stream-1\"}}",
-    "",
-    "data: [DONE]",
-    "",
-  ].join("\n");
-
-  const complete = collectCodexResponseItemsFromStream(completeStream);
-  assert.equal(complete.status, "completed");
-  assert.equal(complete.responseId, "resp-stream-1");
-  assert.equal(complete.previousResponseId, "resp-prev-1");
-  assert.equal(complete.outputItems.length, 2);
-  assert.match(JSON.stringify(complete.outputItems), /hello/);
-  assert.match(JSON.stringify(complete.outputItems), /npm test/);
-  assert.equal(complete.eventTypeCounts["response.output_text.delta"], 1);
-
-  const incomplete = collectCodexResponseItemsFromStream(completeStream.replace("event: response.completed", "event: response.output_text.delta"));
-  assert.equal(incomplete.status, "incomplete");
-});
-
-test("CDH-04 builds effective history from proxy journal in strict order with replay and observation split", async () => {
+test("CDH-02 response journal stores stream output items and stream metadata", async () => {
   await withTempState(async (stateDir) => {
-    await appendCodexRequestJournalEntry({
+    const completeStream = [
+      "event: response.created",
+      "data: {\"response\":{\"id\":\"resp-stream-1\",\"previous_response_id\":\"resp-prev-1\"}}",
+      "",
+      "event: response.output_item.added",
+      "data: {\"output_index\":0,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"\"}]}}",
+      "",
+      "event: response.output_text.delta",
+      "data: {\"item_id\":\"msg-1\",\"output_index\":0,\"delta\":\"hello\"}",
+      "",
+      "event: response.output_item.added",
+      "data: {\"output_index\":1,\"item\":{\"id\":\"fc-1\",\"type\":\"function_call\",\"call_id\":\"call-1\",\"name\":\"run_tests\",\"arguments\":\"\"}}",
+      "",
+      "event: response.function_call_arguments.delta",
+      "data: {\"item_id\":\"fc-1\",\"output_index\":1,\"delta\":\"{\\\"command\\\":\"}",
+      "",
+      "event: response.function_call_arguments.delta",
+      "data: {\"item_id\":\"fc-1\",\"output_index\":1,\"delta\":\"\\\"npm test\\\"}\"}",
+      "",
+      "event: response.completed",
+      "data: {\"response\":{\"id\":\"resp-stream-1\"}}",
+      "",
+      "data: [DONE]",
+      "",
+    ].join("\n");
+
+    const complete = await appendCodexResponseJournalEntry({
       stateDir,
       sessionId: "codex-session-1",
       requestId: "request-1",
-      payload: {
-        model: "gpt-5.4-mini",
-        input: [
-          { role: "developer", content: "stable instructions" },
-          { role: "user", content: "turn one" },
-        ],
-      },
-      status: "completed",
-      observedAt: "2026-07-24T10:00:00.000Z",
+      rawStreamText: completeStream,
     });
-    await appendCodexResponseJournalEntry({
+    const incomplete = await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-2",
+      rawStreamText: completeStream.replace("event: response.completed", "event: response.output_text.delta"),
+    });
+
+    const journal = await loadCodexContextHistoryJournal(stateDir, "codex-session-1");
+
+    assert.equal(complete.stream, true);
+    assert.equal(complete.status, "completed");
+    assert.equal(complete.responseId, "resp-stream-1");
+    assert.equal(complete.previousResponseId, "resp-prev-1");
+    assert.equal(complete.outputItems.length, 2);
+    assert.match(JSON.stringify(complete.outputItems), /hello/);
+    assert.match(JSON.stringify(complete.outputItems), /npm test/);
+    assert.equal(complete.eventTypeCounts?.["response.output_text.delta"], 1);
+    assert.equal(incomplete.status, "incomplete");
+    assert.equal(journal.length, 2);
+  });
+});
+
+test("CDH-02 response journal marks malformed completed streams incomplete", async () => {
+  await withTempState(async (stateDir) => {
+    const entry = await appendCodexResponseJournalEntry({
       stateDir,
       sessionId: "codex-session-1",
       requestId: "request-1",
-      response: {
-        id: "resp-1",
-        output: [
-          { id: "msg-1", type: "message", role: "assistant", content: [{ type: "output_text", text: "need tool" }] },
-          { id: "fc-1", type: "function_call", call_id: "call-1", name: "run_tests", arguments: "{}" },
-          { id: "ws-1", type: "web_search_call", query: "observed but not replayed" },
-        ],
-      },
-      observedAt: "2026-07-24T10:00:01.000Z",
-    });
-    await appendCodexRequestJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "request-2",
-      payload: {
-        model: "gpt-5.4-mini",
-        previous_response_id: "resp-1",
-        input: [
-          { type: "function_call_output", call_id: "call-1", output: "{\"passed\":true}" },
-          { role: "user", content: "turn two" },
-        ],
-      },
-      status: "completed",
-      observedAt: "2026-07-24T10:00:02.000Z",
-    });
-    await appendCodexResponseJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "request-2",
-      response: {
-        id: "resp-2",
-        previous_response_id: "resp-1",
-        output: [
-          { id: "msg-2", type: "message", role: "assistant", content: [{ type: "output_text", text: "done" }] },
-        ],
-      },
-      status: "completed",
-      observedAt: "2026-07-24T10:00:03.000Z",
-    });
-
-    const history = await buildCodexEffectiveHistory({
-      stateDir,
-      sessionId: "codex-session-1",
-      headResponseId: "resp-2",
-    });
-
-    assert.equal(history.source, "proxy_journal");
-    assert.equal(history.incomplete, false);
-    assert.equal(history.unresolvedCallIds.length, 0);
-    assert.equal(history.observationOnlyItems.length, 1);
-    assert.equal(history.observationOnlyItems[0]?.item.type, "web_search_call");
-    assert.deepEqual(
-      history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
-      ["developer", "user", "message", "function_call", "function_call_output", "user", "message"],
-    );
-    assert.match(history.revision, /^rev-[0-9a-f]+$/);
-  });
-});
-
-test("CDH-04 excludes failed requests and abandoned response branches", async () => {
-  await withTempState(async (stateDir) => {
-    await appendCodexRequestJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "root-request",
-      turnOrdinal: 1,
-      payload: { input: [{ role: "user", content: "root" }] },
-      status: "completed",
-    });
-    await appendCodexResponseJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "root-request",
-      response: { id: "resp-root", output: [] },
-      status: "completed",
-    });
-    await appendCodexRequestJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "failed-request",
-      turnOrdinal: 2,
-      payload: {
-        previous_response_id: "resp-root",
-        input: [{ role: "user", content: "FAILED_BRANCH_SENTINEL" }],
-      },
-      status: "failed",
-    });
-    await appendCodexRequestJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "branch-a-request",
-      turnOrdinal: 3,
-      payload: {
-        previous_response_id: "resp-root",
-        input: [{ role: "user", content: "BRANCH_A_SENTINEL" }],
-      },
-      status: "completed",
-    });
-    await appendCodexResponseJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "branch-a-request",
-      response: { id: "resp-a", previous_response_id: "resp-root", output: [] },
-      status: "completed",
-    });
-    await appendCodexRequestJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "branch-b-request",
-      turnOrdinal: 4,
-      payload: {
-        previous_response_id: "resp-root",
-        input: [{ role: "user", content: "BRANCH_B_SENTINEL" }],
-      },
-      status: "completed",
-    });
-    await appendCodexResponseJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
-      requestId: "branch-b-request",
-      response: { id: "resp-b", previous_response_id: "resp-root", output: [] },
-      status: "completed",
-    });
-
-    const history = await buildCodexEffectiveHistory({
-      stateDir,
-      sessionId: "codex-session-1",
-      headResponseId: "resp-a",
-    });
-    const replayed = JSON.stringify(history.replayableItems);
-    assert.match(replayed, /BRANCH_A_SENTINEL/);
-    assert.doesNotMatch(replayed, /BRANCH_B_SENTINEL|FAILED_BRANCH_SENTINEL/);
-    assert.equal(history.incomplete, false);
-  });
-});
-
-test("CDH-04 keeps synthetic item ids stable across request state events", async () => {
-  async function buildWithStates(states: Array<"pending" | "completed">): Promise<string[]> {
-    let ids: string[] = [];
-    await withTempState(async (stateDir) => {
-      for (const status of states) {
-        await appendCodexRequestJournalEntry({
-          stateDir,
-          sessionId: "codex-session-1",
-          requestId: "request-1",
-          turnOrdinal: 1,
-          payload: { input: [{ role: "user", content: "stable synthetic item" }] },
-          status,
-        });
-      }
-      await appendCodexResponseJournalEntry({
-        stateDir,
-        sessionId: "codex-session-1",
-        requestId: "request-1",
-        response: { id: "resp-1", output: [] },
-        status: "completed",
-      });
-      ids = (await buildCodexEffectiveHistory({
-        stateDir,
-        sessionId: "codex-session-1",
-        headResponseId: "resp-1",
-      })).replayableItems.map((entry) => entry.stableItemId);
-    });
-    return ids;
-  }
-
-  assert.deepEqual(await buildWithStates(["completed"]), await buildWithStates(["pending", "completed"]));
-});
-
-test("CDH-04 delegates to rollout parser bootstrap when proxy journal is incomplete", async () => {
-  await withTempState(async (stateDir) => {
-    await appendCodexResponseJournalEntry({
-      stateDir,
-      sessionId: "codex-session-1",
       rawStreamText: [
         "event: response.created",
-        "data: {\"response\":{\"id\":\"resp-incomplete\"}}",
+        "data: {\"response\":{\"id\":\"resp-malformed-completed\"}}",
+        "",
+        "event: response.output_item.done",
+        "data: {\"output_index\":0,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"kept\"}]}}",
         "",
         "event: response.output_text.delta",
-        "data: {\"item_id\":\"msg-1\",\"delta\":\"partial\"}",
+        "data: {\"truncated\":",
+        "",
+        "event: response.completed",
+        "data: {\"response\":{\"id\":\"resp-malformed-completed\"}}",
         "",
       ].join("\n"),
     });
 
-    const history = await buildCodexEffectiveHistory({
-      stateDir,
-      sessionId: "codex-session-1",
-      async rolloutParserBootstrap() {
-        return {
-          revision: "rollout-rev-1",
-          replayableItems: [
-            {
-              stableItemId: "rollout-user-1",
-              nativeId: "rollout-msg-1",
-              item: { role: "user", content: "bootstrapped from rollout parser fake" },
-            },
-          ],
-          observationOnlyItems: [],
-          unresolvedCallIds: [],
-          source: "rollout_bootstrap",
-          incomplete: false,
-        };
-      },
-    });
-
-    assert.equal(history.source, "rollout_bootstrap");
-    assert.equal(history.revision, "rollout-rev-1");
-    assert.equal(history.replayableItems[0]?.item.content, "bootstrapped from rollout parser fake");
+    assert.equal(entry.status, "incomplete");
+    assert.equal(entry.responseId, "resp-malformed-completed");
+    assert.equal(entry.malformedEventCount, 1);
+    assert.match(JSON.stringify(entry.outputItems), /kept/);
   });
 });

--- a/components/adapters/codex/tests/context-history-replayability.test.ts
+++ b/components/adapters/codex/tests/context-history-replayability.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  codexReplayabilityForItem,
+  isCodexObservationOnlyItem,
+  type CodexReplayabilityMode,
+  type CodexReplayabilityReason,
+  type JsonObject,
+} from "../src/context-history/index.js";
+
+function assertReplayability(
+  item: JsonObject,
+  mode: CodexReplayabilityMode,
+  reason: CodexReplayabilityReason,
+): void {
+  assert.deepEqual(codexReplayabilityForItem(item), { mode, reason });
+}
+
+test("CDH-05 Replayability classifies messages and tool call pairs as replayable by default", () => {
+  assertReplayability({ role: "user", content: "user input" }, "replayable", "default_replayable");
+  assertReplayability({ role: "developer", content: "stable instruction" }, "replayable", "default_replayable");
+  assertReplayability({
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text: "assistant output" }],
+  }, "replayable", "default_replayable");
+  assertReplayability({
+    type: "function_call",
+    call_id: "call-1",
+    name: "run_tests",
+    arguments: "{}",
+  }, "replayable", "tool_closure_required");
+  assertReplayability({
+    type: "function_call_output",
+    call_id: "call-1",
+    output: "{\"ok\":true}",
+  }, "replayable", "tool_closure_required");
+  assertReplayability({
+    type: "custom_tool_call",
+    call_id: "custom-1",
+    name: "edit",
+    input: "payload",
+  }, "replayable", "tool_closure_required");
+  assertReplayability({
+    type: "custom_tool_call_output",
+    call_id: "custom-1",
+    output: "{\"edited\":true}",
+  }, "replayable", "tool_closure_required");
+});
+
+test("CDH-05 Replayability keeps exact encrypted reasoning payloads replayable", () => {
+  const reasoning = {
+    id: "rs-1",
+    type: "reasoning",
+    encrypted_content: "opaque-provider-payload",
+  };
+
+  assertReplayability(reasoning, "replayable", "exact_payload_required");
+  assert.equal(isCodexObservationOnlyItem(reasoning), false);
+});
+
+test("CDH-05 Replayability classifies provider observations as observation-only by default", () => {
+  for (const item of [
+    { type: "web_search_call", query: "provider-owned observation" },
+    { type: "event_msg", message: "runtime event" },
+  ]) {
+    assertReplayability(item, "observation_only", "provider_observation");
+    assert.equal(isCodexObservationOnlyItem(item), true);
+  }
+  const turnContext = { type: "turn_context", content: "current turn metadata" };
+  assertReplayability(turnContext, "observation_only", "turn_context_instruction");
+  assert.equal(isCodexObservationOnlyItem(turnContext), true);
+});

--- a/components/adapters/codex/tests/context-history-sse-item-collector.test.ts
+++ b/components/adapters/codex/tests/context-history-sse-item-collector.test.ts
@@ -1,0 +1,303 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  collectCodexResponseItemsFromStream,
+  type JsonObject,
+} from "../src/context-history/index.js";
+
+function sseBlock(event: string | undefined, data: JsonObject | string): string {
+  const lines = event ? [`event: ${event}`] : [];
+  const text = typeof data === "string" ? data : JSON.stringify(data);
+  for (const line of text.split("\n")) lines.push(`data: ${line}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function sseStream(...blocks: string[]): string {
+  return blocks.join("\n");
+}
+
+function asObject(value: unknown): JsonObject {
+  assert.ok(value && typeof value === "object" && !Array.isArray(value));
+  return value as JsonObject;
+}
+
+function outputText(item: JsonObject): string {
+  assert.ok(Array.isArray(item.content));
+  const part = asObject(item.content[0]);
+  assert.equal(typeof part.text, "string");
+  return part.text;
+}
+
+test("CDH-03 SSE Item Collector applies content part, delta, and done events", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.created", {
+      response: { id: "resp-stream-1", previous_response_id: "resp-prev-1" },
+    }),
+    sseBlock("response.output_item.added", {
+      output_index: 0,
+      item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.content_part.added", {
+      item_id: "msg-1",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "Hello" },
+    }),
+    sseBlock("response.output_text.delta", {
+      item_id: "msg-1",
+      output_index: 0,
+      content_index: 0,
+      delta: ", world",
+    }),
+    sseBlock("response.output_text.done", {
+      item_id: "msg-1",
+      output_index: 0,
+      content_index: 0,
+      text: "Hello, world!",
+    }),
+    sseBlock("response.content_part.done", {
+      item_id: "msg-1",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "Hello, world!" },
+    }),
+    sseBlock("response.completed", { response: { id: "resp-stream-1" } }),
+    sseBlock(undefined, "[DONE]"),
+  ));
+  const message = asObject(result.outputItems[0]);
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.responseId, "resp-stream-1");
+  assert.equal(result.previousResponseId, "resp-prev-1");
+  assert.equal(result.outputItems.length, 1);
+  assert.equal(message.type, "message");
+  assert.equal(outputText(message), "Hello, world!");
+  assert.equal(result.eventTypeCounts["response.content_part.done"], 1);
+  assert.equal(result.eventTypeCounts["response.output_text.done"], 1);
+});
+
+test("CDH-03 SSE Item Collector applies function argument delta and done events", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.output_item.added", {
+      output_index: 0,
+      item: {
+        id: "fc-1",
+        type: "function_call",
+        call_id: "call-1",
+        name: "run_tests",
+        arguments: "",
+      },
+    }),
+    sseBlock("response.function_call_arguments.delta", {
+      item_id: "fc-1",
+      output_index: 0,
+      delta: "{\"command\":",
+    }),
+    sseBlock("response.function_call_arguments.delta", {
+      item_id: "fc-1",
+      output_index: 0,
+      delta: "\"npm test\"}",
+    }),
+    sseBlock("response.function_call_arguments.done", {
+      item_id: "fc-1",
+      output_index: 0,
+      arguments: "{\"command\":\"npm test\"}",
+    }),
+    sseBlock("response.completed", { response: { id: "resp-stream-2" } }),
+  ));
+  const item = asObject(result.outputItems[0]);
+
+  assert.equal(result.status, "completed");
+  assert.equal(item.type, "function_call");
+  assert.equal(item.call_id, "call-1");
+  assert.equal(item.arguments, "{\"command\":\"npm test\"}");
+  assert.equal(result.eventTypeCounts["response.function_call_arguments.done"], 1);
+});
+
+test("CDH-03 SSE Item Collector uses response data.type when SSE event fields are absent", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock(undefined, {
+      type: "response.created",
+      response: { id: "resp-data-type" },
+    }),
+    sseBlock(undefined, {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock(undefined, {
+      type: "response.output_text.delta",
+      item_id: "msg-1",
+      output_index: 0,
+      delta: "typed",
+    }),
+    sseBlock(undefined, {
+      type: "response.completed",
+      response: { id: "resp-data-type" },
+    }),
+  ));
+  const message = asObject(result.outputItems[0]);
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.responseId, "resp-data-type");
+  assert.equal(outputText(message), "typed");
+  assert.equal(result.eventTypeCounts["response.output_text.delta"], 1);
+  assert.equal(result.eventTypeCounts.message, undefined);
+});
+
+test("CDH-03 SSE Item Collector ignores non-response data.type overrides", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.output_item.added", {
+      type: "message",
+      output_index: 0,
+      item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.output_text.delta", {
+      type: "output_text",
+      item_id: "msg-1",
+      output_index: 0,
+      delta: "kept",
+    }),
+  ));
+
+  assert.equal(outputText(asObject(result.outputItems[0])), "kept");
+  assert.equal(result.eventTypeCounts["response.output_text.delta"], 1);
+  assert.equal(result.eventTypeCounts.output_text, undefined);
+});
+
+test("CDH-03 SSE Item Collector aggregates reasoning and custom tool delta events", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.output_item.added", {
+      output_index: 0,
+      item: { id: "rs-1", type: "reasoning", summary: [] },
+    }),
+    sseBlock("response.reasoning_summary_part.added", {
+      item_id: "rs-1",
+      output_index: 0,
+      summary_index: 0,
+      part: { type: "summary_text", text: "" },
+    }),
+    sseBlock("response.reasoning_summary_text.delta", {
+      item_id: "rs-1",
+      output_index: 0,
+      summary_index: 0,
+      delta: "checked",
+    }),
+    sseBlock("response.reasoning_summary_text.done", {
+      item_id: "rs-1",
+      output_index: 0,
+      summary_index: 0,
+      text: "checked",
+    }),
+    sseBlock("response.output_item.added", {
+      output_index: 1,
+      item: {
+        id: "cc-1",
+        type: "custom_tool_call",
+        call_id: "custom-1",
+        name: "edit",
+        input: "",
+      },
+    }),
+    sseBlock("response.custom_tool_call_input.delta", {
+      item_id: "cc-1",
+      output_index: 1,
+      delta: "pay",
+    }),
+    sseBlock("response.custom_tool_call_input.done", {
+      item_id: "cc-1",
+      output_index: 1,
+      input: "payload",
+    }),
+    sseBlock("response.completed", { response: { id: "resp-stream-4" } }),
+  ));
+  const reasoning = asObject(result.outputItems[0]);
+  const customCall = asObject(result.outputItems[1]);
+
+  assert.ok(Array.isArray(reasoning.summary));
+  assert.equal(asObject(reasoning.summary[0]).text, "checked");
+  assert.equal(customCall.type, "custom_tool_call");
+  assert.equal(customCall.call_id, "custom-1");
+  assert.equal(customCall.input, "payload");
+});
+
+test("CDH-03 SSE Item Collector preserves accumulated fields across empty item updates", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.output_item.added", {
+      output_index: 0,
+      item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.output_text.delta", {
+      item_id: "msg-1",
+      output_index: 0,
+      delta: "partial",
+    }),
+    sseBlock("response.output_item.done", {
+      output_index: 0,
+      item: {
+        id: "msg-1",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "" }],
+      },
+    }),
+  ));
+
+  assert.equal(outputText(asObject(result.outputItems[0])), "partial");
+});
+
+test("CDH-03 SSE Item Collector keeps reasoning items and only counts unknown events", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.future_event", {
+      headers: { authorization: "Bearer secret" },
+      note: "count only",
+    }),
+    sseBlock("response.output_text.delta", "{\"truncated\":"),
+    sseBlock("response.output_item.done", {
+      output_index: 0,
+      item: { id: "rs-1", type: "reasoning", encrypted_content: "opaque" },
+    }),
+    sseBlock("response.completed", { response: { id: "resp-stream-3" } }),
+  ));
+  const item = asObject(result.outputItems[0]);
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.malformedEventCount, 1);
+  assert.equal(result.malformedEventTypeCounts["response.output_text.delta"], 1);
+  assert.equal(result.eventTypeCounts["response.future_event"], 1);
+  assert.equal(result.outputItems.length, 1);
+  assert.equal(item.type, "reasoning");
+  assert.equal(item.encrypted_content, "opaque");
+  assert.doesNotMatch(JSON.stringify(result.outputItems), /authorization|Bearer secret/i);
+});
+
+test("CDH-03 SSE Item Collector marks interrupted streams incomplete", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.created", { response: { id: "resp-interrupted" } }),
+    sseBlock("response.output_item.added", {
+      output_index: 0,
+      item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.output_text.delta", {
+      item_id: "msg-1",
+      output_index: 0,
+      delta: "partial",
+    }),
+  ));
+
+  assert.equal(result.status, "incomplete");
+  assert.equal(result.responseId, "resp-interrupted");
+  assert.equal(outputText(asObject(result.outputItems[0])), "partial");
+});
+
+test("CDH-03 SSE Item Collector parses multiline data fields", () => {
+  const result = collectCodexResponseItemsFromStream(sseBlock(
+    "response.created",
+    "{\"response\":{\n\"id\":\"resp-multiline\",\n\"previous_response_id\":\"resp-prev\"}}",
+  ));
+
+  assert.equal(result.responseId, "resp-multiline");
+  assert.equal(result.previousResponseId, "resp-prev");
+});


### PR DESCRIPTION
Based on the latest bd2ddc7.

Changes:
- Split out CDH-03 SSE Item Collector for collecting message, reasoning, function call, and custom tool call outputs from Responses API streams.
- Added stream event counts and malformed event counts to the response journal.
- Updated Effective History Builder to consume SSE-collected items, preserve valid history for malformed completed streams, and mark the history as incomplete.
- Added a thin CDH-05 replayability classification interface.
- Split tests for CDH-03/04/05/06 to keep coverage aligned with each component.

Boundaries:
- Did not modify rollout-parser.
- Did not modify proxy/rebase integration files.

Tests:
- context-history + rollout tests: 37 passed
- context-rebase behavior tests: 9 passed
- typecheck passed
- build passed