### PR TITLE
feat(codex): add response chain rebase controls

### DIFF
--- a/components/adapters/codex/src/config.ts
+++ b/components/adapters/codex/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import type { CodexContextRewriteConfig, CodexMutationPlan } from "./context-rewrite/types.js";
 
 export type CodexProviderConfig = {
   name?: string;
@@ -30,6 +31,9 @@ export type TokenPilotCodexConfig = {
   modules: {
     stabilizer: boolean;
     reduction: boolean;
+  };
+  contextRewrite: CodexContextRewriteConfig & {
+    mutationPlan?: CodexMutationPlan;
   };
   reduction: {
     triggerMinChars: number;
@@ -126,6 +130,24 @@ function sanitizeCodexReductionPassOptions(raw: unknown): Record<string, Record<
   return output;
 }
 
+function sanitizeCodexMutationPlan(raw: unknown): CodexMutationPlan | undefined {
+  const input = asRecord(raw);
+  if (!Array.isArray(input.operations)) return undefined;
+  const operations = input.operations
+    .filter((operation) => operation && typeof operation === "object" && !Array.isArray(operation))
+    .map((operation) => {
+      const next = operation as Record<string, unknown>;
+      return {
+        type: typeof next.type === "string" ? next.type : "",
+        stableItemId: stringValue(next.stableItemId),
+      };
+    });
+  return {
+    baseRevision: stringValue(input.baseRevision),
+    operations,
+  };
+}
+
 export function normalizeTokenPilotCodexConfig(
   raw: unknown,
   options?: NormalizeCodexConfigOptions,
@@ -134,6 +156,7 @@ export function normalizeTokenPilotCodexConfig(
   const proxyMode = asRecord(obj.proxyMode);
   const hooks = asRecord(obj.hooks);
   const modules = asRecord(obj.modules);
+  const contextRewrite = asRecord(obj.contextRewrite);
   const reduction = asRecord(obj.reduction);
   const passes = asRecord(reduction.passes);
   const upstream = asRecord(obj.upstream);
@@ -167,6 +190,14 @@ export function normalizeTokenPilotCodexConfig(
     modules: {
       stabilizer: boolValue(modules.stabilizer, true),
       reduction: boolValue(modules.reduction, true),
+    },
+    contextRewrite: {
+      enabled: boolValue(contextRewrite.enabled, false),
+      mode: "response_chain_rebase",
+      failureMode: "bypass",
+      retryOriginalRequest: boolValue(contextRewrite.retryOriginalRequest, true),
+      cooldownMs: numberValue(contextRewrite.cooldownMs, 300_000, 0, 86_400_000),
+      mutationPlan: sanitizeCodexMutationPlan(contextRewrite.mutationPlan),
     },
     reduction: {
       triggerMinChars: numberValue(reduction.triggerMinChars, 2200, 256, 1_000_000),
@@ -210,7 +241,7 @@ function parseTomlStringValue(raw: string | undefined): string | undefined {
   if (typeof raw !== "string") return undefined;
   const trimmed = raw.trim();
   if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
-    return trimmed.slice(1, -1).replace(/\\"/g, "\"");
+    return trimmed.slice(1, -1).replace(/\\"/g, "\"").replace(/\\\\/g, "\\");
   }
   if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
     return trimmed.slice(1, -1);

--- a/components/adapters/codex/src/context-history/effective-history.ts
+++ b/components/adapters/codex/src/context-history/effective-history.ts
@@ -63,7 +63,16 @@ function committedResponses(
 }
 
 function previousResponseId(turn: CommittedTurn): string | undefined {
-  return turn.response.entry.previousResponseId ?? turn.request.entry.previousResponseId;
+  if ("previousResponseId" in turn.response.entry) {
+    return typeof turn.response.entry.previousResponseId === "string"
+      ? turn.response.entry.previousResponseId
+      : undefined;
+  }
+  return turn.request.entry.previousResponseId;
+}
+
+function committedInputItems(turn: CommittedTurn): JsonObject[] {
+  return turn.request.entry.committedInputItems ?? turn.request.entry.inputItems;
 }
 
 function buildCommittedChain(params: {
@@ -101,7 +110,7 @@ function buildCommittedChain(params: {
     const previousId = previousResponseId(turn);
     if (!previousId) break;
     cursor = params.responses.get(previousId);
-    if (!cursor) return { chain: [], complete: false };
+    if (!cursor) return { chain, complete: false };
   }
   return { chain, complete: true };
 }
@@ -205,6 +214,128 @@ function hasMalformedStreamEvents(chain: CommittedTurn[]): boolean {
   return chain.some((turn) => (turn.response.entry.malformedEventCount ?? 0) > 0);
 }
 
+function effectiveItemKeys(entry: CodexEffectiveHistoryItem): string[] {
+  const type = typeof entry.item.type === "string"
+    ? entry.item.type
+    : typeof entry.item.role === "string"
+      ? `message:${entry.item.role}`
+      : "item";
+  const keys = [`stable:${entry.stableItemId}`];
+  if (entry.nativeId) keys.push(`native:${entry.nativeId}`);
+  if (typeof entry.item.id === "string") keys.push(`item:${type}:${entry.item.id}`);
+  if (entry.callId) keys.push(`call:${type}:${entry.callId}`);
+  return keys;
+}
+
+function appendMergedEffectiveItems(params: {
+  target: CodexEffectiveHistoryItem[];
+  entries: CodexEffectiveHistoryItem[];
+  seen: Set<string>;
+}): void {
+  for (const entry of params.entries) {
+    const keys = effectiveItemKeys(entry);
+    if (keys.some((key) => params.seen.has(key))) continue;
+    keys.forEach((key) => params.seen.add(key));
+    params.target.push({
+      ...entry,
+      item: cloneJson(entry.item),
+    });
+  }
+}
+
+function historyRevision(params: {
+  replayableItems: CodexEffectiveHistoryItem[];
+  observationOnlyItems: CodexEffectiveHistoryItem[];
+  deferredItems: CodexEffectiveHistoryItem[];
+  unresolved: string[];
+  incomplete: boolean;
+}): string {
+  return `rev-${hashJson({
+    replayableItems: params.replayableItems.map((entry) => ({
+      stableItemId: entry.stableItemId,
+      fingerprint: hashJson(entry.item),
+    })),
+    observationOnlyItems: params.observationOnlyItems.map((entry) => ({
+      stableItemId: entry.stableItemId,
+      fingerprint: hashJson(entry.item),
+    })),
+    deferredItems: params.deferredItems.map((entry) => ({
+      stableItemId: entry.stableItemId,
+      fingerprint: hashJson(entry.item),
+    })),
+    unresolved: params.unresolved,
+    incomplete: params.incomplete,
+  })}`;
+}
+
+function mergeRolloutBootstrapWithProxyJournal(params: {
+  bootstrapped: CodexEffectiveHistory;
+  proxyReplayableItems: CodexEffectiveHistoryItem[];
+  proxyObservationOnlyItems: CodexEffectiveHistoryItem[];
+  proxyDeferredItems: CodexEffectiveHistoryItem[];
+  proxyIncomplete: boolean;
+}): CodexEffectiveHistory {
+  const seen = new Set<string>();
+  const replayableItems: CodexEffectiveHistoryItem[] = [];
+  const observationOnlyItems: CodexEffectiveHistoryItem[] = [];
+  const deferredItems: CodexEffectiveHistoryItem[] = [];
+  appendMergedEffectiveItems({
+    target: replayableItems,
+    entries: params.bootstrapped.replayableItems,
+    seen,
+  });
+  appendMergedEffectiveItems({
+    target: observationOnlyItems,
+    entries: params.bootstrapped.observationOnlyItems,
+    seen,
+  });
+  appendMergedEffectiveItems({
+    target: deferredItems,
+    entries: params.bootstrapped.deferredItems,
+    seen,
+  });
+  appendMergedEffectiveItems({
+    target: replayableItems,
+    entries: params.proxyReplayableItems,
+    seen,
+  });
+  appendMergedEffectiveItems({
+    target: observationOnlyItems,
+    entries: params.proxyObservationOnlyItems,
+    seen,
+  });
+  appendMergedEffectiveItems({
+    target: deferredItems,
+    entries: params.proxyDeferredItems,
+    seen,
+  });
+  const unresolved = Array.from(new Set([
+    ...params.bootstrapped.unresolvedCallIds,
+    ...unresolvedCallIds(replayableItems),
+  ])).sort();
+  const incomplete = Boolean(
+    params.bootstrapped.incomplete
+    || params.proxyIncomplete
+    || deferredItems.length > 0
+    || unresolved.length > 0
+  );
+  return {
+    revision: historyRevision({
+      replayableItems,
+      observationOnlyItems,
+      deferredItems,
+      unresolved,
+      incomplete,
+    }),
+    replayableItems,
+    observationOnlyItems,
+    deferredItems,
+    unresolvedCallIds: unresolved,
+    source: "rollout_proxy_merge",
+    incomplete,
+  };
+}
+
 export async function buildCodexEffectiveHistory(params: {
   stateDir: string;
   sessionId: string;
@@ -220,37 +351,41 @@ export async function buildCodexEffectiveHistory(params: {
     requests,
     responses,
   });
+  const malformedStreams = hasMalformedStreamEvents(committedChain.chain);
+  const emptyChainWithJournal = Boolean(
+    committedChain.chain.length === 0
+    && journalRead.entries.some((entry) => (
+      entry.status !== "failed"
+      && !(entry.kind === "request" && entry.requestId === params.currentRequestId)
+    ))
+  );
+  const uncommittedActiveWork = hasUncommittedActiveWork({
+    chain: committedChain.chain,
+    currentRequestId: params.currentRequestId,
+    explicitHead: params.headResponseId !== undefined,
+    requests,
+  });
+  const uncommittedResponseWork = hasUncommittedResponseWork({
+    chain: committedChain.chain,
+    explicitHead: params.headResponseId !== undefined,
+    journal: journalRead.entries,
+    requests,
+  });
   const journalIncomplete = Boolean(
     journalRead.readError
     || journalRead.malformedLineCount > 0
-    || hasMalformedStreamEvents(committedChain.chain)
+    || malformedStreams
     || !committedChain.complete
-    || (
-      committedChain.chain.length === 0
-      && journalRead.entries.some((entry) => (
-        entry.status !== "failed"
-        && !(entry.kind === "request" && entry.requestId === params.currentRequestId)
-      ))
-    )
-    || hasUncommittedActiveWork({
-      chain: committedChain.chain,
-      currentRequestId: params.currentRequestId,
-      explicitHead: params.headResponseId !== undefined,
-      requests,
-    })
-    || hasUncommittedResponseWork({
-      chain: committedChain.chain,
-      explicitHead: params.headResponseId !== undefined,
-      journal: journalRead.entries,
-      requests,
-    }),
+    || emptyChainWithJournal
+    || uncommittedActiveWork
+    || uncommittedResponseWork,
   );
   const replayableItems: CodexEffectiveHistoryItem[] = [];
   const observationOnlyItems: CodexEffectiveHistoryItem[] = [];
   const deferredItems: CodexEffectiveHistoryItem[] = [];
   const seen = new Set<string>();
   for (const turn of committedChain.chain) {
-    turn.request.entry.inputItems.forEach((item, itemOrdinal) => {
+    committedInputItems(turn).forEach((item, itemOrdinal) => {
       appendEffectiveItem({
         item,
         sessionId: params.sessionId,
@@ -282,24 +417,31 @@ export async function buildCodexEffectiveHistory(params: {
   const effectiveIncomplete = journalIncomplete || deferredItems.length > 0 || unresolved.length > 0;
   if ((journalRead.entries.length === 0 || effectiveIncomplete) && params.rolloutParserBootstrap) {
     const bootstrapped = await params.rolloutParserBootstrap();
-    if (bootstrapped) return bootstrapped;
+    if (bootstrapped) {
+      if (committedChain.chain.length === 0) return bootstrapped;
+      return mergeRolloutBootstrapWithProxyJournal({
+        bootstrapped,
+        proxyReplayableItems: replayableItems,
+        proxyObservationOnlyItems: observationOnlyItems,
+        proxyDeferredItems: deferredItems,
+        proxyIncomplete: Boolean(
+          journalRead.readError
+          || journalRead.malformedLineCount > 0
+          || malformedStreams
+          || emptyChainWithJournal
+          || uncommittedActiveWork
+          || uncommittedResponseWork
+        ),
+      });
+    }
   }
-  const revision = `rev-${hashJson({
-    replayableItems: replayableItems.map((entry) => ({
-      stableItemId: entry.stableItemId,
-      fingerprint: hashJson(entry.item),
-    })),
-    observationOnlyItems: observationOnlyItems.map((entry) => ({
-      stableItemId: entry.stableItemId,
-      fingerprint: hashJson(entry.item),
-    })),
-    deferredItems: deferredItems.map((entry) => ({
-      stableItemId: entry.stableItemId,
-      fingerprint: hashJson(entry.item),
-    })),
+  const revision = historyRevision({
+    replayableItems,
+    observationOnlyItems,
+    deferredItems,
     unresolved,
     incomplete: effectiveIncomplete,
-  })}`;
+  });
 
   return {
     revision,

--- a/components/adapters/codex/src/context-history/request-journal.ts
+++ b/components/adapters/codex/src/context-history/request-journal.ts
@@ -49,6 +49,7 @@ export async function appendCodexRequestJournalEntry(params: {
   stateDir: string;
   sessionId: string;
   payload: JsonObject;
+  committedInputItems?: JsonObject[];
   requestId?: string;
   turnOrdinal?: number;
   status?: CodexJournalStatus;
@@ -79,6 +80,11 @@ export async function appendCodexRequestJournalEntry(params: {
       typeof params.payload.prompt_cache_key === "string" ? params.payload.prompt_cache_key : undefined
     ),
     inputItems: existing?.inputItems ?? sanitizedInputItems(params.payload),
+    committedInputItems: existing?.committedInputItems ?? (
+      params.committedInputItems
+        ? cloneJson(sanitizeValue(params.committedInputItems)) as JsonObject[]
+        : undefined
+    ),
     status: nextStatus,
     error: params.error,
     observedAt: params.observedAt ?? new Date().toISOString(),

--- a/components/adapters/codex/src/context-history/response-journal.ts
+++ b/components/adapters/codex/src/context-history/response-journal.ts
@@ -19,13 +19,28 @@ function outputRefs(outputItems: JsonObject[]): CodexResponseJournalEntry["outpu
 
 function responseStatus(params: {
   status?: CodexJournalStatus;
+  responseStatus?: CodexJournalStatus;
   streamStatus?: CodexJournalStatus;
   malformedEventCount?: number;
 }): CodexJournalStatus {
-  const status = normalizeStatus(params.status, params.streamStatus ?? "completed");
+  if (params.status === "failed" || params.responseStatus === "failed" || params.streamStatus === "failed") {
+    return "failed";
+  }
+  if (params.status === "incomplete" || params.responseStatus === "incomplete" || params.streamStatus === "incomplete") {
+    return "incomplete";
+  }
+  const status = normalizeStatus(params.status, params.streamStatus ?? params.responseStatus ?? "completed");
   return status === "completed" && (params.malformedEventCount ?? 0) > 0
     ? "incomplete"
     : status;
+}
+
+function responseBodyStatus(response: JsonObject): CodexJournalStatus | undefined {
+  const status = typeof response.status === "string" ? response.status.toLowerCase() : undefined;
+  if (!status) return undefined;
+  if (status === "completed") return "completed";
+  if (status === "failed" || status === "cancelled") return "failed";
+  return "incomplete";
 }
 
 export async function appendCodexResponseJournalEntry(params: {
@@ -34,6 +49,7 @@ export async function appendCodexResponseJournalEntry(params: {
   requestId?: string;
   response?: JsonObject;
   rawStreamText?: string;
+  previousResponseId?: string | null;
   status?: CodexJournalStatus;
   error?: string;
   observedAt?: string;
@@ -53,8 +69,10 @@ export async function appendCodexResponseJournalEntry(params: {
     requestId: params.requestId,
     sessionId: params.sessionId,
     responseId: streamCollected?.responseId ?? (typeof response.id === "string" ? response.id : undefined),
-    previousResponseId: streamCollected?.previousResponseId
-      ?? (typeof response.previous_response_id === "string" ? response.previous_response_id : undefined),
+    previousResponseId: params.previousResponseId !== undefined
+      ? params.previousResponseId
+      : streamCollected?.previousResponseId
+        ?? (typeof response.previous_response_id === "string" ? response.previous_response_id : undefined),
     stream: typeof params.rawStreamText === "string",
     outputItems,
     outputItemRefs: outputRefs(outputItems),
@@ -63,6 +81,7 @@ export async function appendCodexResponseJournalEntry(params: {
     malformedEventTypeCounts: streamCollected?.malformedEventTypeCounts,
     status: responseStatus({
       status: params.status,
+      responseStatus: responseBodyStatus(response),
       streamStatus: streamCollected?.status,
       malformedEventCount: streamCollected?.malformedEventCount,
     }),

--- a/components/adapters/codex/src/context-history/sse-item-collector.ts
+++ b/components/adapters/codex/src/context-history/sse-item-collector.ts
@@ -218,7 +218,9 @@ function mergeContentPart(item: JsonObject, data: JsonObject): void {
   if (!part) return;
 
   const existing = ensureContentPart(item, data);
+  const before = { ...existing };
   Object.assign(existing, part);
+  preserveNonEmptyString(existing, before, part, "text");
 }
 
 function appendOutputText(item: JsonObject, data: JsonObject): void {
@@ -235,6 +237,7 @@ function setOutputText(item: JsonObject, data: JsonObject): void {
   if (text === undefined) return;
 
   const part = ensureContentPart(item, data);
+  if (text.length === 0 && typeof part.text === "string" && part.text.length > 0) return;
   if (typeof part.type !== "string") part.type = "output_text";
   part.text = text;
 }
@@ -246,7 +249,9 @@ function appendStringField(item: JsonObject, field: string, delta: unknown): voi
 }
 
 function setStringField(item: JsonObject, field: string, value: unknown): void {
-  if (typeof value === "string") item[field] = value;
+  if (typeof value !== "string") return;
+  if (value.length === 0 && typeof item[field] === "string" && item[field].length > 0) return;
+  item[field] = value;
 }
 
 function reasoningText(data: JsonObject): string | undefined {
@@ -278,7 +283,9 @@ function mergeReasoningSummaryPart(item: JsonObject, data: JsonObject): void {
   if (!part) return;
 
   const existing = ensureReasoningSummaryPart(item, data);
+  const before = { ...existing };
   Object.assign(existing, part);
+  preserveNonEmptyString(existing, before, part, "text");
 }
 
 function appendReasoningSummaryText(item: JsonObject, data: JsonObject): void {
@@ -295,6 +302,7 @@ function setReasoningSummaryText(item: JsonObject, data: JsonObject): void {
   if (text === undefined) return;
 
   const part = ensureReasoningSummaryPart(item, data);
+  if (text.length === 0 && typeof part.text === "string" && part.text.length > 0) return;
   if (typeof part.type !== "string") part.type = "summary_text";
   part.text = text;
 }

--- a/components/adapters/codex/src/context-history/types.ts
+++ b/components/adapters/codex/src/context-history/types.ts
@@ -16,6 +16,7 @@ export type CodexRequestJournalEntry = {
   previousResponseId?: string;
   promptCacheKey?: string;
   inputItems: JsonObject[];
+  committedInputItems?: JsonObject[];
   status: CodexJournalStatus;
   error?: string;
   observedAt: string;
@@ -33,7 +34,7 @@ export type CodexResponseJournalEntry = {
   requestId?: string;
   sessionId: string;
   responseId?: string;
-  previousResponseId?: string;
+  previousResponseId?: string | null;
   stream: boolean;
   outputItems: JsonObject[];
   outputItemRefs: CodexResponseOutputRef[];
@@ -62,7 +63,7 @@ export type CodexEffectiveHistory = {
   observationOnlyItems: CodexEffectiveHistoryItem[];
   deferredItems: CodexEffectiveHistoryItem[];
   unresolvedCallIds: string[];
-  source: "proxy_journal" | "rollout_bootstrap" | "empty";
+  source: "proxy_journal" | "rollout_bootstrap" | "rollout_proxy_merge" | "empty";
   incomplete: boolean;
 };
 

--- a/components/adapters/codex/src/context-rewrite/fallback.ts
+++ b/components/adapters/codex/src/context-rewrite/fallback.ts
@@ -1,10 +1,36 @@
+import { collectCodexResponseItemsFromStream } from "../context-history/sse-item-collector.js";
 import { cloneJson } from "./shared.js";
 import type {
   CodexRebaseFallbackResult,
+  CodexRebaseEpoch,
+  CodexRebaseAccounting,
+  CodexRebaseCapabilityNotice,
+  CodexRebaseCapabilityStoreParams,
+  CodexRebaseCooldownNotice,
+  CodexRebaseCooldownStoreParams,
+  CodexRebaseEpochStoreParams,
   CodexUpstreamResponse,
   CodexUpstreamSender,
   JsonObject,
 } from "./types.js";
+import {
+  appendPendingCodexRebaseEpoch,
+  commitCodexRebaseEpoch,
+  failCodexRebaseEpoch,
+  readPendingCodexRebaseEpochs,
+  rollbackCodexRebaseEpoch,
+} from "./rebase-epoch.js";
+import {
+  appendCodexRebaseCooldown,
+  codexRebaseCooldownNotice,
+  readActiveCodexRebaseCooldown,
+} from "./rebase-cooldown.js";
+import {
+  appendCodexRebaseCapability,
+  codexRebasePayloadItemTypes,
+  readUnsupportedCodexRebaseItemTypes,
+  unsupportedCodexRebaseItemTypesFromResponse,
+} from "./rebase-capability.js";
 
 function isSuccessfulResponse(response: CodexUpstreamResponse): boolean {
   return response.status >= 200 && response.status < 300;
@@ -24,30 +50,66 @@ function responseIdFromObject(value: unknown): string | undefined {
   return typeof response?.id === "string" && response.id ? response.id : undefined;
 }
 
-function responseIdFromText(text: string): string | undefined {
-  try {
-    const responseId = responseIdFromObject(JSON.parse(text) as unknown);
-    if (responseId) return responseId;
-  } catch {
-    // Streaming Responses use SSE rather than one JSON document.
+function responseStatusFromObject(value: unknown): string | undefined {
+  const object = asObject(value);
+  if (!object) return undefined;
+  if (typeof object.status === "string") return object.status;
+  const response = asObject(object.response);
+  return typeof response?.status === "string" ? response.status : undefined;
+}
+
+function isEventStreamResponse(response: CodexUpstreamResponse): boolean {
+  const contentType = Object.entries(response.headers)
+    .find(([key]) => key.toLowerCase() === "content-type")?.[1]
+    .toLowerCase();
+  return Boolean(
+    contentType?.includes("text/event-stream")
+    || /^event:\s*response\.|^data:\s*\{|\n\n\s*event:\s*response\./m.test(response.text),
+  );
+}
+
+function rebaseResponseObservation(response: CodexUpstreamResponse): {
+  responseId?: string;
+  completed: boolean;
+  failureReason?: string;
+} {
+  if (!isSuccessfulResponse(response)) {
+    return { completed: false, failureReason: "rebase_upstream_rejected" };
+  }
+  if (isEventStreamResponse(response)) {
+    const collected = collectCodexResponseItemsFromStream(response.text);
+    const sawCompleted = (collected.eventTypeCounts["response.completed"] ?? 0) > 0;
+    if (collected.status === "failed") {
+      return { responseId: collected.responseId, completed: false, failureReason: "rebase_stream_failed" };
+    }
+    if (collected.malformedEventCount > 0) {
+      return { responseId: collected.responseId, completed: false, failureReason: "rebase_stream_malformed" };
+    }
+    if (collected.status !== "completed" || !sawCompleted) {
+      return { responseId: collected.responseId, completed: false, failureReason: "rebase_stream_incomplete" };
+    }
+    return {
+      responseId: collected.responseId,
+      completed: typeof collected.responseId === "string" && collected.responseId.length > 0,
+      failureReason: collected.responseId ? undefined : "rebase_response_id_missing",
+    };
   }
 
-  for (const chunk of text.split(/\r?\n\r?\n/)) {
-    const dataText = chunk
-      .split(/\r?\n/)
-      .filter((line) => line.startsWith("data:"))
-      .map((line) => line.slice("data:".length).trimStart())
-      .join("\n")
-      .trim();
-    if (!dataText || dataText === "[DONE]") continue;
-    try {
-      const responseId = responseIdFromObject(JSON.parse(dataText) as unknown);
-      if (responseId) return responseId;
-    } catch {
-      continue;
+  try {
+    const parsed = JSON.parse(response.text) as unknown;
+    const status = responseStatusFromObject(parsed);
+    if (status === "failed" || status === "incomplete") {
+      return { responseId: responseIdFromObject(parsed), completed: false, failureReason: `rebase_response_${status}` };
     }
+    const responseId = responseIdFromObject(parsed);
+    return {
+      responseId,
+      completed: typeof responseId === "string" && responseId.length > 0,
+      failureReason: responseId ? undefined : "rebase_response_id_missing",
+    };
+  } catch {
+    return { completed: false, failureReason: "rebase_response_id_missing" };
   }
-  return undefined;
 }
 
 export async function executeCodexRebaseWithFallback(params: {
@@ -57,38 +119,285 @@ export async function executeCodexRebaseWithFallback(params: {
   originalPayload: JsonObject;
   rebasedPayload: JsonObject;
   sendUpstream: CodexUpstreamSender;
+  accounting?: CodexRebaseAccounting;
+  epochStore?: CodexRebaseEpochStoreParams;
+  cooldownStore?: CodexRebaseCooldownStoreParams;
+  capabilityStore?: CodexRebaseCapabilityStoreParams;
 }): Promise<CodexRebaseFallbackResult> {
   let rebaseResponse: CodexUpstreamResponse | undefined;
+  let epoch: CodexRebaseEpoch | undefined;
+  let cooldown: CodexRebaseCooldownNotice | undefined;
+  let capability: CodexRebaseCapabilityNotice | undefined;
   let failureReason = "rebase_upstream_error";
+  const rebaseItemTypes = params.capabilityStore
+    ? codexRebasePayloadItemTypes(params.rebasedPayload)
+    : [];
+
+  async function sendOriginalBypass(
+    notice?: CodexRebaseCapabilityNotice,
+  ): Promise<CodexRebaseFallbackResult> {
+    const response = await params.sendUpstream(cloneJson(params.originalPayload));
+    return {
+      response,
+      outcome: isSuccessfulResponse(response) ? "bypassed" : "failed",
+      capability: notice,
+    };
+  }
+
+  if (params.capabilityStore && rebaseItemTypes.length > 0) {
+    try {
+      const skippedItemTypes = await readUnsupportedCodexRebaseItemTypes({
+        stateDir: params.capabilityStore.stateDir,
+        provider: params.capabilityStore.provider,
+        model: params.capabilityStore.model,
+        itemTypes: rebaseItemTypes,
+      });
+      if (skippedItemTypes.length > 0) {
+        return sendOriginalBypass({
+          provider: params.capabilityStore.provider,
+          model: params.capabilityStore.model,
+          itemTypes: rebaseItemTypes,
+          skippedItemTypes,
+          reason: "capability_unsupported",
+        });
+      }
+    } catch {
+      // Capability cache is advisory; an unreadable cache must not interrupt proxying.
+    }
+  }
+
+  if (params.cooldownStore) {
+    const activeCooldown = await readActiveCodexRebaseCooldown({
+      stateDir: params.cooldownStore.stateDir,
+      sessionId: params.sessionId,
+      planId: params.planId,
+      now: params.cooldownStore.now,
+    });
+    if (activeCooldown) {
+      const response = await params.sendUpstream(cloneJson(params.originalPayload));
+      return {
+        response,
+        outcome: isSuccessfulResponse(response) ? "bypassed" : "failed",
+        cooldown: codexRebaseCooldownNotice(activeCooldown),
+      };
+    }
+  }
+
+  async function recordCooldown(reason: string): Promise<CodexRebaseCooldownNotice> {
+    const startedAt = params.cooldownStore?.now ?? new Date().toISOString();
+    if (!params.cooldownStore) {
+      return { planId: params.planId, startedAt, reason };
+    }
+    return codexRebaseCooldownNotice(await appendCodexRebaseCooldown({
+      stateDir: params.cooldownStore.stateDir,
+      sessionId: params.sessionId,
+      planId: params.planId,
+      reason,
+      cooldownMs: params.cooldownStore.cooldownMs,
+      startedAt,
+    }));
+  }
+
+  async function safeRecordCooldown(reason: string): Promise<CodexRebaseCooldownNotice> {
+    try {
+      return await recordCooldown(reason);
+    } catch {
+      return {
+        planId: params.planId,
+        startedAt: params.cooldownStore?.now ?? new Date().toISOString(),
+        reason,
+      };
+    }
+  }
+
+  async function recordCapabilities(paramsForRecord: {
+    itemTypes: string[];
+    status: "supported" | "unsupported";
+    reason: string;
+    responseStatus?: number;
+  }): Promise<void> {
+    const store = params.capabilityStore;
+    if (!store) return;
+    await Promise.all(paramsForRecord.itemTypes.map((itemType) => appendCodexRebaseCapability({
+      stateDir: store.stateDir,
+      provider: store.provider,
+      model: store.model,
+      itemType,
+      status: paramsForRecord.status,
+      reason: paramsForRecord.reason,
+      responseStatus: paramsForRecord.responseStatus,
+      observedAt: store.now,
+    })));
+  }
+
+  async function safeRecordCapabilities(paramsForRecord: {
+    itemTypes: string[];
+    status: "supported" | "unsupported";
+    reason: string;
+    responseStatus?: number;
+  }): Promise<void> {
+    try {
+      await recordCapabilities(paramsForRecord);
+    } catch {
+      // Capability updates are advisory and must not change request outcome.
+    }
+  }
+
+  async function transitionEpochAfterFallback(paramsForTransition: {
+    fallbackSucceeded: boolean;
+    failureReason: string;
+  }): Promise<CodexRebaseEpoch | undefined> {
+    if (!params.epochStore) return epoch;
+    const fallbackAccounting = params.accounting
+      ? {
+        ...params.accounting,
+        fallbackExtraRequestCount: params.accounting.fallbackExtraRequestCount + 1,
+      }
+      : undefined;
+    try {
+      return paramsForTransition.fallbackSucceeded
+        ? await rollbackCodexRebaseEpoch({
+          stateDir: params.epochStore.stateDir,
+          sessionId: params.sessionId,
+          epochId: params.epochId,
+          failureReason: paramsForTransition.failureReason,
+          accounting: fallbackAccounting,
+        })
+        : await failCodexRebaseEpoch({
+          stateDir: params.epochStore.stateDir,
+          sessionId: params.sessionId,
+          epochId: params.epochId,
+          failureReason: paramsForTransition.failureReason,
+          accounting: fallbackAccounting,
+        });
+    } catch {
+      return epoch;
+    }
+  }
+
+  async function sendOriginalWithFallbackOutcome(reason: string): Promise<CodexRebaseFallbackResult> {
+    let fallbackResponse: CodexUpstreamResponse;
+    try {
+      fallbackResponse = await params.sendUpstream(cloneJson(params.originalPayload));
+    } catch (error) {
+      cooldown = await safeRecordCooldown("fallback_upstream_error");
+      await transitionEpochAfterFallback({
+        fallbackSucceeded: false,
+        failureReason: "fallback_upstream_error",
+      });
+      throw error;
+    }
+    const fallbackSucceeded = isSuccessfulResponse(fallbackResponse);
+    cooldown = await safeRecordCooldown(reason);
+    epoch = await transitionEpochAfterFallback({
+      fallbackSucceeded,
+      failureReason: reason,
+    });
+    return {
+      response: fallbackResponse,
+      outcome: fallbackSucceeded ? "bypassed" : "failed",
+      rebaseResponse,
+      epoch,
+      cooldown,
+      capability,
+    };
+  }
+
+  if (params.epochStore) {
+    try {
+      const activeEpoch = (await readPendingCodexRebaseEpochs({
+        stateDir: params.epochStore.stateDir,
+        sessionId: params.sessionId,
+      })).find((entry) => entry.epochId !== params.epochId);
+      if (activeEpoch) {
+        return sendOriginalBypass();
+      }
+
+      epoch = await appendPendingCodexRebaseEpoch({
+        stateDir: params.epochStore.stateDir,
+        sessionId: params.sessionId,
+        planId: params.planId,
+        epochId: params.epochId,
+        oldPreviousResponseId: params.epochStore.oldPreviousResponseId,
+        oldRevision: params.epochStore.oldRevision,
+        accounting: params.accounting,
+      });
+    } catch {
+      return sendOriginalWithFallbackOutcome("epoch_store_error");
+    }
+  }
   try {
     rebaseResponse = await params.sendUpstream(cloneJson(params.rebasedPayload));
-    const newResponseId = isSuccessfulResponse(rebaseResponse)
-      ? responseIdFromText(rebaseResponse.text)
-      : undefined;
+    const observation = rebaseResponseObservation(rebaseResponse);
+    const newResponseId = observation.completed ? observation.responseId : undefined;
     if (newResponseId) {
+      if (params.epochStore) {
+        try {
+          epoch = await commitCodexRebaseEpoch({
+            stateDir: params.epochStore.stateDir,
+            sessionId: params.sessionId,
+            epochId: params.epochId,
+            newResponseId,
+            newRevision: params.epochStore.newRevision,
+            accounting: params.accounting,
+          });
+        } catch {
+          return sendOriginalWithFallbackOutcome("epoch_store_error");
+        }
+      }
+      if (params.capabilityStore && rebaseItemTypes.length > 0) {
+        await safeRecordCapabilities({
+          itemTypes: rebaseItemTypes,
+          status: "supported",
+          reason: "rebase_committed",
+          responseStatus: rebaseResponse.status,
+        });
+        capability = {
+          provider: params.capabilityStore.provider,
+          model: params.capabilityStore.model,
+          itemTypes: rebaseItemTypes,
+          supportedItemTypes: rebaseItemTypes,
+          reason: "rebase_committed",
+        };
+      }
       return {
         response: rebaseResponse,
         outcome: "committed",
         newResponseId,
         rebaseResponse,
+        epoch,
+        capability,
       };
     }
-    failureReason = isSuccessfulResponse(rebaseResponse)
-      ? "rebase_response_id_missing"
-      : "rebase_upstream_rejected";
+    failureReason = observation.failureReason ?? (
+      isSuccessfulResponse(rebaseResponse)
+        ? "rebase_response_id_missing"
+        : "rebase_upstream_rejected"
+    );
+    if (params.capabilityStore) {
+      const unsupportedItemTypes = unsupportedCodexRebaseItemTypesFromResponse({
+        response: rebaseResponse,
+        itemTypes: rebaseItemTypes,
+      });
+      if (unsupportedItemTypes.length > 0) {
+        await safeRecordCapabilities({
+          itemTypes: unsupportedItemTypes,
+          status: "unsupported",
+          reason: "schema_error",
+          responseStatus: rebaseResponse.status,
+        });
+        capability = {
+          provider: params.capabilityStore.provider,
+          model: params.capabilityStore.model,
+          itemTypes: rebaseItemTypes,
+          unsupportedItemTypes,
+          reason: "schema_error",
+        };
+      }
+    }
   } catch {
     failureReason = "rebase_upstream_error";
   }
 
-  const fallbackResponse = await params.sendUpstream(cloneJson(params.originalPayload));
-  return {
-    response: fallbackResponse,
-    outcome: isSuccessfulResponse(fallbackResponse) ? "bypassed" : "failed",
-    rebaseResponse,
-    cooldown: {
-      planId: params.planId,
-      startedAt: new Date().toISOString(),
-      reason: failureReason,
-    },
-  };
+  return sendOriginalWithFallbackOutcome(failureReason);
 }

--- a/components/adapters/codex/src/context-rewrite/index.ts
+++ b/components/adapters/codex/src/context-rewrite/index.ts
@@ -1,4 +1,34 @@
 export * from "./types.js";
 export { applyCodexContextRewrite } from "./disabled.js";
 export { executeCodexRebaseWithFallback } from "./fallback.js";
-export { buildCodexRebaseRequest, validateCodexRebaseRequest } from "./rebase-request.js";
+export {
+  buildCodexRebaseRequest,
+  validateCodexRebaseRequest,
+  withCodexRebaseReplayAccountingInput,
+} from "./rebase-request.js";
+export {
+  appendCodexRebaseCapability,
+  codexRebaseCapabilityJournalPath,
+  codexRebasePayloadItemTypes,
+  formatCodexRebaseCapabilityStatus,
+  readCodexRebaseCapabilityJournal,
+  readUnsupportedCodexRebaseItemTypes,
+  unsupportedCodexRebaseItemTypesFromResponse,
+} from "./rebase-capability.js";
+export {
+  appendCodexRebaseCooldown,
+  codexRebaseCooldownJournalPath,
+  codexRebaseCooldownNotice,
+  readActiveCodexRebaseCooldown,
+  readCodexRebaseCooldownJournal,
+} from "./rebase-cooldown.js";
+export {
+  appendPendingCodexRebaseEpoch,
+  codexRebaseEpochJournalPath,
+  commitCodexRebaseEpoch,
+  failCodexRebaseEpoch,
+  readCodexRebaseEpochJournal,
+  readLatestCodexRebaseEpoch,
+  readPendingCodexRebaseEpochs,
+  rollbackCodexRebaseEpoch,
+} from "./rebase-epoch.js";

--- a/components/adapters/codex/src/context-rewrite/rebase-capability.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-capability.ts
@@ -1,0 +1,216 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { appendJsonl } from "@lightmem2/host-adapter";
+import {
+  CODEX_REBASE_CAPABILITY_SCHEMA,
+  type CodexRebaseCapability,
+  type CodexRebaseCapabilityStatus,
+  type CodexUpstreamResponse,
+  type JsonObject,
+} from "./types.js";
+
+export type CodexRebaseCapabilityJournalReadResult = {
+  entries: CodexRebaseCapability[];
+  capabilities: CodexRebaseCapability[];
+  malformedLineCount: number;
+  readError?: string;
+};
+
+function cleanDimension(value: string, fallback: string): string {
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+export function codexRebaseCapabilityJournalPath(stateDir: string): string {
+  return join(stateDir, "context-rewrite", "codex", "provider-capabilities.jsonl");
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isStatus(value: unknown): value is CodexRebaseCapabilityStatus {
+  return value === "supported" || value === "unsupported";
+}
+
+function isCodexRebaseCapability(value: unknown): value is CodexRebaseCapability {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return entry.schema === CODEX_REBASE_CAPABILITY_SCHEMA
+    && typeof entry.provider === "string"
+    && typeof entry.model === "string"
+    && typeof entry.itemType === "string"
+    && isStatus(entry.status)
+    && timestampMs(entry.observedAt) !== undefined
+    && (entry.reason === undefined || typeof entry.reason === "string")
+    && (entry.responseStatus === undefined || typeof entry.responseStatus === "number")
+    && (entry.errorCode === undefined || typeof entry.errorCode === "string");
+}
+
+function capabilityKey(entry: Pick<CodexRebaseCapability, "provider" | "model" | "itemType">): string {
+  return `${entry.provider}\u0000${entry.model}\u0000${entry.itemType}`;
+}
+
+function collapseLatestCapabilities(entries: CodexRebaseCapability[]): CodexRebaseCapability[] {
+  const latest = new Map<string, CodexRebaseCapability>();
+  for (const entry of entries) {
+    const key = capabilityKey(entry);
+    latest.delete(key);
+    latest.set(key, entry);
+  }
+  return Array.from(latest.values());
+}
+
+export async function readCodexRebaseCapabilityJournal(
+  stateDir: string,
+): Promise<CodexRebaseCapabilityJournalReadResult> {
+  let raw: string;
+  try {
+    raw = await readFile(codexRebaseCapabilityJournalPath(stateDir), "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return { entries: [], capabilities: [], malformedLineCount: 0 };
+    }
+    return {
+      entries: [],
+      capabilities: [],
+      malformedLineCount: 0,
+      readError: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const entries: CodexRebaseCapability[] = [];
+  let malformedLineCount = 0;
+  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (isCodexRebaseCapability(parsed)) entries.push(parsed);
+      else malformedLineCount += 1;
+    } catch {
+      malformedLineCount += 1;
+    }
+  }
+  return {
+    entries,
+    capabilities: collapseLatestCapabilities(entries),
+    malformedLineCount,
+  };
+}
+
+export async function appendCodexRebaseCapability(params: {
+  stateDir: string;
+  provider: string;
+  model: string;
+  itemType: string;
+  status: CodexRebaseCapabilityStatus;
+  reason?: string;
+  responseStatus?: number;
+  errorCode?: string;
+  observedAt?: string;
+}): Promise<CodexRebaseCapability> {
+  const observedAt = params.observedAt ?? new Date().toISOString();
+  if (timestampMs(observedAt) === undefined) {
+    throw new Error("Codex rebase capability requires a valid observation time");
+  }
+  const entry: CodexRebaseCapability = {
+    schema: CODEX_REBASE_CAPABILITY_SCHEMA,
+    provider: cleanDimension(params.provider, "unknown-provider"),
+    model: cleanDimension(params.model, "unknown-model"),
+    itemType: cleanDimension(params.itemType, "unknown"),
+    status: params.status,
+    reason: params.reason,
+    responseStatus: params.responseStatus,
+    errorCode: params.errorCode,
+    observedAt,
+  };
+  await appendJsonl(codexRebaseCapabilityJournalPath(params.stateDir), entry);
+  return entry;
+}
+
+export async function readUnsupportedCodexRebaseItemTypes(params: {
+  stateDir: string;
+  provider: string;
+  model: string;
+  itemTypes: string[];
+}): Promise<string[]> {
+  const journal = await readCodexRebaseCapabilityJournal(params.stateDir);
+  if (journal.readError) return [];
+  const latest = new Map(journal.capabilities.map((entry) => [capabilityKey(entry), entry]));
+  const provider = cleanDimension(params.provider, "unknown-provider");
+  const model = cleanDimension(params.model, "unknown-model");
+  return Array.from(new Set(params.itemTypes))
+    .filter((itemType) => latest.get(capabilityKey({
+      provider,
+      model,
+      itemType: cleanDimension(itemType, "unknown"),
+    }))?.status === "unsupported");
+}
+
+function asObject(value: unknown): JsonObject | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : undefined;
+}
+
+export function codexRebasePayloadItemTypes(payload: JsonObject): string[] {
+  const input = Array.isArray(payload.input) ? payload.input : [];
+  const itemTypes: string[] = [];
+  for (const item of input) {
+    const entry = asObject(item);
+    if (!entry) continue;
+    if (typeof entry.type === "string" && entry.type.trim()) itemTypes.push(entry.type.trim());
+    else if (typeof entry.role === "string" && entry.role.trim()) itemTypes.push("message");
+    else itemTypes.push("unknown");
+  }
+  return Array.from(new Set(itemTypes));
+}
+
+function collectStrings(value: unknown, output: string[] = []): string[] {
+  if (typeof value === "string") {
+    output.push(value);
+    return output;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, output);
+    return output;
+  }
+  const object = asObject(value);
+  if (!object) return output;
+  for (const item of Object.values(object)) collectStrings(item, output);
+  return output;
+}
+
+function parsedResponseText(text: string): unknown {
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function schemaErrorText(response: CodexUpstreamResponse): string {
+  const parsed = parsedResponseText(response.text);
+  return (parsed === undefined ? [response.text] : collectStrings(parsed)).join(" ").toLowerCase();
+}
+
+export function unsupportedCodexRebaseItemTypesFromResponse(params: {
+  response: CodexUpstreamResponse;
+  itemTypes: string[];
+}): string[] {
+  if (params.response.status !== 400) return [];
+  const text = schemaErrorText(params.response);
+  if (!/(schema|unsupported|not supported|invalid_request_error|unknown item)/i.test(text)) return [];
+  return params.itemTypes.filter((itemType) => text.includes(itemType.toLowerCase()));
+}
+
+export function formatCodexRebaseCapabilityStatus(entry: CodexRebaseCapability): string {
+  return `${entry.provider}/${entry.model} ${entry.itemType} ${entry.status}`;
+}

--- a/components/adapters/codex/src/context-rewrite/rebase-cooldown.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-cooldown.ts
@@ -1,0 +1,155 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { appendJsonl } from "@lightmem2/host-adapter";
+import {
+  CODEX_REBASE_COOLDOWN_SCHEMA,
+  type CodexRebaseCooldown,
+  type CodexRebaseCooldownNotice,
+} from "./types.js";
+
+export type CodexRebaseCooldownJournalReadResult = {
+  entries: CodexRebaseCooldown[];
+  cooldowns: CodexRebaseCooldown[];
+  malformedLineCount: number;
+  readError?: string;
+};
+
+function encodedSessionId(sessionId: string): string {
+  return encodeURIComponent(sessionId.trim() || "unknown-session");
+}
+
+export function codexRebaseCooldownJournalPath(stateDir: string, sessionId: string): string {
+  return join(stateDir, "context-rewrite", "codex", "sessions", encodedSessionId(sessionId), "rebase-cooldowns.jsonl");
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isCodexRebaseCooldown(value: unknown): value is CodexRebaseCooldown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return entry.schema === CODEX_REBASE_COOLDOWN_SCHEMA
+    && typeof entry.sessionId === "string"
+    && typeof entry.planId === "string"
+    && typeof entry.reason === "string"
+    && timestampMs(entry.startedAt) !== undefined
+    && timestampMs(entry.expiresAt) !== undefined;
+}
+
+function collapseLatestCooldowns(entries: CodexRebaseCooldown[]): CodexRebaseCooldown[] {
+  const latest = new Map<string, CodexRebaseCooldown>();
+  for (const entry of entries) {
+    latest.delete(entry.planId);
+    latest.set(entry.planId, entry);
+  }
+  return Array.from(latest.values());
+}
+
+function cooldownNotice(entry: CodexRebaseCooldown): CodexRebaseCooldownNotice {
+  return {
+    planId: entry.planId,
+    startedAt: entry.startedAt,
+    expiresAt: entry.expiresAt,
+    reason: entry.reason,
+  };
+}
+
+function latestCooldownByPlan(
+  cooldowns: CodexRebaseCooldown[],
+  planId: string,
+): CodexRebaseCooldown | undefined {
+  for (let index = cooldowns.length - 1; index >= 0; index -= 1) {
+    const entry = cooldowns[index];
+    if (entry?.planId === planId) return entry;
+  }
+  return undefined;
+}
+
+export async function readCodexRebaseCooldownJournal(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexRebaseCooldownJournalReadResult> {
+  let raw: string;
+  try {
+    raw = await readFile(codexRebaseCooldownJournalPath(stateDir, sessionId), "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return { entries: [], cooldowns: [], malformedLineCount: 0 };
+    }
+    return {
+      entries: [],
+      cooldowns: [],
+      malformedLineCount: 0,
+      readError: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const entries: CodexRebaseCooldown[] = [];
+  let malformedLineCount = 0;
+  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (isCodexRebaseCooldown(parsed) && parsed.sessionId === sessionId) entries.push(parsed);
+      else malformedLineCount += 1;
+    } catch {
+      malformedLineCount += 1;
+    }
+  }
+  return {
+    entries,
+    cooldowns: collapseLatestCooldowns(entries),
+    malformedLineCount,
+  };
+}
+
+export async function appendCodexRebaseCooldown(params: {
+  stateDir: string;
+  sessionId: string;
+  planId: string;
+  reason: string;
+  cooldownMs: number;
+  startedAt?: string;
+}): Promise<CodexRebaseCooldown> {
+  const startedAt = params.startedAt ?? new Date().toISOString();
+  const startedAtMs = timestampMs(startedAt);
+  if (startedAtMs === undefined) throw new Error("Codex rebase cooldown requires a valid start time");
+  const durationMs = Number.isFinite(params.cooldownMs) ? Math.max(0, params.cooldownMs) : 0;
+  const entry: CodexRebaseCooldown = {
+    schema: CODEX_REBASE_COOLDOWN_SCHEMA,
+    sessionId: params.sessionId,
+    planId: params.planId,
+    reason: params.reason,
+    startedAt,
+    expiresAt: new Date(startedAtMs + durationMs).toISOString(),
+  };
+  await appendJsonl(codexRebaseCooldownJournalPath(params.stateDir, params.sessionId), entry);
+  return entry;
+}
+
+export async function readActiveCodexRebaseCooldown(params: {
+  stateDir: string;
+  sessionId: string;
+  planId: string;
+  now?: string;
+}): Promise<CodexRebaseCooldown | undefined> {
+  const journal = await readCodexRebaseCooldownJournal(params.stateDir, params.sessionId);
+  const cooldown = latestCooldownByPlan(journal.cooldowns, params.planId);
+  if (!cooldown) return undefined;
+  const nowMs = timestampMs(params.now ?? new Date().toISOString());
+  const expiresAtMs = timestampMs(cooldown.expiresAt);
+  if (nowMs === undefined || expiresAtMs === undefined || nowMs >= expiresAtMs) return undefined;
+  return cooldown;
+}
+
+export function codexRebaseCooldownNotice(entry: CodexRebaseCooldown): CodexRebaseCooldownNotice {
+  return cooldownNotice(entry);
+}

--- a/components/adapters/codex/src/context-rewrite/rebase-epoch.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-epoch.ts
@@ -1,0 +1,280 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { appendJsonl } from "@lightmem2/host-adapter";
+import {
+  CODEX_REBASE_EPOCH_SCHEMA,
+  type CodexRebaseEpoch,
+  type CodexRebaseAccounting,
+  type CodexRebaseEpochStatus,
+} from "./types.js";
+
+export type CodexRebaseEpochJournalReadResult = {
+  entries: CodexRebaseEpoch[];
+  epochs: CodexRebaseEpoch[];
+  malformedLineCount: number;
+  readError?: string;
+};
+
+function encodedSessionId(sessionId: string): string {
+  return encodeURIComponent(sessionId.trim() || "unknown-session");
+}
+
+export function codexRebaseEpochJournalPath(stateDir: string, sessionId: string): string {
+  return join(stateDir, "context-rewrite", "codex", "sessions", encodedSessionId(sessionId), "rebase-epochs.jsonl");
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function isStatus(value: unknown): value is CodexRebaseEpochStatus {
+  return value === "pending" || value === "committed" || value === "failed" || value === "rolled_back";
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isCodexRebaseAccounting(value: unknown): value is CodexRebaseAccounting {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return isNonNegativeNumber(entry.plannedSavedChars)
+    && isNonNegativeNumber(entry.plannedSavedTokens)
+    && isNonNegativeNumber(entry.actuallyRemovedChars)
+    && isNonNegativeNumber(entry.actuallyRemovedTokens)
+    && isNonNegativeNumber(entry.rebaseReplayCostChars)
+    && isNonNegativeNumber(entry.rebaseReplayCostTokens)
+    && isNonNegativeNumber(entry.subsequentSavedCharsPerTurn)
+    && isNonNegativeNumber(entry.subsequentSavedTokensPerTurn)
+    && isNonNegativeNumber(entry.estimatorCostChars)
+    && isNonNegativeNumber(entry.estimatorCostTokens)
+    && isNonNegativeNumber(entry.fallbackExtraRequestCount)
+    && isNonNegativeNumber(entry.cacheColdMissCount)
+    && (entry.breakEvenTurn === undefined || isNonNegativeNumber(entry.breakEvenTurn));
+}
+
+function isCodexRebaseEpoch(value: unknown): value is CodexRebaseEpoch {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const entry = value as Record<string, unknown>;
+  return entry.schema === CODEX_REBASE_EPOCH_SCHEMA
+    && typeof entry.epochId === "string"
+    && typeof entry.sessionId === "string"
+    && typeof entry.planId === "string"
+    && typeof entry.oldPreviousResponseId === "string"
+    && typeof entry.oldRevision === "string"
+    && isStatus(entry.status)
+    && timestampMs(entry.createdAt) !== undefined
+    && timestampMs(entry.updatedAt) !== undefined
+    && (entry.newResponseId === undefined || typeof entry.newResponseId === "string")
+    && (entry.newRevision === undefined || typeof entry.newRevision === "string")
+    && (entry.failureReason === undefined || typeof entry.failureReason === "string")
+    && (entry.accounting === undefined || isCodexRebaseAccounting(entry.accounting));
+}
+
+function collapseLatestEpochs(entries: CodexRebaseEpoch[]): CodexRebaseEpoch[] {
+  const latest = new Map<string, CodexRebaseEpoch>();
+  for (const entry of entries) {
+    latest.delete(entry.epochId);
+    latest.set(entry.epochId, entry);
+  }
+  return Array.from(latest.values());
+}
+
+function latestEpochById(entries: CodexRebaseEpoch[], epochId: string): CodexRebaseEpoch | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry?.epochId === epochId) return entry;
+  }
+  return undefined;
+}
+
+function latestEpoch(epochs: CodexRebaseEpoch[]): CodexRebaseEpoch | undefined {
+  return epochs.at(-1);
+}
+
+function throwIfReadFailed(journal: CodexRebaseEpochJournalReadResult): void {
+  if (journal.readError) throw new Error(`Unable to read Codex rebase epoch journal: ${journal.readError}`);
+}
+
+export async function readCodexRebaseEpochJournal(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexRebaseEpochJournalReadResult> {
+  let raw: string;
+  try {
+    raw = await readFile(codexRebaseEpochJournalPath(stateDir, sessionId), "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return { entries: [], epochs: [], malformedLineCount: 0 };
+    }
+    return {
+      entries: [],
+      epochs: [],
+      malformedLineCount: 0,
+      readError: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const entries: CodexRebaseEpoch[] = [];
+  let malformedLineCount = 0;
+  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (isCodexRebaseEpoch(parsed) && parsed.sessionId === sessionId) entries.push(parsed);
+      else malformedLineCount += 1;
+    } catch {
+      malformedLineCount += 1;
+    }
+  }
+  return {
+    entries,
+    epochs: collapseLatestEpochs(entries),
+    malformedLineCount,
+  };
+}
+
+export async function appendPendingCodexRebaseEpoch(params: {
+  stateDir: string;
+  sessionId: string;
+  planId: string;
+  oldPreviousResponseId: string;
+  oldRevision: string;
+  epochId?: string;
+  accounting?: CodexRebaseAccounting;
+  createdAt?: string;
+}): Promise<CodexRebaseEpoch> {
+  const epochId = params.epochId ?? `epoch-${randomUUID()}`;
+  const current = await readCodexRebaseEpochJournal(params.stateDir, params.sessionId);
+  throwIfReadFailed(current);
+  const existing = latestEpochById(current.entries, epochId);
+  if (existing) {
+    if (existing.status !== "pending") throw new Error(`Codex rebase epoch already terminal: ${epochId}`);
+    if (
+      existing.sessionId !== params.sessionId
+    || existing.planId !== params.planId
+      || existing.oldPreviousResponseId !== params.oldPreviousResponseId
+      || existing.oldRevision !== params.oldRevision
+    ) {
+      throw new Error(`Codex rebase epoch mismatch: ${epochId}`);
+    }
+    return existing;
+  }
+
+  const createdAt = params.createdAt ?? new Date().toISOString();
+  if (timestampMs(createdAt) === undefined) throw new Error("Codex rebase epoch requires a valid create time");
+  const entry: CodexRebaseEpoch = {
+    schema: CODEX_REBASE_EPOCH_SCHEMA,
+    epochId,
+    sessionId: params.sessionId,
+    planId: params.planId,
+    oldPreviousResponseId: params.oldPreviousResponseId,
+    oldRevision: params.oldRevision,
+    status: "pending",
+    accounting: params.accounting,
+    createdAt,
+    updatedAt: createdAt,
+  };
+  await appendJsonl(codexRebaseEpochJournalPath(params.stateDir, params.sessionId), entry);
+  return entry;
+}
+
+async function transitionCodexRebaseEpoch(params: {
+  stateDir: string;
+  sessionId: string;
+  epochId: string;
+  status: Exclude<CodexRebaseEpochStatus, "pending">;
+  newResponseId?: string;
+  newRevision?: string;
+  failureReason?: string;
+  accounting?: CodexRebaseAccounting;
+  updatedAt?: string;
+}): Promise<CodexRebaseEpoch> {
+  const current = await readCodexRebaseEpochJournal(params.stateDir, params.sessionId);
+  throwIfReadFailed(current);
+  const existing = latestEpochById(current.entries, params.epochId);
+  if (!existing) throw new Error(`Unknown Codex rebase epoch: ${params.epochId}`);
+  if (existing.status !== "pending") return existing;
+  const updatedAt = params.updatedAt ?? new Date().toISOString();
+  if (timestampMs(updatedAt) === undefined) throw new Error("Codex rebase epoch requires a valid update time");
+
+  const entry: CodexRebaseEpoch = {
+    ...existing,
+    status: params.status,
+    newResponseId: params.newResponseId,
+    newRevision: params.newRevision,
+    failureReason: params.failureReason,
+    accounting: params.accounting ?? existing.accounting,
+    updatedAt,
+  };
+  await appendJsonl(codexRebaseEpochJournalPath(params.stateDir, params.sessionId), entry);
+  return entry;
+}
+
+export async function commitCodexRebaseEpoch(params: {
+  stateDir: string;
+  sessionId: string;
+  epochId: string;
+  newResponseId: string;
+  newRevision?: string;
+  accounting?: CodexRebaseAccounting;
+  updatedAt?: string;
+}): Promise<CodexRebaseEpoch> {
+  if (!params.newResponseId) throw new Error("Codex rebase epoch commit requires a response id");
+  return transitionCodexRebaseEpoch({
+    ...params,
+    status: "committed",
+  });
+}
+
+export async function failCodexRebaseEpoch(params: {
+  stateDir: string;
+  sessionId: string;
+  epochId: string;
+  failureReason: string;
+  accounting?: CodexRebaseAccounting;
+  updatedAt?: string;
+}): Promise<CodexRebaseEpoch> {
+  return transitionCodexRebaseEpoch({
+    ...params,
+    status: "failed",
+  });
+}
+
+export async function rollbackCodexRebaseEpoch(params: {
+  stateDir: string;
+  sessionId: string;
+  epochId: string;
+  failureReason: string;
+  accounting?: CodexRebaseAccounting;
+  updatedAt?: string;
+}): Promise<CodexRebaseEpoch> {
+  return transitionCodexRebaseEpoch({
+    ...params,
+    status: "rolled_back",
+  });
+}
+
+export async function readPendingCodexRebaseEpochs(params: {
+  stateDir: string;
+  sessionId: string;
+}): Promise<CodexRebaseEpoch[]> {
+  const journal = await readCodexRebaseEpochJournal(params.stateDir, params.sessionId);
+  return journal.epochs.filter((entry) => entry.status === "pending");
+}
+
+export async function readLatestCodexRebaseEpoch(params: {
+  stateDir: string;
+  sessionId: string;
+}): Promise<CodexRebaseEpoch | undefined> {
+  const journal = await readCodexRebaseEpochJournal(params.stateDir, params.sessionId);
+  return latestEpoch(journal.epochs);
+}

--- a/components/adapters/codex/src/context-rewrite/rebase-request.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-request.ts
@@ -2,6 +2,7 @@ import { cloneJson, stableInputKey } from "./shared.js";
 import type {
   CodexEffectiveHistory,
   CodexMutationPlan,
+  CodexRebaseAccounting,
   CodexRebaseRequestResult,
   CodexRebaseValidation,
   JsonObject,
@@ -90,6 +91,71 @@ function stripServerOwnedResponsesFields(item: JsonObject): JsonObject {
   return next;
 }
 
+function jsonChars(value: unknown): number {
+  const text = JSON.stringify(value);
+  return typeof text === "string" ? text.length : 0;
+}
+
+function estimatedTokens(chars: number): number {
+  return chars > 0 ? Math.ceil(chars / 4) : 0;
+}
+
+function sumItemChars(items: JsonObject[]): number {
+  return items.reduce((total, item) => total + jsonChars(item), 0);
+}
+
+function buildRebaseAccounting(params: {
+  effectiveHistory: CodexEffectiveHistory;
+  evictedStableItemIds: Set<string>;
+  payload: JsonObject;
+}): CodexRebaseAccounting {
+  const plannedItems = [
+    ...params.effectiveHistory.replayableItems,
+    ...params.effectiveHistory.observationOnlyItems,
+  ].filter((entry) => params.evictedStableItemIds.has(entry.stableItemId));
+  const removedItems = params.effectiveHistory.replayableItems
+    .filter((entry) => params.evictedStableItemIds.has(entry.stableItemId));
+  const plannedSavedChars = sumItemChars(plannedItems.map((entry) => entry.item));
+  const actuallyRemovedChars = sumItemChars(removedItems.map((entry) => entry.item));
+  const rebaseReplayCostChars = jsonChars(params.payload.input);
+  const estimatorCostChars = 0;
+  const totalOneTimeCost = rebaseReplayCostChars + estimatorCostChars;
+  return {
+    plannedSavedChars,
+    plannedSavedTokens: estimatedTokens(plannedSavedChars),
+    actuallyRemovedChars,
+    actuallyRemovedTokens: estimatedTokens(actuallyRemovedChars),
+    rebaseReplayCostChars,
+    rebaseReplayCostTokens: estimatedTokens(rebaseReplayCostChars),
+    subsequentSavedCharsPerTurn: actuallyRemovedChars,
+    subsequentSavedTokensPerTurn: estimatedTokens(actuallyRemovedChars),
+    estimatorCostChars,
+    estimatorCostTokens: estimatedTokens(estimatorCostChars),
+    fallbackExtraRequestCount: 0,
+    cacheColdMissCount: 1,
+    breakEvenTurn: actuallyRemovedChars > 0
+      ? Math.ceil(totalOneTimeCost / actuallyRemovedChars)
+      : undefined,
+  };
+}
+
+export function withCodexRebaseReplayAccountingInput(
+  accounting: CodexRebaseAccounting,
+  input: unknown,
+): CodexRebaseAccounting {
+  const rebaseReplayCostChars = jsonChars(input);
+  const estimatorCostChars = accounting.estimatorCostChars;
+  const totalOneTimeCost = rebaseReplayCostChars + estimatorCostChars;
+  return {
+    ...accounting,
+    rebaseReplayCostChars,
+    rebaseReplayCostTokens: estimatedTokens(rebaseReplayCostChars),
+    breakEvenTurn: accounting.subsequentSavedCharsPerTurn > 0
+      ? Math.ceil(totalOneTimeCost / accounting.subsequentSavedCharsPerTurn)
+      : undefined,
+  };
+}
+
 export function buildCodexRebaseRequest(params: {
   sessionId: string;
   planId: string;
@@ -125,5 +191,10 @@ export function buildCodexRebaseRequest(params: {
     payload,
     oldRevision: params.effectiveHistory.revision,
     rebaseRevision: `${params.effectiveHistory.revision}:${params.planId}:rebase`,
+    accounting: buildRebaseAccounting({
+      effectiveHistory: params.effectiveHistory,
+      evictedStableItemIds: evicted,
+      payload,
+    }),
   };
 }

--- a/components/adapters/codex/src/context-rewrite/types.ts
+++ b/components/adapters/codex/src/context-rewrite/types.ts
@@ -19,6 +19,7 @@ export type CodexContextRewriteConfig = {
 };
 
 export type CodexMutationPlan = {
+  baseRevision?: string;
   operations: Array<{
     type: string;
     stableItemId?: string;
@@ -35,6 +36,43 @@ export type CodexRebaseRequestResult = {
   payload: JsonObject;
   oldRevision: string;
   rebaseRevision: string;
+  accounting: CodexRebaseAccounting;
+};
+
+export const CODEX_REBASE_EPOCH_SCHEMA = "lightmem2.codex.rebase-epoch/v1";
+
+export type CodexRebaseEpochStatus = "pending" | "committed" | "failed" | "rolled_back";
+
+export type CodexRebaseAccounting = {
+  plannedSavedChars: number;
+  plannedSavedTokens: number;
+  actuallyRemovedChars: number;
+  actuallyRemovedTokens: number;
+  rebaseReplayCostChars: number;
+  rebaseReplayCostTokens: number;
+  subsequentSavedCharsPerTurn: number;
+  subsequentSavedTokensPerTurn: number;
+  estimatorCostChars: number;
+  estimatorCostTokens: number;
+  fallbackExtraRequestCount: number;
+  cacheColdMissCount: number;
+  breakEvenTurn?: number;
+};
+
+export type CodexRebaseEpoch = {
+  schema: typeof CODEX_REBASE_EPOCH_SCHEMA;
+  epochId: string;
+  sessionId: string;
+  planId: string;
+  oldPreviousResponseId: string;
+  newResponseId?: string;
+  oldRevision: string;
+  newRevision?: string;
+  status: CodexRebaseEpochStatus;
+  failureReason?: string;
+  accounting?: CodexRebaseAccounting;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type CodexUpstreamResponse = {
@@ -48,11 +86,73 @@ export type CodexRebaseFallbackResult = {
   outcome: "committed" | "bypassed" | "failed";
   newResponseId?: string;
   rebaseResponse?: CodexUpstreamResponse;
-  cooldown?: {
-    planId: string;
-    startedAt: string;
-    reason: string;
-  };
+  epoch?: CodexRebaseEpoch;
+  cooldown?: CodexRebaseCooldownNotice;
+  capability?: CodexRebaseCapabilityNotice;
+};
+
+export type CodexRebaseEpochStoreParams = {
+  stateDir: string;
+  oldPreviousResponseId: string;
+  oldRevision: string;
+  newRevision?: string;
+};
+
+export const CODEX_REBASE_COOLDOWN_SCHEMA = "lightmem2.codex.rebase-cooldown/v1";
+
+export type CodexRebaseCooldown = {
+  schema: typeof CODEX_REBASE_COOLDOWN_SCHEMA;
+  sessionId: string;
+  planId: string;
+  reason: string;
+  startedAt: string;
+  expiresAt: string;
+};
+
+export type CodexRebaseCooldownNotice = {
+  planId: string;
+  startedAt: string;
+  expiresAt?: string;
+  reason: string;
+};
+
+export type CodexRebaseCooldownStoreParams = {
+  stateDir: string;
+  cooldownMs: number;
+  now?: string;
+};
+
+export const CODEX_REBASE_CAPABILITY_SCHEMA = "lightmem2.codex.rebase-capability/v1";
+
+export type CodexRebaseCapabilityStatus = "supported" | "unsupported";
+
+export type CodexRebaseCapability = {
+  schema: typeof CODEX_REBASE_CAPABILITY_SCHEMA;
+  provider: string;
+  model: string;
+  itemType: string;
+  status: CodexRebaseCapabilityStatus;
+  reason?: string;
+  responseStatus?: number;
+  errorCode?: string;
+  observedAt: string;
+};
+
+export type CodexRebaseCapabilityNotice = {
+  provider: string;
+  model: string;
+  itemTypes: string[];
+  skippedItemTypes?: string[];
+  supportedItemTypes?: string[];
+  unsupportedItemTypes?: string[];
+  reason?: string;
+};
+
+export type CodexRebaseCapabilityStoreParams = {
+  stateDir: string;
+  provider: string;
+  model: string;
+  now?: string;
 };
 
 export type CodexContextRewriteResult = {

--- a/components/adapters/codex/src/doctor.ts
+++ b/components/adapters/codex/src/doctor.ts
@@ -15,6 +15,10 @@ import {
   readCodexProviderFromToml,
   readCodexRootModelProvider,
 } from "./config.js";
+import {
+  formatCodexRebaseCapabilityStatus,
+  readCodexRebaseCapabilityJournal,
+} from "./context-rewrite/rebase-capability.js";
 import { readDaemonStatus } from "./daemon.js";
 import { resolveCodexHookCommandForInstall, resolveCodexMcpServerSpecForInstall } from "./install.js";
 
@@ -50,6 +54,7 @@ export type CodexDoctorReport = {
   coreRuntimeHealthy: boolean;
   recoveryMcpHealthy: boolean;
   degradedMode: boolean;
+  rebaseCapabilityStatus?: string[];
 };
 
 const HOOK_EVENT_NAMES = [
@@ -79,6 +84,7 @@ async function checkHealth(baseUrl: string): Promise<boolean> {
 }
 
 export function formatCodexDoctorReport(report: CodexDoctorReport): string {
+  const rebaseCapabilityStatus = report.rebaseCapabilityStatus ?? [];
   const lines = [
     "TokenPilot Codex doctor:",
     `- tokenpilot config: ${report.tokenPilotConfigPath}`,
@@ -112,6 +118,7 @@ export function formatCodexDoctorReport(report: CodexDoctorReport): string {
     `- upstream provider: ${report.upstreamProvider ?? "(unset)"}`,
     `- upstream base URL: ${report.upstreamBaseUrl ?? "(unset)"}`,
     `- upstream loops into local proxy: ${report.upstreamLoopDetected ? "yes" : "no"}`,
+    `- CDR-05 rebase capability cache: ${rebaseCapabilityStatus.length > 0 ? rebaseCapabilityStatus.join(", ") : "(none)"}`,
   ];
   const fixes: string[] = [];
   if (!report.adapterEnabled) {
@@ -204,6 +211,10 @@ export async function inspectCodexDoctor(params: {
     expectedStateDir: params.config.stateDir,
     expectedStartupTimeoutSec: DEFAULT_TOKENPILOT_MCP_STARTUP_TIMEOUT_SEC,
   });
+  const capabilityJournal = await readCodexRebaseCapabilityJournal(params.config.stateDir);
+  const rebaseCapabilityStatus = capabilityJournal.capabilities
+    .map(formatCodexRebaseCapabilityStatus)
+    .sort();
   const coreRuntimeHealthy = params.config.enabled
     && Boolean(tokenpilotProvider)
     && providerIntercepted
@@ -242,5 +253,6 @@ export async function inspectCodexDoctor(params: {
     coreRuntimeHealthy,
     recoveryMcpHealthy,
     degradedMode: coreRuntimeHealthy && !recoveryMcpHealthy,
+    rebaseCapabilityStatus,
   };
 }

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { mkdir } from "node:fs/promises";
 import {
@@ -8,6 +9,8 @@ import {
 import {
   countTextWithPreciseTokens,
   createStaticStatePathResolver,
+  type HostRequestEnvelope,
+  prepareBeforeCallWithReductionSummary,
   recordUxEffect,
   sendJsonResponse,
   startHostGatewayRuntimeServer,
@@ -53,6 +56,26 @@ import { snapshotCodexResponsesStream } from "./stream-observer.js";
 import { appendTrace } from "./trace.js";
 import { appendCodexCacheAuditRecord, buildCodexCacheAuditSnapshot } from "./cache-audit.js";
 import { initializeCodexTokenPilotPreset } from "./preset.js";
+import {
+  appendCodexRequestJournalEntry,
+  appendCodexResponseJournalEntry,
+  buildCodexEffectiveHistory,
+  collectCodexResponseItemsFromStream,
+} from "./context-history/index.js";
+import type {
+  CodexJournalStatus,
+  CodexRequestJournalEntry,
+  JsonObject,
+} from "./context-history/types.js";
+import {
+  buildCodexRebaseRequest,
+  executeCodexRebaseWithFallback,
+  withCodexRebaseReplayAccountingInput,
+} from "./context-rewrite/index.js";
+import type {
+  CodexMutationPlan,
+  CodexRebaseRequestResult,
+} from "./context-rewrite/types.js";
 
 export type CodexProxyRuntime = {
   baseUrl: string;
@@ -103,6 +126,99 @@ function normalizeResponsesInputForUpstream(input: any): void {
   }
 }
 
+function asJsonObject(value: unknown): JsonObject | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : undefined;
+}
+
+function parseJsonObject(text: string): JsonObject | undefined {
+  try {
+    return asJsonObject(JSON.parse(text) as unknown);
+  } catch {
+    return undefined;
+  }
+}
+
+function cloneJsonObject(value: JsonObject): JsonObject {
+  return JSON.parse(JSON.stringify(value)) as JsonObject;
+}
+
+function hashJson(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex").slice(0, 24);
+}
+
+function codexMutationPlanId(plan: CodexMutationPlan): string {
+  return `plan-${hashJson({
+    baseRevision: plan.baseRevision ?? null,
+    operations: plan.operations,
+  })}`;
+}
+
+function encodedRequestPayload(params: {
+  codec: ReturnType<typeof createCodexResponsesPayloadCodec>;
+  envelope: HostRequestEnvelope;
+  fallback: JsonObject;
+}): JsonObject {
+  const encoded = asJsonObject(params.codec.encodeRequest(params.envelope));
+  return encoded ? cloneJsonObject(encoded) : cloneJsonObject(params.fallback);
+}
+
+function responsePayloadStatus(response: JsonObject | undefined): CodexJournalStatus | undefined {
+  const status = typeof response?.status === "string" ? response.status.toLowerCase() : undefined;
+  if (!status) return undefined;
+  if (status === "completed") return "completed";
+  if (status === "failed" || status === "cancelled") return "failed";
+  return "incomplete";
+}
+
+function nonStreamRequestStatus(params: {
+  httpStatus: number;
+  response: JsonObject | undefined;
+}): CodexJournalStatus {
+  if (params.httpStatus < 200 || params.httpStatus >= 300) return "failed";
+  return responsePayloadStatus(params.response) ?? "completed";
+}
+
+function streamRequestStatus(params: {
+  httpStatus: number;
+  collected: ReturnType<typeof collectCodexResponseItemsFromStream>;
+}): CodexJournalStatus {
+  if (params.httpStatus < 200 || params.httpStatus >= 300) return "failed";
+  if (params.collected.status === "failed") return "failed";
+  const sawCompleted = (params.collected.eventTypeCounts["response.completed"] ?? 0) > 0;
+  if (params.collected.status !== "completed" || !sawCompleted) return "incomplete";
+  return "completed";
+}
+
+function truncateJournalError(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > 1000 ? `${trimmed.slice(0, 1000)}...` : trimmed;
+}
+
+function activeMutationPlan(config: TokenPilotCodexConfig): CodexMutationPlan | undefined {
+  const plan = config.contextRewrite.mutationPlan;
+  return plan && plan.operations.length > 0 ? plan : undefined;
+}
+
+function canAttemptCodexRebase(params: {
+  config: TokenPilotCodexConfig;
+  payload: JsonObject;
+  requestEntry?: CodexRequestJournalEntry;
+}): boolean {
+  return Boolean(
+    params.config.contextRewrite.enabled
+    && params.config.contextRewrite.mode === "response_chain_rebase"
+    && params.config.contextRewrite.failureMode === "bypass"
+    && params.config.contextRewrite.retryOriginalRequest
+    && params.requestEntry
+    && activeMutationPlan(params.config)
+    && typeof params.payload.previous_response_id === "string"
+    && params.payload.previous_response_id,
+  );
+}
+
 export async function startCodexResponsesProxy(params: {
   config: TokenPilotCodexConfig;
   logger: TokenPilotCodexLogger;
@@ -132,14 +248,13 @@ export async function startCodexResponsesProxy(params: {
       stateDir: config.stateDir,
     },
     async handleRequest({ req, res, body }) {
-      const payload = JSON.parse(body);
-      normalizeResponsesInputForUpstream(payload?.input);
-      const originalRequestText = extractResponsesInputText(payload?.input);
+      const inboundPayload = JSON.parse(body) as JsonObject;
+      normalizeResponsesInputForUpstream(inboundPayload?.input);
       const inboundPromptCacheKey =
-        typeof payload?.prompt_cache_key === "string" ? payload.prompt_cache_key.trim() : "";
+        typeof inboundPayload?.prompt_cache_key === "string" ? inboundPayload.prompt_cache_key.trim() : "";
       const mappedPreviousSessionId =
-        typeof payload?.previous_response_id === "string"
-          ? await resolveCodexSessionIdByResponseId(config.stateDir, payload.previous_response_id)
+        typeof inboundPayload?.previous_response_id === "string"
+          ? await resolveCodexSessionIdByResponseId(config.stateDir, inboundPayload.previous_response_id)
           : undefined;
       const mappedPromptCacheSessionId =
         !mappedPreviousSessionId && inboundPromptCacheKey
@@ -150,14 +265,13 @@ export async function startCodexResponsesProxy(params: {
           mappedPreviousSessionId: mappedPreviousSessionId ?? mappedPromptCacheSessionId,
         }),
       );
-      let envelope = codec.decodeRequest(payload);
+      let envelope = codec.decodeRequest(inboundPayload);
       const inboundModel = envelope.model;
       const model = inboundModel.startsWith("tokenpilot/")
         ? inboundModel.slice("tokenpilot/".length)
         : inboundModel;
       if (model !== inboundModel) {
         envelope = { ...envelope, model };
-        syncPayloadFromEnvelope(payload, envelope, codec);
       }
       const sessionId = envelope.session.sessionId;
       if (inboundPromptCacheKey) {
@@ -170,20 +284,86 @@ export async function startCodexResponsesProxy(params: {
         }
         await indexCodexPromptCacheKeySession(config.stateDir, inboundPromptCacheKey, sessionId);
       }
-      const prepared = await prepareObservedBeforeCall<CodexReductionSummary>({
+      const originalPayload = encodedRequestPayload({
+        codec,
         envelope,
+        fallback: inboundPayload,
+      });
+      normalizeResponsesInputForUpstream(originalPayload?.input);
+      const originalRequestText = extractResponsesInputText(originalPayload?.input);
+
+      let requestJournalEntry: CodexRequestJournalEntry | undefined;
+      try {
+        requestJournalEntry = await appendCodexRequestJournalEntry({
+          stateDir: config.stateDir,
+          sessionId,
+          payload: originalPayload,
+          status: "pending",
+        });
+      } catch (err) {
+        await appendTrace(config.stateDir, {
+          stage: "context_history_request_journal_failed",
+          sessionId,
+          model,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+
+      let rebaseRequest: CodexRebaseRequestResult | undefined;
+      let rebasePlanId: string | undefined;
+      let rebaseAccounting = rebaseRequest?.accounting;
+      const mutationPlan = activeMutationPlan(config);
+      if (canAttemptCodexRebase({ config, payload: originalPayload, requestEntry: requestJournalEntry })
+        && mutationPlan
+        && requestJournalEntry) {
+        const planId = codexMutationPlanId(mutationPlan);
+        try {
+          const effectiveHistory = await buildCodexEffectiveHistory({
+            stateDir: config.stateDir,
+            sessionId,
+            headResponseId: String(originalPayload.previous_response_id),
+            currentRequestId: requestJournalEntry.requestId,
+          });
+          rebaseRequest = buildCodexRebaseRequest({
+            sessionId,
+            planId,
+            baseRevision: mutationPlan.baseRevision ?? effectiveHistory.revision,
+            originalPayload,
+            effectiveHistory,
+            currentInput: originalPayload.input,
+            mutationPlan,
+          });
+          rebasePlanId = planId;
+        } catch (err) {
+          await appendTrace(config.stateDir, {
+            stage: "context_rewrite_rebase_deferred",
+            sessionId,
+            model,
+            reason: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      const payload = cloneJsonObject(rebaseRequest?.payload ?? originalPayload);
+      normalizeResponsesInputForUpstream(payload?.input);
+      const preparedEnvelope = rebaseRequest ? codec.decodeRequest(payload) : envelope;
+      const prepareStablePrefixForCodex = (nextEnvelope: HostRequestEnvelope) => (
+        prepareCodexStablePrefix(canonicalizeEnvelopeTools(nextEnvelope), config)
+      );
+      const applyBeforeCallReductionForCodex = async (args: {
+        envelope: HostRequestEnvelope;
+        codec: any;
+      }) => reduceCodexRequestEnvelope({
+        envelope: args.envelope,
+        codec: args.codec,
+        config,
+      });
+      const prepared = await prepareObservedBeforeCall<CodexReductionSummary>({
+        envelope: preparedEnvelope,
         codec,
         config: { mode: "normal" },
-        prepareStablePrefix(nextEnvelope) {
-          return prepareCodexStablePrefix(canonicalizeEnvelopeTools(nextEnvelope), config);
-        },
-        async applyBeforeCallReduction({ envelope: nextEnvelope, codec: nextCodec }) {
-          return reduceCodexRequestEnvelope({
-            envelope: nextEnvelope,
-            codec: nextCodec,
-            config,
-          });
-        },
+        prepareStablePrefix: prepareStablePrefixForCodex,
+        applyBeforeCallReduction: applyBeforeCallReductionForCodex,
         observability: {
           stateDir: config.stateDir,
           sessionId,
@@ -227,6 +407,21 @@ export async function startCodexResponsesProxy(params: {
       const reductionSummary = prepared.reductionSummary;
       syncPayloadFromEnvelope(payload, prepared.envelope, codec);
       normalizeResponsesInputForUpstream(payload?.input);
+      if (rebaseRequest) {
+        rebaseAccounting = withCodexRebaseReplayAccountingInput(rebaseRequest.accounting, payload.input);
+      }
+      const fallbackPayload = cloneJsonObject(originalPayload);
+      if (rebaseRequest) {
+        const fallbackPrepared = await prepareBeforeCallWithReductionSummary<CodexReductionSummary>({
+          envelope,
+          codec,
+          config: { mode: "normal" },
+          prepareStablePrefix: prepareStablePrefixForCodex,
+          applyBeforeCallReduction: applyBeforeCallReductionForCodex,
+        });
+        syncPayloadFromEnvelope(fallbackPayload, fallbackPrepared.envelope, codec);
+        normalizeResponsesInputForUpstream(fallbackPayload?.input);
+      }
       const requestText = extractResponsesInputText(payload?.input);
       const cacheAuditSnapshot = buildCodexCacheAuditSnapshot({
         envelope: prepared.envelope,
@@ -244,7 +439,6 @@ export async function startCodexResponsesProxy(params: {
               ? prepared.envelope.metadata.promptCacheKey
             : null,
       });
-
       await appendTrace(config.stateDir, {
         stage: "proxy_before_call",
         sessionId,
@@ -259,10 +453,152 @@ export async function startCodexResponsesProxy(params: {
         reductionSkippedReason: reductionSummary?.skippedReason ?? null,
         reductionPassEffects: reductionSummary?.passEffects ?? [],
         promptCacheKey: prepared.envelope.metadata?.promptCacheKey ?? null,
+        contextRewriteEnabled: config.contextRewrite.enabled,
+        contextRewritePlanned: Boolean(rebaseRequest),
       });
 
       const authorization = typeof req.headers.authorization === "string" ? req.headers.authorization : undefined;
+      const sendUpstream = (nextPayload: JsonObject) => requestUpstreamResponses({
+        upstream,
+        payload: nextPayload,
+        inboundAuthorization: authorization,
+        stateDir: config.stateDir,
+      });
+      let contextRewriteOutcome: string | undefined;
+      const sendRebasedOrCurrentPayload = () => rebaseRequest && requestJournalEntry && rebasePlanId
+        ? executeCodexRebaseWithFallback({
+          sessionId,
+          planId: rebasePlanId,
+          epochId: `epoch-${requestJournalEntry.requestId}`,
+          originalPayload: fallbackPayload,
+          rebasedPayload: payload,
+          sendUpstream,
+          accounting: rebaseAccounting,
+          epochStore: {
+            stateDir: config.stateDir,
+            oldPreviousResponseId: String(originalPayload.previous_response_id),
+            oldRevision: rebaseRequest.oldRevision,
+            newRevision: rebaseRequest.rebaseRevision,
+          },
+          cooldownStore: {
+            stateDir: config.stateDir,
+            cooldownMs: config.contextRewrite.cooldownMs,
+          },
+          capabilityStore: {
+            stateDir: config.stateDir,
+            provider: upstream.name ?? config.upstreamProvider ?? "OpenAI",
+            model,
+          },
+        }).then((result) => {
+          contextRewriteOutcome = result.outcome;
+          return result.response;
+        })
+        : sendUpstream(payload);
+      const recordStreamResponse = async (paramsForRecord: {
+        status: number;
+        rawStreamText: string;
+      }): Promise<void> => {
+        const snapshot = snapshotCodexResponsesStream(paramsForRecord.rawStreamText);
+        const collected = collectCodexResponseItemsFromStream(paramsForRecord.rawStreamText);
+        const requestStatus = streamRequestStatus({
+          httpStatus: paramsForRecord.status,
+          collected,
+        });
+        await recordCodexUxReduction({
+          stateDir: config.stateDir,
+          sessionId,
+          model,
+          originalRequestText,
+          reducedRequestText: requestText,
+        });
+        await appendCodexCacheAuditRecord({
+          stateDir: config.stateDir,
+          snapshot: cacheAuditSnapshot,
+          responsePromptCacheKey: snapshot.responsePromptCacheKey ?? null,
+          usage: snapshot.usage ?? null,
+          status: paramsForRecord.status,
+        });
+        if (requestJournalEntry) {
+          const error = requestStatus === "failed" ? truncateJournalError(paramsForRecord.rawStreamText) : undefined;
+          try {
+            await appendCodexResponseJournalEntry({
+              stateDir: config.stateDir,
+              sessionId,
+              requestId: requestJournalEntry.requestId,
+              rawStreamText: paramsForRecord.rawStreamText,
+              previousResponseId: contextRewriteOutcome === "committed" ? null : undefined,
+              status: requestStatus,
+              error,
+            });
+            await appendCodexRequestJournalEntry({
+              stateDir: config.stateDir,
+              sessionId,
+              requestId: requestJournalEntry.requestId,
+              payload,
+              committedInputItems: contextRewriteOutcome === "committed" && Array.isArray(payload.input)
+                ? payload.input as JsonObject[]
+                : undefined,
+              status: requestStatus,
+              error,
+            });
+          } catch (err) {
+            await appendTrace(config.stateDir, {
+              stage: "context_history_response_journal_failed",
+              sessionId,
+              model,
+              stream: true,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+        await appendTrace(config.stateDir, {
+          stage: "proxy_after_call",
+          sessionId,
+          model,
+          status: paramsForRecord.status,
+          stream: true,
+          completed: requestStatus === "completed",
+          streamStatus: collected.status,
+          malformedEventCount: collected.malformedEventCount,
+          responseChars: paramsForRecord.rawStreamText.length,
+          assistantChars: snapshot.assistantText.length,
+          responseId: snapshot.responseId ?? null,
+          previousResponseId: snapshot.previousResponseId ?? null,
+          contextRewriteOutcome: contextRewriteOutcome ?? null,
+        });
+        await upsertCodexSessionSnapshot(config.stateDir, sessionId, {
+          latestResponseId: snapshot.responseId,
+          previousResponseId: snapshot.previousResponseId,
+          latestModel: model,
+          disclosedReadPaths: reductionSummary?.disclosedReadPaths,
+        });
+        if (typeof snapshot.responseId === "string" && snapshot.responseId) {
+          await indexCodexResponseSession(config.stateDir, snapshot.responseId, sessionId);
+        }
+        await appendCodexRecentTurnBinding(config.stateDir, {
+          sessionId,
+          responseId: snapshot.responseId,
+          previousResponseId: snapshot.previousResponseId,
+          model,
+          requestChars: requestText.length,
+          responseChars: paramsForRecord.rawStreamText.length,
+          assistantChars: snapshot.assistantText.length,
+          stream: true,
+          updatedAt: new Date().toISOString(),
+        });
+      };
       if (payload.stream === true) {
+        if (rebaseRequest && requestJournalEntry) {
+          const upstreamResp = await sendRebasedOrCurrentPayload();
+          res.statusCode = upstreamResp.status;
+          setForwardResponseHeaders(res, upstreamResp.headers, "text/event-stream; charset=utf-8");
+          await recordStreamResponse({
+            status: upstreamResp.status,
+            rawStreamText: upstreamResp.text,
+          });
+          res.end(upstreamResp.text);
+          return;
+        }
         const upstreamResp = await requestUpstreamResponsesStream({
           upstream,
           payload,
@@ -279,53 +615,10 @@ export async function startCodexResponsesProxy(params: {
         });
         upstreamResp.stream.once("end", async () => {
           const rawStreamText = Buffer.concat(streamChunks).toString("utf8");
-          const snapshot = snapshotCodexResponsesStream(rawStreamText);
           try {
-            await recordCodexUxReduction({
-              stateDir: config.stateDir,
-              sessionId,
-              model,
-              originalRequestText,
-              reducedRequestText: requestText,
-            });
-            await appendCodexCacheAuditRecord({
-              stateDir: config.stateDir,
-              snapshot: cacheAuditSnapshot,
-              responsePromptCacheKey: snapshot.responsePromptCacheKey ?? null,
-              usage: snapshot.usage ?? null,
+            await recordStreamResponse({
               status: upstreamResp.status,
-            });
-            await appendTrace(config.stateDir, {
-              stage: "proxy_after_call",
-              sessionId,
-              model,
-              status: upstreamResp.status,
-              stream: true,
-              completed: true,
-              responseChars: rawStreamText.length,
-              assistantChars: snapshot.assistantText.length,
-              responseId: snapshot.responseId ?? null,
-              previousResponseId: snapshot.previousResponseId ?? null,
-            });
-            await upsertCodexSessionSnapshot(config.stateDir, sessionId, {
-              latestResponseId: snapshot.responseId,
-              previousResponseId: snapshot.previousResponseId,
-              latestModel: model,
-              disclosedReadPaths: reductionSummary?.disclosedReadPaths,
-            });
-            if (typeof snapshot.responseId === "string" && snapshot.responseId) {
-              await indexCodexResponseSession(config.stateDir, snapshot.responseId, sessionId);
-            }
-            await appendCodexRecentTurnBinding(config.stateDir, {
-              sessionId,
-              responseId: snapshot.responseId,
-              previousResponseId: snapshot.previousResponseId,
-              model,
-              requestChars: requestText.length,
-              responseChars: rawStreamText.length,
-              assistantChars: snapshot.assistantText.length,
-              stream: true,
-              updatedAt: new Date().toISOString(),
+              rawStreamText,
             });
             res.end();
           } catch (err) {
@@ -360,18 +653,14 @@ export async function startCodexResponsesProxy(params: {
         return;
       }
 
-      const upstreamResp = await requestUpstreamResponses({
-        upstream,
-        payload,
-        inboundAuthorization: authorization,
-        stateDir: config.stateDir,
-      });
+      const upstreamResp = await sendRebasedOrCurrentPayload();
+      const responseJson = parseJsonObject(upstreamResp.text);
       let responseId: string | undefined;
       let previousResponseId: string | undefined;
       let assistantChars = 0;
       let toolCallCount = 0;
       try {
-        const decoded = codec.decodeResponse(JSON.parse(upstreamResp.text), prepared.envelope);
+        const decoded = codec.decodeResponse(responseJson ?? JSON.parse(upstreamResp.text), prepared.envelope);
         responseId = typeof decoded.metadata?.responseId === "string" ? decoded.metadata.responseId : undefined;
         previousResponseId = typeof decoded.metadata?.previousResponseId === "string" ? decoded.metadata.previousResponseId : undefined;
         assistantChars = decoded.assistantText?.length ?? 0;
@@ -388,6 +677,43 @@ export async function startCodexResponsesProxy(params: {
         });
       } catch {
         // Some upstream error payloads may not match the expected Responses shape.
+      }
+      if (requestJournalEntry) {
+        const status = nonStreamRequestStatus({
+          httpStatus: upstreamResp.status,
+          response: responseJson,
+        });
+        const error = status === "failed" ? truncateJournalError(upstreamResp.text) : undefined;
+        try {
+          await appendCodexResponseJournalEntry({
+            stateDir: config.stateDir,
+            sessionId,
+            requestId: requestJournalEntry.requestId,
+            response: responseJson,
+            previousResponseId: contextRewriteOutcome === "committed" ? null : undefined,
+            status,
+            error,
+          });
+          await appendCodexRequestJournalEntry({
+            stateDir: config.stateDir,
+            sessionId,
+            requestId: requestJournalEntry.requestId,
+            payload,
+            committedInputItems: contextRewriteOutcome === "committed" && Array.isArray(payload.input)
+              ? payload.input as JsonObject[]
+              : undefined,
+            status,
+            error,
+          });
+        } catch (err) {
+          await appendTrace(config.stateDir, {
+            stage: "context_history_response_journal_failed",
+            sessionId,
+            model,
+            stream: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
       await recordCodexUxReduction({
         stateDir: config.stateDir,
@@ -426,6 +752,7 @@ export async function startCodexResponsesProxy(params: {
         assistantChars,
         responseId: responseId ?? null,
         previousResponseId: previousResponseId ?? null,
+        contextRewriteOutcome: contextRewriteOutcome ?? null,
       });
       res.statusCode = upstreamResp.status;
       setForwardResponseHeaders(res, upstreamResp.headers, "application/json; charset=utf-8");

--- a/components/adapters/codex/src/session-report.ts
+++ b/components/adapters/codex/src/session-report.ts
@@ -9,6 +9,17 @@ import {
 } from "@lightmem2/product-surface";
 import { readRecentCodexCacheAuditRecordsForSession, summarizeCodexCacheAudit } from "./cache-audit.js";
 import {
+  formatCodexRebaseCapabilityStatus,
+  readCodexRebaseCapabilityJournal,
+  readCodexRebaseCooldownJournal,
+  readCodexRebaseEpochJournal,
+} from "./context-rewrite/index.js";
+import type {
+  CodexRebaseCooldown,
+  CodexRebaseEpoch,
+  CodexRebaseEpochStatus,
+} from "./context-rewrite/types.js";
+import {
   loadCodexRecentTurnBindings,
   loadCodexSessionSnapshot,
   resolveCanonicalCodexSessionId,
@@ -28,6 +39,129 @@ export type CodexSessionTopology = {
   updatedAt?: string;
   turnCount: number;
 };
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function activeCooldowns(cooldowns: CodexRebaseCooldown[]): CodexRebaseCooldown[] {
+  const now = Date.now();
+  return cooldowns.filter((entry) => {
+    const expiresAtMs = timestampMs(entry.expiresAt);
+    return expiresAtMs !== undefined && expiresAtMs > now;
+  });
+}
+
+function countEpochs(epochs: CodexRebaseEpoch[]): Record<CodexRebaseEpochStatus, number> {
+  return {
+    pending: epochs.filter((entry) => entry.status === "pending").length,
+    committed: epochs.filter((entry) => entry.status === "committed").length,
+    failed: epochs.filter((entry) => entry.status === "failed").length,
+    rolled_back: epochs.filter((entry) => entry.status === "rolled_back").length,
+  };
+}
+
+function latestEpoch(epochs: CodexRebaseEpoch[]): CodexRebaseEpoch | undefined {
+  return epochs.at(-1);
+}
+
+function latestCooldown(cooldowns: CodexRebaseCooldown[]): CodexRebaseCooldown | undefined {
+  return cooldowns.at(-1);
+}
+
+function formatCharsAndTokens(chars: number, tokens: number): string {
+  return `${chars} chars (~${tokens} tokens)`;
+}
+
+function formatCodexRebaseAccounting(epoch: CodexRebaseEpoch): string | undefined {
+  const accounting = epoch.accounting;
+  if (!accounting) return undefined;
+  return "- CDR-02 rebase accounting: "
+    + `planned_saved=${formatCharsAndTokens(accounting.plannedSavedChars, accounting.plannedSavedTokens)}, `
+    + `removed=${formatCharsAndTokens(accounting.actuallyRemovedChars, accounting.actuallyRemovedTokens)}, `
+    + `replay_cost=${formatCharsAndTokens(accounting.rebaseReplayCostChars, accounting.rebaseReplayCostTokens)}, `
+    + `subsequent_saved=${accounting.subsequentSavedCharsPerTurn} chars/turn `
+    + `(~${accounting.subsequentSavedTokensPerTurn} tokens/turn), `
+    + `estimator_cost=${formatCharsAndTokens(accounting.estimatorCostChars, accounting.estimatorCostTokens)}, `
+    + `fallback_extra_requests=${accounting.fallbackExtraRequestCount} `
+    + `cache_cold_misses=${accounting.cacheColdMissCount} `
+    + `break_even_turn=${accounting.breakEvenTurn ?? "never"}`;
+}
+
+async function buildCodexRebaseReportLines(
+  stateDir: string,
+  sessionId: string,
+): Promise<string[]> {
+  const [epochJournal, cooldownJournal, capabilityJournal] = await Promise.all([
+    readCodexRebaseEpochJournal(stateDir, sessionId),
+    readCodexRebaseCooldownJournal(stateDir, sessionId),
+    readCodexRebaseCapabilityJournal(stateDir),
+  ]);
+  const readErrors = [
+    epochJournal.readError ? `epoch=${epochJournal.readError}` : "",
+    cooldownJournal.readError ? `cooldown=${cooldownJournal.readError}` : "",
+    capabilityJournal.readError ? `capability=${capabilityJournal.readError}` : "",
+  ].filter(Boolean);
+  const epochs = epochJournal.epochs;
+  const cooldowns = cooldownJournal.cooldowns;
+  const capabilities = capabilityJournal.capabilities;
+  if (
+    epochs.length === 0
+    && cooldowns.length === 0
+    && capabilities.length === 0
+    && readErrors.length === 0
+  ) {
+    return [];
+  }
+
+  const counts = countEpochs(epochs);
+  const latest = latestEpoch(epochs);
+  const currentCooldowns = activeCooldowns(cooldowns);
+  const cooldown = latestCooldown(cooldowns);
+  const capabilityStatus = capabilities
+    .map(formatCodexRebaseCapabilityStatus)
+    .sort();
+  const malformedRows =
+    epochJournal.malformedLineCount
+    + cooldownJournal.malformedLineCount
+    + capabilityJournal.malformedLineCount;
+  const lines = [
+    "- CDR-03 rebase epochs: "
+      + `committed=${counts.committed}, `
+      + `rolled_back=${counts.rolled_back}, `
+      + `failed=${counts.failed}, `
+      + `pending=${counts.pending}`,
+  ];
+  if (latest) {
+    lines.push(
+      "- CDR-03 latest rebase epoch: "
+        + `${latest.status} ${latest.epochId} `
+        + `old=${latest.oldPreviousResponseId}`
+        + (latest.newResponseId ? ` new=${latest.newResponseId}` : ""),
+    );
+    const accountingLine = formatCodexRebaseAccounting(latest);
+    if (accountingLine) lines.push(accountingLine);
+  }
+  if (cooldowns.length > 0) {
+    lines.push(
+      "- CDR-04 rebase cooldowns: "
+        + `active=${currentCooldowns.length}/${cooldowns.length}`
+        + (cooldown ? ` latest=${cooldown.reason} expires=${cooldown.expiresAt}` : ""),
+    );
+  }
+  if (capabilityStatus.length > 0) {
+    lines.push(`- CDR-05 rebase capability cache: ${capabilityStatus.join(", ")}`);
+  }
+  if (malformedRows > 0) {
+    lines.push(`- rebase journal malformed rows: ${malformedRows}`);
+  }
+  if (readErrors.length > 0) {
+    lines.push(`- rebase journal read errors: ${readErrors.join(", ")}`);
+  }
+  return lines;
+}
 
 export async function resolveCodexSessionTopology(
   stateDir: string,
@@ -76,8 +210,9 @@ export async function renderCodexSessionReport(stateDir: string, sessionRef?: st
   const cacheAuditSummary = cacheAuditRecords.length > 0
     ? summarizeCodexCacheAudit(cacheAuditRecords)
     : null;
+  const rebaseReportLines = await buildCodexRebaseReportLines(stateDir, topology.sessionId);
 
-  return renderSessionReport({
+  const baseReport = await renderSessionReport({
     stateDir,
     title: "TokenPilot Codex report:",
     sessionId: topology.sessionId,
@@ -89,4 +224,7 @@ export async function renderCodexSessionReport(stateDir: string, sessionRef?: st
       readAggregate: readUxSessionAggregate,
     },
   });
+  return rebaseReportLines.length > 0
+    ? `${baseReport}\n${rebaseReportLines.join("\n")}`
+    : baseReport;
 }

--- a/components/adapters/codex/tests/config.test.ts
+++ b/components/adapters/codex/tests/config.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { join } from "node:path";
 import test from "node:test";
 import { normalizeTokenPilotCodexConfig } from "../src/config.js";
 
@@ -8,14 +9,19 @@ test("normalizeTokenPilotCodexConfig applies stable defaults", () => {
   assert.equal(config.logLevel, "info");
   assert.equal(config.proxyPort, 17667);
   assert.equal(config.upstreamProvider, "OpenAI");
-  assert.match(config.stateDir, /\.codex\/tokenpilot-state\/tokenpilot$/);
+  assert.match(config.stateDir.replace(/\\/g, "/"), /\.codex\/tokenpilot-state\/tokenpilot$/);
+  assert.equal(config.contextRewrite.enabled, false);
+  assert.equal(config.contextRewrite.mode, "response_chain_rebase");
+  assert.equal(config.contextRewrite.failureMode, "bypass");
+  assert.equal(config.contextRewrite.retryOriginalRequest, true);
+  assert.equal(config.contextRewrite.cooldownMs, 300_000);
 });
 
 test("normalizeTokenPilotCodexConfig derives default stateDir from the tokenpilot config path", () => {
   const config = normalizeTokenPilotCodexConfig({}, {
     configPath: "/tmp/custom-codex-root/tokenpilot.json",
   });
-  assert.equal(config.stateDir, "/tmp/custom-codex-root/tokenpilot-state/tokenpilot");
+  assert.equal(config.stateDir, join("/tmp/custom-codex-root", "tokenpilot-state", "tokenpilot"));
 });
 
 test("normalizeTokenPilotCodexConfig trims and clamps values", () => {
@@ -27,4 +33,20 @@ test("normalizeTokenPilotCodexConfig trims and clamps values", () => {
   assert.equal(config.logLevel, "debug");
   assert.equal(config.proxyPort, 65535);
   assert.equal(config.upstreamProvider, "OPENAI");
+});
+
+test("normalizeTokenPilotCodexConfig preserves context rewrite plan revisions", () => {
+  const config = normalizeTokenPilotCodexConfig({
+    contextRewrite: {
+      mutationPlan: {
+        baseRevision: "rev-base",
+        operations: [{ type: "evict", stableItemId: "item-1" }],
+      },
+    },
+  });
+
+  assert.equal(config.contextRewrite.mutationPlan?.baseRevision, "rev-base");
+  assert.deepEqual(config.contextRewrite.mutationPlan?.operations, [
+    { type: "evict", stableItemId: "item-1" },
+  ]);
 });

--- a/components/adapters/codex/tests/context-history-effective-history.test.ts
+++ b/components/adapters/codex/tests/context-history-effective-history.test.ts
@@ -297,6 +297,72 @@ test("CDH-04 Effective History Builder delegates to rollout parser bootstrap whe
   });
 });
 
+test("CDH-04 Effective History Builder merges rollout bootstrap with post-baseline proxy journal", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-rollout-merge",
+      requestId: "request-after-rollout",
+      payload: {
+        previous_response_id: "resp-rollout-baseline",
+        input: [{ role: "user", content: "proxy journal after rollout baseline" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-rollout-merge",
+      requestId: "request-after-rollout",
+      response: {
+        id: "resp-proxy-head",
+        previous_response_id: "resp-rollout-baseline",
+        output: [
+          {
+            id: "msg-after-rollout",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "proxy journal answer" }],
+          },
+        ],
+      },
+      status: "completed",
+    });
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: "codex-session-rollout-merge",
+      headResponseId: "resp-proxy-head",
+      async rolloutParserBootstrap() {
+        return {
+          revision: "rollout-rev-merge",
+          replayableItems: [
+            {
+              stableItemId: "rollout-baseline-user",
+              nativeId: "rollout-baseline-user",
+              item: { role: "user", content: "rollout compacted baseline" },
+            },
+          ],
+          observationOnlyItems: [],
+          deferredItems: [],
+          unresolvedCallIds: [],
+          source: "rollout_bootstrap",
+          incomplete: false,
+        };
+      },
+    });
+
+    assert.equal(history.source, "rollout_proxy_merge");
+    assert.equal(history.incomplete, false);
+    assert.deepEqual(
+      history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
+      ["user", "user", "message"],
+    );
+    assert.match(JSON.stringify(history.replayableItems), /rollout compacted baseline/);
+    assert.match(JSON.stringify(history.replayableItems), /proxy journal after rollout baseline/);
+    assert.match(JSON.stringify(history.replayableItems), /proxy journal answer/);
+  });
+});
+
 test("CDH-04 Effective History Builder marks malformed SSE journals incomplete without dropping valid items", async () => {
   await withTempState(async (stateDir) => {
     await appendCodexRequestJournalEntry({

--- a/components/adapters/codex/tests/context-history-journal.test.ts
+++ b/components/adapters/codex/tests/context-history-journal.test.ts
@@ -205,6 +205,50 @@ test("CDH-02 response journal stores full non-stream output items and native ref
   });
 });
 
+test("CDH-02 response journal respects failed non-stream response bodies", async () => {
+  await withTempState(async (stateDir) => {
+    const entry = await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: {
+        id: "resp-body-failed",
+        status: "failed",
+        output: [
+          { id: "msg-1", type: "message", role: "assistant", content: [{ type: "output_text", text: "partial" }] },
+        ],
+      },
+      status: "completed",
+    });
+
+    assert.equal(entry.status, "failed");
+    assert.equal(entry.responseId, "resp-body-failed");
+    assert.match(JSON.stringify(entry.outputItems), /partial/);
+  });
+});
+
+test("CDH-02 response journal respects incomplete non-stream response bodies", async () => {
+  await withTempState(async (stateDir) => {
+    const entry = await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      response: {
+        id: "resp-body-incomplete",
+        status: "incomplete",
+        output: [
+          { id: "msg-1", type: "message", role: "assistant", content: [{ type: "output_text", text: "partial" }] },
+        ],
+      },
+      status: "completed",
+    });
+
+    assert.equal(entry.status, "incomplete");
+    assert.equal(entry.responseId, "resp-body-incomplete");
+    assert.match(JSON.stringify(entry.outputItems), /partial/);
+  });
+});
+
 test("CDH-02 response journal stores stream output items and stream metadata", async () => {
   await withTempState(async (stateDir) => {
     const completeStream = [
@@ -287,5 +331,28 @@ test("CDH-02 response journal marks malformed completed streams incomplete", asy
     assert.equal(entry.responseId, "resp-malformed-completed");
     assert.equal(entry.malformedEventCount, 1);
     assert.match(JSON.stringify(entry.outputItems), /kept/);
+  });
+});
+
+test("CDH-02 response journal keeps interrupted 2xx streams incomplete", async () => {
+  await withTempState(async (stateDir) => {
+    const entry = await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: "codex-session-1",
+      requestId: "request-1",
+      rawStreamText: [
+        "event: response.created",
+        "data: {\"response\":{\"id\":\"resp-interrupted-2xx\"}}",
+        "",
+        "event: response.output_item.done",
+        "data: {\"output_index\":0,\"item\":{\"id\":\"msg-1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"partial\"}]}}",
+        "",
+      ].join("\n"),
+      status: "completed",
+    });
+
+    assert.equal(entry.status, "incomplete");
+    assert.equal(entry.responseId, "resp-interrupted-2xx");
+    assert.match(JSON.stringify(entry.outputItems), /partial/);
   });
 });

--- a/components/adapters/codex/tests/context-history-sse-item-collector.test.ts
+++ b/components/adapters/codex/tests/context-history-sse-item-collector.test.ts
@@ -223,6 +223,128 @@ test("CDH-03 SSE Item Collector aggregates reasoning and custom tool delta event
   assert.equal(customCall.input, "payload");
 });
 
+test("CDH-03 SSE Item Collector handles a mixed upstream stream fixture", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.created", {
+      type: "response.created",
+      response: { id: "resp-realistic-stream", previous_response_id: "resp-prev-realistic" },
+    }),
+    sseBlock("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { id: "msg-realistic", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.content_part.added", {
+      type: "response.content_part.added",
+      item_id: "msg-realistic",
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "" },
+    }),
+    sseBlock("response.output_text.delta", {
+      type: "response.output_text.delta",
+      item_id: "msg-realistic",
+      output_index: 0,
+      content_index: 0,
+      delta: "I'll check ",
+    }),
+    sseBlock("response.output_text.delta", {
+      type: "response.output_text.delta",
+      item_id: "msg-realistic",
+      output_index: 0,
+      content_index: 0,
+      delta: "the state.",
+    }),
+    sseBlock("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { id: "reason-realistic", type: "reasoning", encrypted_content: "encrypted-1", summary: [] },
+    }),
+    sseBlock("response.reasoning_summary_part.added", {
+      type: "response.reasoning_summary_part.added",
+      item_id: "reason-realistic",
+      output_index: 1,
+      summary_index: 0,
+      part: { type: "summary_text", text: "" },
+    }),
+    sseBlock("response.reasoning_summary_text.delta", {
+      type: "response.reasoning_summary_text.delta",
+      item_id: "reason-realistic",
+      output_index: 1,
+      summary_index: 0,
+      delta: "Need a safe rebase.",
+    }),
+    sseBlock("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 2,
+      item: {
+        id: "function-realistic",
+        type: "function_call",
+        call_id: "call-realistic",
+        name: "read_file",
+        arguments: "",
+      },
+    }),
+    sseBlock("response.function_call_arguments.delta", {
+      type: "response.function_call_arguments.delta",
+      item_id: "function-realistic",
+      output_index: 2,
+      delta: "{\"path\":\"context.ts\"",
+    }),
+    sseBlock("response.function_call_arguments.done", {
+      type: "response.function_call_arguments.done",
+      item_id: "function-realistic",
+      output_index: 2,
+      arguments: "{\"path\":\"context.ts\"}",
+    }),
+    sseBlock("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 3,
+      item: {
+        id: "custom-realistic",
+        type: "custom_tool_call",
+        call_id: "custom-realistic",
+        name: "patch",
+        input: "",
+      },
+    }),
+    sseBlock("response.custom_tool_call_input.delta", {
+      type: "response.custom_tool_call_input.delta",
+      item_id: "custom-realistic",
+      output_index: 3,
+      delta: "diff --git",
+    }),
+    sseBlock("response.custom_tool_call_input.done", {
+      type: "response.custom_tool_call_input.done",
+      item_id: "custom-realistic",
+      output_index: 3,
+      input: "diff --git",
+    }),
+    sseBlock("response.completed", {
+      type: "response.completed",
+      response: { id: "resp-realistic-stream", previous_response_id: "resp-prev-realistic" },
+    }),
+    sseBlock(undefined, "[DONE]"),
+  ));
+
+  const message = asObject(result.outputItems[0]);
+  const reasoning = asObject(result.outputItems[1]);
+  const functionCall = asObject(result.outputItems[2]);
+  const customCall = asObject(result.outputItems[3]);
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.responseId, "resp-realistic-stream");
+  assert.equal(result.previousResponseId, "resp-prev-realistic");
+  assert.equal(result.outputItems.length, 4);
+  assert.equal(outputText(message), "I'll check the state.");
+  assert.equal(asObject(reasoning.summary[0]).text, "Need a safe rebase.");
+  assert.equal(reasoning.encrypted_content, "encrypted-1");
+  assert.equal(functionCall.arguments, "{\"path\":\"context.ts\"}");
+  assert.equal(customCall.input, "diff --git");
+  assert.equal(result.malformedEventCount, 0);
+  assert.equal(result.eventTypeCounts["response.output_item.added"], 4);
+});
+
 test("CDH-03 SSE Item Collector preserves accumulated fields across empty item updates", () => {
   const result = collectCodexResponseItemsFromStream(sseStream(
     sseBlock("response.output_item.added", {
@@ -246,6 +368,109 @@ test("CDH-03 SSE Item Collector preserves accumulated fields across empty item u
   ));
 
   assert.equal(outputText(asObject(result.outputItems[0])), "partial");
+});
+
+test("CDH-03 SSE Item Collector preserves accumulated deltas across empty done events", () => {
+  const result = collectCodexResponseItemsFromStream(sseStream(
+    sseBlock("response.output_item.added", {
+      output_index: 0,
+      item: { id: "msg-1", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.output_text.delta", {
+      item_id: "msg-1",
+      output_index: 0,
+      delta: "partial",
+    }),
+    sseBlock("response.output_text.done", {
+      item_id: "msg-1",
+      output_index: 0,
+      text: "",
+    }),
+    sseBlock("response.output_item.added", {
+      output_index: 1,
+      item: {
+        id: "fc-1",
+        type: "function_call",
+        call_id: "call-1",
+        name: "read",
+        arguments: "",
+      },
+    }),
+    sseBlock("response.function_call_arguments.delta", {
+      item_id: "fc-1",
+      output_index: 1,
+      delta: "{\"path\":\"a\"}",
+    }),
+    sseBlock("response.function_call_arguments.done", {
+      item_id: "fc-1",
+      output_index: 1,
+      arguments: "",
+    }),
+    sseBlock("response.output_item.added", {
+      output_index: 2,
+      item: {
+        id: "cc-1",
+        type: "custom_tool_call",
+        call_id: "custom-1",
+        name: "patch",
+        input: "",
+      },
+    }),
+    sseBlock("response.custom_tool_call_input.delta", {
+      item_id: "cc-1",
+      output_index: 2,
+      delta: "diff",
+    }),
+    sseBlock("response.custom_tool_call_input.done", {
+      item_id: "cc-1",
+      output_index: 2,
+      input: "",
+    }),
+    sseBlock("response.output_item.added", {
+      output_index: 3,
+      item: { id: "msg-2", type: "message", role: "assistant", content: [] },
+    }),
+    sseBlock("response.output_text.delta", {
+      item_id: "msg-2",
+      output_index: 3,
+      content_index: 0,
+      delta: "content-part",
+    }),
+    sseBlock("response.content_part.done", {
+      item_id: "msg-2",
+      output_index: 3,
+      content_index: 0,
+      part: { type: "output_text", text: "" },
+    }),
+    sseBlock("response.output_item.added", {
+      output_index: 4,
+      item: { id: "rs-1", type: "reasoning", summary: [] },
+    }),
+    sseBlock("response.reasoning_summary_text.delta", {
+      item_id: "rs-1",
+      output_index: 4,
+      summary_index: 0,
+      delta: "summary",
+    }),
+    sseBlock("response.reasoning_summary_text.done", {
+      item_id: "rs-1",
+      output_index: 4,
+      summary_index: 0,
+      text: "",
+    }),
+    sseBlock("response.reasoning_summary_part.done", {
+      item_id: "rs-1",
+      output_index: 4,
+      summary_index: 0,
+      part: { type: "summary_text", text: "" },
+    }),
+  ));
+
+  assert.equal(outputText(asObject(result.outputItems[0])), "partial");
+  assert.equal(asObject(result.outputItems[1]).arguments, "{\"path\":\"a\"}");
+  assert.equal(asObject(result.outputItems[2]).input, "diff");
+  assert.equal(outputText(asObject(result.outputItems[3])), "content-part");
+  assert.equal(asObject(asObject(result.outputItems[4]).summary[0]).text, "summary");
 });
 
 test("CDH-03 SSE Item Collector preserves encrypted reasoning across empty item updates", () => {

--- a/components/adapters/codex/tests/context-rebase-behavior.test.ts
+++ b/components/adapters/codex/tests/context-rebase-behavior.test.ts
@@ -5,6 +5,7 @@ import {
   applyCodexContextRewrite,
   buildCodexRebaseRequest,
   executeCodexRebaseWithFallback,
+  withCodexRebaseReplayAccountingInput,
   type CodexEffectiveHistory,
   type JsonObject,
 } from "../src/context-rewrite/index.js";
@@ -50,6 +51,14 @@ function textFromResponsesInput(input: unknown): string {
 
 function occurrences(text: string, needle: string): number {
   return text.split(needle).length - 1;
+}
+
+function jsonChars(value: unknown): number {
+  return JSON.stringify(value).length;
+}
+
+function estimatedTokens(chars: number): number {
+  return Math.ceil(chars / 4);
 }
 
 function baseResponsesPayload(): ResponsesPayload {
@@ -166,6 +175,67 @@ test("CDR-01 rejects stale revisions before constructing a rebase request", () =
     currentInput: originalPayload.input,
     mutationPlan: { operations: [] },
   }), /revision_mismatch/);
+});
+
+test("CDR-02 builds rebase accounting for replay cost and break-even", () => {
+  const originalPayload = baseResponsesPayload();
+  const history = effectiveHistoryFixture();
+  const result = buildCodexRebaseRequest({
+    sessionId: "codex-session-1",
+    planId: "plan-accounting",
+    baseRevision: history.revision,
+    originalPayload,
+    effectiveHistory: history,
+    currentInput: originalPayload.input,
+    mutationPlan: {
+      operations: [{ type: "evict", stableItemId: "evicted-user-1" }],
+    },
+  });
+  const evictedItem = history.replayableItems.find((entry) => entry.stableItemId === "evicted-user-1");
+  assert.ok(evictedItem);
+  const evictedChars = jsonChars(evictedItem.item);
+  const rebaseReplayChars = jsonChars(result.payload.input);
+
+  assert.equal(result.accounting.plannedSavedChars, evictedChars);
+  assert.equal(result.accounting.plannedSavedTokens, estimatedTokens(evictedChars));
+  assert.equal(result.accounting.actuallyRemovedChars, evictedChars);
+  assert.equal(result.accounting.actuallyRemovedTokens, estimatedTokens(evictedChars));
+  assert.equal(result.accounting.rebaseReplayCostChars, rebaseReplayChars);
+  assert.equal(result.accounting.rebaseReplayCostTokens, estimatedTokens(rebaseReplayChars));
+  assert.equal(result.accounting.subsequentSavedCharsPerTurn, evictedChars);
+  assert.equal(result.accounting.subsequentSavedTokensPerTurn, estimatedTokens(evictedChars));
+  assert.equal(result.accounting.estimatorCostChars, 0);
+  assert.equal(result.accounting.estimatorCostTokens, 0);
+  assert.equal(result.accounting.fallbackExtraRequestCount, 0);
+  assert.equal(result.accounting.cacheColdMissCount, 1);
+  assert.equal(result.accounting.breakEvenTurn, Math.ceil(rebaseReplayChars / evictedChars));
+});
+
+test("CDR-02 refreshes replay accounting after downstream input changes", () => {
+  const originalPayload = baseResponsesPayload();
+  const history = effectiveHistoryFixture();
+  const result = buildCodexRebaseRequest({
+    sessionId: "codex-session-1",
+    planId: "plan-accounting-refresh",
+    baseRevision: history.revision,
+    originalPayload,
+    effectiveHistory: history,
+    currentInput: originalPayload.input,
+    mutationPlan: {
+      operations: [{ type: "evict", stableItemId: "evicted-user-1" }],
+    },
+  });
+  const reducedInput = [{ role: "user", content: "reduced current input" }];
+  const refreshed = withCodexRebaseReplayAccountingInput(result.accounting, reducedInput);
+
+  assert.equal(refreshed.rebaseReplayCostChars, jsonChars(reducedInput));
+  assert.equal(refreshed.rebaseReplayCostTokens, estimatedTokens(jsonChars(reducedInput)));
+  assert.equal(
+    refreshed.breakEvenTurn,
+    Math.ceil(jsonChars(reducedInput) / result.accounting.subsequentSavedCharsPerTurn),
+  );
+  assert.equal(refreshed.plannedSavedChars, result.accounting.plannedSavedChars);
+  assert.equal(refreshed.actuallyRemovedChars, result.accounting.actuallyRemovedChars);
 });
 
 test("CDR-01 rejects effective history containing deferred provider items", () => {
@@ -309,6 +379,9 @@ test("CDR-03 commits a streaming rebase only after observing its response id", a
           "event: response.created",
           "data: {\"response\":{\"id\":\"resp-rebased-stream\"}}",
           "",
+          "event: response.completed",
+          "data: {\"response\":{\"id\":\"resp-rebased-stream\"}}",
+          "",
           "data: [DONE]",
           "",
         ].join("\n"),
@@ -318,6 +391,47 @@ test("CDR-03 commits a streaming rebase only after observing its response id", a
 
   assert.equal(result.outcome, "committed");
   assert.equal(result.newResponseId, "resp-rebased-stream");
+});
+
+test("CDR-03 does not commit a failed streaming rebase after response.created", async () => {
+  const sentPayloads: JsonObject[] = [];
+  const result = await executeCodexRebaseWithFallback({
+    sessionId: "codex-session-1",
+    planId: "plan-failed-streaming-response",
+    epochId: "epoch-1",
+    originalPayload: baseResponsesPayload(),
+    rebasedPayload: { input: [] },
+    async sendUpstream(payload) {
+      sentPayloads.push(payload);
+      if (sentPayloads.length === 1) {
+        return {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+          text: [
+            "event: response.created",
+            "data: {\"response\":{\"id\":\"resp-failed-stream\"}}",
+            "",
+            "event: response.failed",
+            "data: {\"response\":{\"id\":\"resp-failed-stream\"}}",
+            "",
+            "data: [DONE]",
+            "",
+          ].join("\n"),
+        };
+      }
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({ id: "resp-original-fallback", output: [] }),
+      };
+    },
+  });
+
+  assert.equal(sentPayloads.length, 2);
+  assert.equal(result.outcome, "bypassed");
+  assert.equal(result.newResponseId, undefined);
+  assert.equal(result.rebaseResponse?.status, 200);
+  assert.match(result.response.text, /resp-original-fallback/);
 });
 
 test("CDR-04 falls back to the original request after a transport error", async () => {

--- a/components/adapters/codex/tests/context-rebase-capability.test.ts
+++ b/components/adapters/codex/tests/context-rebase-capability.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendCodexRebaseCapability,
+  CODEX_REBASE_CAPABILITY_SCHEMA,
+  codexRebaseCapabilityJournalPath,
+  executeCodexRebaseWithFallback,
+  readCodexRebaseCapabilityJournal,
+  readCodexRebaseEpochJournal,
+  readUnsupportedCodexRebaseItemTypes,
+  type JsonObject,
+} from "../src/context-rewrite/index.js";
+
+async function withTempState(
+  fn: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-capability-"));
+  try {
+    await fn(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+test("CDR-05 Provider Capability Cache stores support status by provider, model, and item type", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRebaseCapability({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemType: "web_search_call",
+      status: "unsupported",
+      reason: "schema_error",
+      observedAt: "2026-07-28T10:00:00.000Z",
+    });
+
+    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemTypes: ["message", "web_search_call"],
+    }), ["web_search_call"]);
+
+    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4",
+      itemTypes: ["web_search_call"],
+    }), []);
+
+    await appendCodexRebaseCapability({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemType: "web_search_call",
+      status: "supported",
+      reason: "rebase_committed",
+      observedAt: "2026-07-28T10:01:00.000Z",
+    });
+
+    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemTypes: ["web_search_call"],
+    }), []);
+
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(journal.capabilities.length, 1);
+    assert.equal(journal.capabilities[0]?.status, "supported");
+  });
+});
+
+test("CDR-05 Provider Capability Cache records only malformed rows as malformed", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRebaseCapability({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemType: "reasoning",
+      status: "unsupported",
+      observedAt: "2026-07-28T10:00:00.000Z",
+    });
+    await appendFile(
+      codexRebaseCapabilityJournalPath(stateDir),
+      [
+        "not-json",
+        "{\"schema\":\"wrong\"}",
+        JSON.stringify({
+          schema: CODEX_REBASE_CAPABILITY_SCHEMA,
+          provider: "OpenAI",
+          model: "gpt-5.4-mini",
+          itemType: "custom_tool_call",
+          status: "unsupported",
+          observedAt: "bad-time",
+        }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(journal.entries.length, 1);
+    assert.equal(journal.capabilities.length, 1);
+    assert.equal(journal.malformedLineCount, 3);
+  });
+});
+
+test("CDR-05 Provider Capability Cache learns 400 schema item rejection and skips later rebase attempts", async () => {
+  await withTempState(async (stateDir) => {
+    const originalPayload = { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
+    const rebasedPayload = { model: "gpt-5.4-mini", input: [{ type: "web_search_call", query: "not replayable" }, { role: "user", content: "current" }] };
+    const sentPayloads: JsonObject[] = [];
+
+    const first = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-capability",
+      planId: "plan-capability",
+      epochId: "epoch-capability",
+      originalPayload,
+      rebasedPayload,
+      capabilityStore: {
+        stateDir,
+        provider: "OpenAI",
+        model: "gpt-5.4-mini",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return sentPayloads.length === 1
+          ? {
+            status: 400,
+            headers: { "content-type": "application/json" },
+            text: JSON.stringify({ error: { code: "invalid_request_error", message: "Unsupported item type: web_search_call" } }),
+          }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(first.outcome, "bypassed");
+    assert.deepEqual(first.capability?.unsupportedItemTypes, ["web_search_call"]);
+    assert.equal(sentPayloads.length, 2);
+
+    const secondPayloads: JsonObject[] = [];
+    const second = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-capability",
+      planId: "plan-capability-next",
+      epochId: "epoch-capability-next",
+      originalPayload,
+      rebasedPayload,
+      capabilityStore: {
+        stateDir,
+        provider: "OpenAI",
+        model: "gpt-5.4-mini",
+      },
+      async sendUpstream(payload) {
+        secondPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-2", output: [] }) };
+      },
+    });
+
+    assert.equal(second.outcome, "bypassed");
+    assert.equal(second.rebaseResponse, undefined);
+    assert.deepEqual(second.capability?.skippedItemTypes, ["web_search_call"]);
+    assert.deepEqual(secondPayloads, [originalPayload]);
+  });
+});
+
+test("CDR-05 Provider Capability Cache skips unsupported rebases before opening an epoch", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRebaseCapability({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemType: "web_search_call",
+      status: "unsupported",
+      reason: "schema_error",
+      observedAt: "2026-07-28T10:00:00.000Z",
+    });
+
+    const originalPayload = { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
+    const rebasedPayload = { model: "gpt-5.4-mini", input: [{ type: "web_search_call", query: "not replayable" }, { role: "user", content: "current" }] };
+    const sentPayloads: JsonObject[] = [];
+
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-capability-epoch",
+      planId: "plan-capability-epoch",
+      epochId: "epoch-capability-epoch",
+      originalPayload,
+      rebasedPayload,
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      capabilityStore: {
+        stateDir,
+        provider: "OpenAI",
+        model: "gpt-5.4-mini",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.rebaseResponse, undefined);
+    assert.deepEqual(result.capability?.skippedItemTypes, ["web_search_call"]);
+    assert.deepEqual(sentPayloads, [originalPayload]);
+
+    const epochJournal = await readCodexRebaseEpochJournal(stateDir, "codex-session-capability-epoch");
+    assert.equal(epochJournal.entries.length, 0);
+  });
+});
+
+test("CDR-05 Provider Capability Cache does not persist auth, rate limit, or 5xx failures as unsupported", async () => {
+  await withTempState(async (stateDir) => {
+    for (const status of [401, 429, 500]) {
+      let calls = 0;
+      await executeCodexRebaseWithFallback({
+        sessionId: `codex-session-${status}`,
+        planId: `plan-${status}`,
+        epochId: `epoch-${status}`,
+        originalPayload: { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [] },
+        rebasedPayload: { model: "gpt-5.4-mini", input: [{ type: "web_search_call", query: "not replayable" }] },
+        capabilityStore: {
+          stateDir,
+          provider: "OpenAI",
+          model: "gpt-5.4-mini",
+        },
+        async sendUpstream() {
+          calls += 1;
+          return calls === 1
+            ? { status, headers: {}, text: JSON.stringify({ error: { message: "temporary failure" } }) }
+            : { status: 200, headers: {}, text: JSON.stringify({ id: `resp-original-${status}`, output: [] }) };
+        },
+      });
+    }
+
+    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemTypes: ["web_search_call"],
+    }), []);
+  });
+});
+
+test("CDR-05 Provider Capability Cache records supported item types after committed rebase", async () => {
+  await withTempState(async (stateDir) => {
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-supported",
+      planId: "plan-supported",
+      epochId: "epoch-supported",
+      originalPayload: { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [] },
+      rebasedPayload: { model: "gpt-5.4-mini", input: [{ role: "user", content: "current" }] },
+      capabilityStore: {
+        stateDir,
+        provider: "OpenAI",
+        model: "gpt-5.4-mini",
+      },
+      async sendUpstream() {
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-rebased", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "committed");
+
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(journal.capabilities.length, 1);
+    assert.equal(journal.capabilities[0]?.itemType, "message");
+    assert.equal(journal.capabilities[0]?.status, "supported");
+  });
+});

--- a/components/adapters/codex/tests/context-rebase-cooldown.test.ts
+++ b/components/adapters/codex/tests/context-rebase-cooldown.test.ts
@@ -1,0 +1,264 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendCodexRebaseCooldown,
+  CODEX_REBASE_COOLDOWN_SCHEMA,
+  codexRebaseCooldownJournalPath,
+  executeCodexRebaseWithFallback,
+  readActiveCodexRebaseCooldown,
+  readCodexRebaseCooldownJournal,
+  readCodexRebaseEpochJournal,
+  type JsonObject,
+} from "../src/context-rewrite/index.js";
+
+async function withTempState(
+  fn: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-cooldown-"));
+  try {
+    await fn(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+test("CDR-04 Rebase Cooldown records active windows by session and plan", async () => {
+  await withTempState(async (stateDir) => {
+    const cooldown = await appendCodexRebaseCooldown({
+      stateDir,
+      sessionId: "codex-session-1",
+      planId: "plan-1",
+      reason: "rebase_upstream_rejected",
+      cooldownMs: 300_000,
+      startedAt: "2026-07-28T10:00:00.000Z",
+    });
+    assert.equal(cooldown.expiresAt, "2026-07-28T10:05:00.000Z");
+
+    const active = await readActiveCodexRebaseCooldown({
+      stateDir,
+      sessionId: "codex-session-1",
+      planId: "plan-1",
+      now: "2026-07-28T10:04:59.000Z",
+    });
+    assert.equal(active?.reason, "rebase_upstream_rejected");
+
+    assert.equal(await readActiveCodexRebaseCooldown({
+      stateDir,
+      sessionId: "codex-session-1",
+      planId: "plan-1",
+      now: "2026-07-28T10:05:00.000Z",
+    }), undefined);
+    assert.equal(await readActiveCodexRebaseCooldown({
+      stateDir,
+      sessionId: "codex-session-1",
+      planId: "plan-other",
+      now: "2026-07-28T10:04:00.000Z",
+    }), undefined);
+  });
+});
+
+test("CDR-04 Rebase Cooldown isolates malformed and wrong-session rows", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRebaseCooldown({
+      stateDir,
+      sessionId: "codex-session-malformed",
+      planId: "plan-valid",
+      reason: "rebase_response_id_missing",
+      cooldownMs: 60_000,
+      startedAt: "2026-07-28T10:00:00.000Z",
+    });
+    await appendFile(
+      codexRebaseCooldownJournalPath(stateDir, "codex-session-malformed"),
+      [
+        "not-json",
+        "{\"schema\":\"wrong\"}",
+        JSON.stringify({
+          schema: CODEX_REBASE_COOLDOWN_SCHEMA,
+          sessionId: "codex-session-other",
+          planId: "plan-other",
+          reason: "wrong-session",
+          startedAt: "2026-07-28T10:00:00.000Z",
+          expiresAt: "2026-07-28T10:01:00.000Z",
+        }),
+        JSON.stringify({
+          schema: CODEX_REBASE_COOLDOWN_SCHEMA,
+          sessionId: "codex-session-malformed",
+          planId: "plan-invalid-time",
+          reason: "invalid-time",
+          startedAt: "bad-time",
+          expiresAt: "2026-07-28T10:01:00.000Z",
+        }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const journal = await readCodexRebaseCooldownJournal(stateDir, "codex-session-malformed");
+    assert.equal(journal.entries.length, 1);
+    assert.equal(journal.cooldowns.length, 1);
+    assert.equal(journal.malformedLineCount, 4);
+  });
+});
+
+test("CDR-04 Rebase Cooldown persists fallback failures and blocks repeated rebase attempts", async () => {
+  await withTempState(async (stateDir) => {
+    const originalPayload = { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
+    const rebasedPayload = { input: [{ role: "user", content: "rebased" }] };
+    const sentPayloads: JsonObject[] = [];
+
+    const failedRebase = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-cooldown",
+      planId: "plan-cooldown",
+      epochId: "epoch-cooldown",
+      originalPayload,
+      rebasedPayload,
+      cooldownStore: {
+        stateDir,
+        cooldownMs: 300_000,
+        now: "2026-07-28T10:00:00.000Z",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return sentPayloads.length === 1
+          ? { status: 400, headers: {}, text: JSON.stringify({ error: "unsupported" }) }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(failedRebase.outcome, "bypassed");
+    assert.equal(failedRebase.cooldown?.reason, "rebase_upstream_rejected");
+    assert.equal(sentPayloads.length, 2);
+
+    const cooldownHitPayloads: JsonObject[] = [];
+    const cooldownHit = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-cooldown",
+      planId: "plan-cooldown",
+      epochId: "epoch-should-not-start",
+      originalPayload,
+      rebasedPayload,
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      cooldownStore: {
+        stateDir,
+        cooldownMs: 300_000,
+        now: "2026-07-28T10:01:00.000Z",
+      },
+      async sendUpstream(payload) {
+        cooldownHitPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-2", output: [] }) };
+      },
+    });
+
+    assert.equal(cooldownHit.outcome, "bypassed");
+    assert.equal(cooldownHit.rebaseResponse, undefined);
+    assert.equal(cooldownHit.cooldown?.reason, "rebase_upstream_rejected");
+    assert.deepEqual(cooldownHitPayloads, [originalPayload]);
+    const epochJournal = await readCodexRebaseEpochJournal(stateDir, "codex-session-cooldown");
+    assert.equal(epochJournal.entries.length, 0);
+  });
+});
+
+test("CDR-04 Rebase Cooldown expires and allows a later rebase attempt", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCodexRebaseCooldown({
+      stateDir,
+      sessionId: "codex-session-expired",
+      planId: "plan-expired",
+      reason: "rebase_upstream_error",
+      cooldownMs: 60_000,
+      startedAt: "2026-07-28T10:00:00.000Z",
+    });
+
+    const sentPayloads: JsonObject[] = [];
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-expired",
+      planId: "plan-expired",
+      epochId: "epoch-expired",
+      originalPayload: { previous_response_id: "resp-old", input: [] },
+      rebasedPayload: { input: [] },
+      cooldownStore: {
+        stateDir,
+        cooldownMs: 60_000,
+        now: "2026-07-28T10:01:01.000Z",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-rebased", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "committed");
+    assert.equal(sentPayloads.length, 1);
+    assert.deepEqual(sentPayloads[0], { input: [] });
+  });
+});
+
+test("CDR-04 Rebase Cooldown is written when original fallback also fails", async () => {
+  await withTempState(async (stateDir) => {
+    let calls = 0;
+    await assert.rejects(() => executeCodexRebaseWithFallback({
+      sessionId: "codex-session-fallback-error",
+      planId: "plan-fallback-error",
+      epochId: "epoch-fallback-error",
+      originalPayload: { previous_response_id: "resp-old", input: [] },
+      rebasedPayload: { input: [] },
+      cooldownStore: {
+        stateDir,
+        cooldownMs: 300_000,
+        now: "2026-07-28T10:00:00.000Z",
+      },
+      async sendUpstream() {
+        calls += 1;
+        if (calls === 1) return { status: 400, headers: {}, text: JSON.stringify({ error: "rejected" }) };
+        throw new Error("fallback connection reset");
+      },
+    }), /fallback connection reset/);
+
+    const active = await readActiveCodexRebaseCooldown({
+      stateDir,
+      sessionId: "codex-session-fallback-error",
+      planId: "plan-fallback-error",
+      now: "2026-07-28T10:01:00.000Z",
+    });
+    assert.equal(active?.reason, "fallback_upstream_error");
+  });
+});
+
+test("CDR-04 Rebase Cooldown does not interrupt successful original fallback when cooldown cannot be written", async () => {
+  await withTempState(async (stateDir) => {
+    const blockedStateDir = join(stateDir, "blocked-state");
+    await writeFile(blockedStateDir, "", "utf8");
+    const sentPayloads: JsonObject[] = [];
+
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-cooldown-store-error",
+      planId: "plan-cooldown-store-error",
+      epochId: "epoch-cooldown-store-error",
+      originalPayload: { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] },
+      rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+      cooldownStore: {
+        stateDir: blockedStateDir,
+        cooldownMs: 300_000,
+        now: "2026-07-28T10:00:00.000Z",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return sentPayloads.length === 1
+          ? { status: 400, headers: {}, text: JSON.stringify({ error: "unsupported" }) }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.cooldown?.reason, "rebase_upstream_rejected");
+    assert.equal(sentPayloads.length, 2);
+    assert.deepEqual(sentPayloads[1], { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] });
+  });
+});

--- a/components/adapters/codex/tests/context-rebase-epoch.test.ts
+++ b/components/adapters/codex/tests/context-rebase-epoch.test.ts
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendPendingCodexRebaseEpoch,
+  CODEX_REBASE_EPOCH_SCHEMA,
+  codexRebaseEpochJournalPath,
+  commitCodexRebaseEpoch,
+  executeCodexRebaseWithFallback,
+  failCodexRebaseEpoch,
+  readCodexRebaseEpochJournal,
+  readLatestCodexRebaseEpoch,
+  readPendingCodexRebaseEpochs,
+  type JsonObject,
+} from "../src/context-rewrite/index.js";
+
+async function withTempState(
+  fn: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-epoch-"));
+  try {
+    await fn(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+test("CDR-03 Rebase Epoch writes pending records and commits only with a response id", async () => {
+  await withTempState(async (stateDir) => {
+    const pending = await appendPendingCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-1",
+      epochId: "epoch-1",
+      planId: "plan-1",
+      oldPreviousResponseId: "resp-old",
+      oldRevision: "rev-old",
+      createdAt: "2026-07-28T10:00:00.000Z",
+    });
+    assert.equal(pending.status, "pending");
+
+    await assert.rejects(() => commitCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-1",
+      epochId: "epoch-1",
+      newResponseId: "",
+    }), /response id/);
+
+    const committed = await commitCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-1",
+      epochId: "epoch-1",
+      newResponseId: "resp-new",
+      newRevision: "rev-new",
+      updatedAt: "2026-07-28T10:00:01.000Z",
+    });
+
+    assert.equal(committed.status, "committed");
+    assert.equal(committed.newResponseId, "resp-new");
+    assert.equal(committed.oldPreviousResponseId, "resp-old");
+    assert.deepEqual(await readPendingCodexRebaseEpochs({ stateDir, sessionId: "codex-session-1" }), []);
+
+    const journal = await readCodexRebaseEpochJournal(stateDir, "codex-session-1");
+    assert.equal(journal.entries.length, 2);
+    assert.equal(journal.epochs.length, 1);
+    assert.equal(journal.epochs[0]?.status, "committed");
+  });
+});
+
+test("CDR-03 Rebase Epoch restores pending epochs after restart", async () => {
+  await withTempState(async (stateDir) => {
+    await appendPendingCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-restart",
+      epochId: "epoch-pending",
+      planId: "plan-restart",
+      oldPreviousResponseId: "resp-old",
+      oldRevision: "rev-old",
+    });
+
+    const restored = await readPendingCodexRebaseEpochs({
+      stateDir,
+      sessionId: "codex-session-restart",
+    });
+    assert.equal(restored.length, 1);
+    assert.equal(restored[0]?.epochId, "epoch-pending");
+    assert.equal(restored[0]?.status, "pending");
+  });
+});
+
+test("CDR-03 Rebase Epoch rejects mismatched or terminal epoch reuse", async () => {
+  await withTempState(async (stateDir) => {
+    const params = {
+      stateDir,
+      sessionId: "codex-session-reuse",
+      epochId: "epoch-reuse",
+      planId: "plan-reuse",
+      oldPreviousResponseId: "resp-old",
+      oldRevision: "rev-old",
+    };
+    await appendPendingCodexRebaseEpoch(params);
+    await assert.rejects(() => appendPendingCodexRebaseEpoch({
+      ...params,
+      oldRevision: "rev-other",
+    }), /epoch mismatch/);
+
+    await commitCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-reuse",
+      epochId: "epoch-reuse",
+      newResponseId: "resp-new",
+    });
+    await assert.rejects(() => appendPendingCodexRebaseEpoch(params), /already terminal/);
+  });
+});
+
+test("CDR-03 Rebase Epoch marks failed epochs and keeps terminal records immutable", async () => {
+  await withTempState(async (stateDir) => {
+    await appendPendingCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-failed",
+      epochId: "epoch-failed",
+      planId: "plan-failed",
+      oldPreviousResponseId: "resp-old",
+      oldRevision: "rev-old",
+    });
+    const failed = await failCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-failed",
+      epochId: "epoch-failed",
+      failureReason: "rebase_upstream_error",
+    });
+    assert.equal(failed.status, "failed");
+
+    const unchanged = await commitCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-failed",
+      epochId: "epoch-failed",
+      newResponseId: "resp-late",
+    });
+    assert.equal(unchanged.status, "failed");
+    assert.equal(unchanged.newResponseId, undefined);
+
+    const journal = await readCodexRebaseEpochJournal(stateDir, "codex-session-failed");
+    assert.equal(journal.entries.length, 2);
+    assert.equal((await readLatestCodexRebaseEpoch({ stateDir, sessionId: "codex-session-failed" }))?.status, "failed");
+  });
+});
+
+test("CDR-03 Rebase Epoch isolates malformed rows without losing valid epochs", async () => {
+  await withTempState(async (stateDir) => {
+    await appendPendingCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-malformed",
+      epochId: "epoch-valid",
+      planId: "plan-valid",
+      oldPreviousResponseId: "resp-old",
+      oldRevision: "rev-old",
+    });
+    await appendFile(
+      codexRebaseEpochJournalPath(stateDir, "codex-session-malformed"),
+      [
+        "not-json",
+        "{\"schema\":\"wrong\"}",
+        JSON.stringify({
+          schema: CODEX_REBASE_EPOCH_SCHEMA,
+          epochId: "epoch-other-session",
+          sessionId: "codex-session-other",
+          planId: "plan-other",
+          oldPreviousResponseId: "resp-other",
+          oldRevision: "rev-other",
+          status: "pending",
+          createdAt: "2026-07-28T10:00:00.000Z",
+          updatedAt: "2026-07-28T10:00:00.000Z",
+        }),
+        JSON.stringify({
+          schema: CODEX_REBASE_EPOCH_SCHEMA,
+          epochId: "epoch-invalid-time",
+          sessionId: "codex-session-malformed",
+          planId: "plan-invalid-time",
+          oldPreviousResponseId: "resp-old",
+          oldRevision: "rev-old",
+          status: "pending",
+          createdAt: "bad-time",
+          updatedAt: "2026-07-28T10:00:00.000Z",
+        }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const journal = await readCodexRebaseEpochJournal(stateDir, "codex-session-malformed");
+    assert.equal(journal.entries.length, 1);
+    assert.equal(journal.epochs.length, 1);
+    assert.equal(journal.malformedLineCount, 4);
+  });
+});
+
+test("CDR-03 Rebase Epoch integrates with fallback commit and rollback outcomes", async () => {
+  await withTempState(async (stateDir) => {
+    const committed = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-fallback",
+      planId: "plan-commit",
+      epochId: "epoch-commit",
+      originalPayload: { previous_response_id: "resp-old", input: [] },
+      rebasedPayload: { input: [] },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+        newRevision: "rev-new",
+      },
+      async sendUpstream() {
+        return {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          text: JSON.stringify({ id: "resp-new", output: [] }),
+        };
+      },
+    });
+    assert.equal(committed.outcome, "committed");
+    assert.equal(committed.epoch?.status, "committed");
+    assert.equal(committed.epoch?.newResponseId, "resp-new");
+
+    let calls = 0;
+    const rolledBack = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-fallback",
+      planId: "plan-rollback",
+      epochId: "epoch-rollback",
+      originalPayload: { previous_response_id: "resp-old", input: [] },
+      rebasedPayload: { input: [] },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      async sendUpstream() {
+        calls += 1;
+        return calls === 1
+          ? { status: 400, headers: {}, text: JSON.stringify({ error: "rejected" }) }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+    assert.equal(rolledBack.outcome, "bypassed");
+    assert.equal(rolledBack.epoch?.status, "rolled_back");
+
+    const journal = await readCodexRebaseEpochJournal(stateDir, "codex-session-fallback");
+    assert.deepEqual(journal.epochs.map((entry) => entry.status), ["committed", "rolled_back"]);
+  });
+});
+
+test("CDR-01 Rebase Epoch bypasses when another epoch is already in flight", async () => {
+  await withTempState(async (stateDir) => {
+    await appendPendingCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-in-flight",
+      epochId: "epoch-existing",
+      planId: "plan-existing",
+      oldPreviousResponseId: "resp-old-existing",
+      oldRevision: "rev-existing",
+    });
+    const sentPayloads: JsonObject[] = [];
+
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-in-flight",
+      planId: "plan-new",
+      epochId: "epoch-new",
+      originalPayload: { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] },
+      rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.rebaseResponse, undefined);
+    assert.equal(result.cooldown, undefined);
+    assert.deepEqual(sentPayloads, [
+      { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] },
+    ]);
+    assert.deepEqual(
+      (await readPendingCodexRebaseEpochs({ stateDir, sessionId: "codex-session-in-flight" }))
+        .map((entry) => entry.epochId),
+      ["epoch-existing"],
+    );
+  });
+});
+
+test("CDR-03 Rebase Epoch records fallback extra request accounting", async () => {
+  await withTempState(async (stateDir) => {
+    let calls = 0;
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-fallback-accounting",
+      planId: "plan-fallback-accounting",
+      epochId: "epoch-fallback-accounting",
+      originalPayload: { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] },
+      rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+      accounting: {
+        plannedSavedChars: 40,
+        plannedSavedTokens: 10,
+        actuallyRemovedChars: 40,
+        actuallyRemovedTokens: 10,
+        rebaseReplayCostChars: 100,
+        rebaseReplayCostTokens: 25,
+        subsequentSavedCharsPerTurn: 40,
+        subsequentSavedTokensPerTurn: 10,
+        estimatorCostChars: 0,
+        estimatorCostTokens: 0,
+        fallbackExtraRequestCount: 0,
+        cacheColdMissCount: 1,
+        breakEvenTurn: 3,
+      },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      async sendUpstream() {
+        calls += 1;
+        return calls === 1
+          ? { status: 400, headers: {}, text: JSON.stringify({ error: "rejected" }) }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+    assert.equal(result.outcome, "bypassed");
+
+    const latest = await readLatestCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-fallback-accounting",
+    });
+    assert.equal(latest?.status, "rolled_back");
+    assert.equal(latest?.accounting?.fallbackExtraRequestCount, 1);
+    assert.equal(latest?.accounting?.cacheColdMissCount, 1);
+  });
+});
+
+test("CDR-03 Rebase Epoch marks failed when original fallback throws", async () => {
+  await withTempState(async (stateDir) => {
+    let calls = 0;
+    await assert.rejects(() => executeCodexRebaseWithFallback({
+      sessionId: "codex-session-fallback-error",
+      planId: "plan-fallback-error",
+      epochId: "epoch-fallback-error",
+      originalPayload: { previous_response_id: "resp-old", input: [] },
+      rebasedPayload: { input: [] },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      async sendUpstream() {
+        calls += 1;
+        if (calls === 1) {
+          return { status: 400, headers: {}, text: JSON.stringify({ error: "rejected" }) };
+        }
+        throw new Error("fallback connection reset");
+      },
+    }), /fallback connection reset/);
+
+    const latest = await readLatestCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-fallback-error",
+    });
+    assert.equal(latest?.status, "failed");
+    assert.equal(latest?.failureReason, "fallback_upstream_error");
+  });
+});
+
+test("CDR-03 Rebase Epoch bypasses rebase when pending epoch cannot be written", async () => {
+  await withTempState(async (stateDir) => {
+    const blockedStateDir = join(stateDir, "blocked-state");
+    await writeFile(blockedStateDir, "", "utf8");
+    const sentPayloads: JsonObject[] = [];
+
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-epoch-store-error",
+      planId: "plan-epoch-store-error",
+      epochId: "epoch-store-error",
+      originalPayload: { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] },
+      rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+      epochStore: {
+        stateDir: blockedStateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.cooldown?.reason, "epoch_store_error");
+    assert.deepEqual(sentPayloads, [
+      { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] },
+    ]);
+  });
+});
+
+test("CDR-03 Rebase Epoch falls back when committed epoch cannot be persisted", async () => {
+  await withTempState(async (stateDir) => {
+    const sentPayloads: JsonObject[] = [];
+    const journalPath = codexRebaseEpochJournalPath(stateDir, "codex-session-commit-store-error");
+
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-commit-store-error",
+      planId: "plan-commit-store-error",
+      epochId: "epoch-commit-store-error",
+      originalPayload: { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] },
+      rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+        newRevision: "rev-new",
+      },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        if (sentPayloads.length === 1) {
+          await rm(journalPath, { force: true });
+          await mkdir(journalPath);
+          return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-rebased", output: [] }) };
+        }
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.cooldown?.reason, "epoch_store_error");
+    assert.equal(sentPayloads.length, 2);
+    assert.deepEqual(sentPayloads[1], { previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] });
+  });
+});

--- a/components/adapters/codex/tests/context-rebase-pipeline.test.ts
+++ b/components/adapters/codex/tests/context-rebase-pipeline.test.ts
@@ -1,0 +1,1194 @@
+import assert from "node:assert/strict";
+import { createServer as createHttpServer } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { reserveUnusedPort } from "@lightmem2/host-adapter";
+
+import { normalizeTokenPilotCodexConfig } from "../src/config.js";
+import {
+  buildCodexEffectiveHistory,
+  loadCodexContextHistoryJournal,
+} from "../src/context-history/index.js";
+import { createConsoleLogger } from "../src/logger.js";
+import { startCodexResponsesProxy } from "../src/proxy-runtime.js";
+import { resolveCodexSessionIdByResponseId } from "../src/session-state.js";
+
+type JsonObject = Record<string, unknown>;
+
+const FETCH_FORBIDDEN_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77,
+  79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123,
+  135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530,
+  531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719,
+  1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666,
+  6667, 6668, 6669, 6697, 10080,
+]);
+
+async function reserveFetchPort(): Promise<number> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const port = await reserveUnusedPort();
+    if (!FETCH_FORBIDDEN_PORTS.has(port)) return port;
+  }
+  throw new Error("Unable to reserve a fetch-safe test port");
+}
+
+async function startSequencedResponsesUpstream(params?: {
+  rejectRebase?: boolean;
+  responseStatus?: string;
+}): Promise<{
+  baseUrl: string;
+  requests: JsonObject[];
+  close(): Promise<void>;
+}> {
+  const port = await reserveFetchPort();
+  const requests: JsonObject[] = [];
+  const server = createHttpServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/responses") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    const body = await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))));
+      req.on("error", reject);
+      req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    });
+    const payload = JSON.parse(body) as JsonObject;
+    requests.push(payload);
+    const isRebase = !("previous_response_id" in payload) && requests.length > 1;
+    if (params?.rejectRebase && isRebase) {
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: { code: "invalid_request_error", message: "schema rejected replay" } }));
+      return;
+    }
+    const id = `resp-pipeline-${requests.length}`;
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      id,
+      object: "response",
+      status: params?.responseStatus,
+      previous_response_id: typeof payload.previous_response_id === "string" ? payload.previous_response_id : undefined,
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: `ok ${id}` }],
+        },
+      ],
+    }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close() {
+      return new Promise((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function streamResponseText(id: string, previousResponseId: string | undefined): string {
+  return [
+    "event: response.created",
+    `data: ${JSON.stringify({
+      type: "response.created",
+      response: {
+        id,
+        previous_response_id: previousResponseId,
+      },
+    })}`,
+    "",
+    "event: response.output_item.done",
+    `data: ${JSON.stringify({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        id: `msg-${id}`,
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: `ok ${id}` }],
+      },
+    })}`,
+    "",
+    "event: response.completed",
+    `data: ${JSON.stringify({
+      type: "response.completed",
+      response: {
+        id,
+        previous_response_id: previousResponseId,
+      },
+    })}`,
+    "",
+    "data: [DONE]",
+    "",
+    "",
+  ].join("\n");
+}
+
+async function startSequencedStreamResponsesUpstream(params?: {
+  rejectRebase?: boolean;
+  incomplete?: boolean;
+}): Promise<{
+  baseUrl: string;
+  requests: JsonObject[];
+  close(): Promise<void>;
+}> {
+  const port = await reserveFetchPort();
+  const requests: JsonObject[] = [];
+  const server = createHttpServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/responses") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    const body = await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))));
+      req.on("error", reject);
+      req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    });
+    const payload = JSON.parse(body) as JsonObject;
+    requests.push(payload);
+    const isRebase = !("previous_response_id" in payload) && requests.length > 1;
+    if (params?.rejectRebase && isRebase) {
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: { code: "invalid_request_error", message: "stream replay rejected" } }));
+      return;
+    }
+    const id = `resp-stream-pipeline-${requests.length}`;
+    const previousResponseId = typeof payload.previous_response_id === "string"
+      ? payload.previous_response_id
+      : undefined;
+    res.statusCode = 200;
+    res.setHeader("content-type", "text/event-stream; charset=utf-8");
+    res.end(params?.incomplete
+      ? [
+        "event: response.created",
+        `data: ${JSON.stringify({
+          type: "response.created",
+          response: {
+            id,
+            previous_response_id: previousResponseId,
+          },
+        })}`,
+        "",
+        "event: response.output_text.delta",
+        `data: ${JSON.stringify({
+          type: "response.output_text.delta",
+          output_index: 0,
+          delta: `partial ${id}`,
+        })}`,
+        "",
+        "data: [DONE]",
+        "",
+        "",
+      ].join("\n")
+      : streamResponseText(id, previousResponseId));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close() {
+      return new Promise((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function inputText(payload: JsonObject | undefined): string {
+  const input = Array.isArray(payload?.input) ? payload.input : [];
+  return JSON.stringify(input);
+}
+
+test("CDR-06 proxy pipeline rebases a non-stream request from effective history", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "OLD_SENTINEL_PIPELINE" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const oldItem = history.replayableItems.find((entry) => JSON.stringify(entry.item).includes("OLD_SENTINEL_PIPELINE"));
+    assert.ok(oldItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: oldItem.stableItemId }],
+    };
+
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-pipeline-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "CURRENT_SENTINEL_PIPELINE" }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    assert.equal(upstream.requests.length, 2);
+    assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
+    assert.doesNotMatch(inputText(upstream.requests[1]), /OLD_SENTINEL_PIPELINE/);
+    assert.match(inputText(upstream.requests[1]), /CURRENT_SENTINEL_PIPELINE/);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDH-02 proxy journal respects failed non-stream response bodies", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-body-failed-"));
+  const upstream = await startSequencedResponsesUpstream({ responseStatus: "failed" });
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-body-failed";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: false,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const response = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "BODY_FAILED_SENTINEL" }],
+      }),
+    });
+    assert.equal(response.status, 200);
+
+    const journal = await loadCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.filter((entry) => entry.kind === "request").at(-1)?.status, "failed");
+    assert.equal(journal.find((entry) => entry.kind === "response")?.status, "failed");
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-01 proxy pipeline defers stale mutation plans", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-stale-plan-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-stale-plan";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "OLD_SENTINEL_STALE_PLAN" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const oldItem = history.replayableItems.find((entry) => JSON.stringify(entry.item).includes("OLD_SENTINEL_STALE_PLAN"));
+    assert.ok(oldItem);
+    (config as any).contextRewrite.mutationPlan = {
+      baseRevision: "rev-stale",
+      operations: [{ type: "evict", stableItemId: oldItem.stableItemId }],
+    };
+
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-pipeline-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "CURRENT_SENTINEL_STALE_PLAN" }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    assert.equal(upstream.requests.length, 2);
+    assert.equal(upstream.requests[1]?.previous_response_id, "resp-pipeline-1");
+    assert.match(inputText(upstream.requests[1]), /CURRENT_SENTINEL_STALE_PLAN/);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 proxy pipeline falls back and cools down rejected rebases", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-fallback-"));
+  const upstream = await startSequencedResponsesUpstream({ rejectRebase: true });
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-fallback";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "OLD_SENTINEL_PIPELINE_FALLBACK" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const oldItem = history.replayableItems.find(
+      (entry) => JSON.stringify(entry.item).includes("OLD_SENTINEL_PIPELINE_FALLBACK"),
+    );
+    assert.ok(oldItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: oldItem.stableItemId }],
+    };
+
+    const turn = {
+      model: "gpt-5.4-mini",
+      stream: false,
+      previous_response_id: "resp-pipeline-1",
+      metadata: { tokenpilotSessionId: sessionId },
+      input: [{ role: "user", content: "CURRENT_SENTINEL_PIPELINE_FALLBACK" }],
+    };
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(turn),
+    });
+    assert.equal(second.status, 200);
+    assert.equal(upstream.requests.length, 3);
+    assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
+    assert.equal(upstream.requests[2]?.previous_response_id, "resp-pipeline-1");
+
+    const third = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(turn),
+    });
+    assert.equal(third.status, 200);
+    assert.equal(upstream.requests.length, 4);
+    assert.equal(upstream.requests[3]?.previous_response_id, "resp-pipeline-1");
+
+    const fourth = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        ...turn,
+        input: [{ role: "user", content: "DIFFERENT_CURRENT_SENTINEL_PIPELINE_FALLBACK" }],
+      }),
+    });
+    assert.equal(fourth.status, 200);
+    assert.equal(upstream.requests.length, 5);
+    assert.equal(upstream.requests[4]?.previous_response_id, "resp-pipeline-1");
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-04 fallback keeps non-rebase before-call reductions", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-fallback-reduction-"));
+  const upstream = await startSequencedResponsesUpstream({ rejectRebase: true });
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-fallback-reduction";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: true,
+      },
+      reduction: {
+        triggerMinChars: 256,
+        maxToolChars: 400,
+        passes: {
+          readStateCompaction: false,
+          toolPayloadTrim: true,
+          htmlSlimming: false,
+          execOutputTruncation: true,
+          agentsStartupOptimization: false,
+        },
+        passOptions: {
+          execOutputTruncation: {
+            toolThresholds: {
+              bash: 400,
+            },
+          },
+        },
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "OLD_SENTINEL_FALLBACK_REDUCTION" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const oldItem = history.replayableItems.find(
+      (entry) => JSON.stringify(entry.item).includes("OLD_SENTINEL_FALLBACK_REDUCTION"),
+    );
+    assert.ok(oldItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: oldItem.stableItemId }],
+    };
+
+    const longOutput = `RAW_FALLBACK_REDUCTION\n${"line\n".repeat(600)}`;
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-pipeline-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [
+          { role: "user", content: "CURRENT_SENTINEL_FALLBACK_REDUCTION" },
+          { type: "function_call", call_id: "call-fallback-reduction", name: "bash", arguments: "{}" },
+          { type: "function_call_output", call_id: "call-fallback-reduction", output: longOutput },
+        ],
+      }),
+    });
+
+    assert.equal(second.status, 200);
+    assert.equal(upstream.requests.length, 3);
+    assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
+    assert.equal(upstream.requests[2]?.previous_response_id, "resp-pipeline-1");
+    const fallbackOutput = ((upstream.requests[2]?.input as JsonObject[] | undefined) ?? [])
+      .find((item) => item.type === "function_call_output")?.output;
+    assert.equal(typeof fallbackOutput, "string");
+    assert.ok(String(fallbackOutput).length < longOutput.length);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 proxy pipeline falls back and cools down rejected stream rebases", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-stream-fallback-"));
+  const upstream = await startSequencedStreamResponsesUpstream({ rejectRebase: true });
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-stream-fallback";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: true,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "OLD_SENTINEL_PIPELINE_STREAM_FALLBACK" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+    await first.text();
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const oldItem = history.replayableItems.find(
+      (entry) => JSON.stringify(entry.item).includes("OLD_SENTINEL_PIPELINE_STREAM_FALLBACK"),
+    );
+    assert.ok(oldItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: oldItem.stableItemId }],
+    };
+
+    const turn = {
+      model: "gpt-5.4-mini",
+      stream: true,
+      previous_response_id: "resp-stream-pipeline-1",
+      metadata: { tokenpilotSessionId: sessionId },
+      input: [{ role: "user", content: "CURRENT_SENTINEL_PIPELINE_STREAM_FALLBACK" }],
+    };
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(turn),
+    });
+    const secondText = await second.text();
+    assert.equal(second.status, 200);
+    assert.match(secondText, /resp-stream-pipeline-3/);
+    assert.equal(upstream.requests.length, 3);
+    assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
+    assert.equal(upstream.requests[2]?.previous_response_id, "resp-stream-pipeline-1");
+
+    const third = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(turn),
+    });
+    assert.equal(third.status, 200);
+    await third.text();
+    assert.equal(upstream.requests.length, 4);
+    assert.equal(upstream.requests[3]?.previous_response_id, "resp-stream-pipeline-1");
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDH-02 proxy journal and trace keep interrupted 2xx streams incomplete", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-stream-incomplete-"));
+  const upstream = await startSequencedStreamResponsesUpstream({ incomplete: true });
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-stream-incomplete";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: false,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const response = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: true,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "INTERRUPTED_STREAM_TRACE" }],
+      }),
+    });
+    assert.equal(response.status, 200);
+    await response.text();
+
+    const journal = await loadCodexContextHistoryJournal(stateDir, sessionId);
+    const requestEntries = journal.filter((entry) => entry.kind === "request");
+    assert.equal(requestEntries.at(-1)?.status, "incomplete");
+    assert.equal(journal.find((entry) => entry.kind === "response")?.status, "incomplete");
+
+    const traceRows = (await readFile(join(stateDir, "event-trace.jsonl"), "utf8"))
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => JSON.parse(line) as JsonObject);
+    const afterCall = traceRows.findLast((entry) => entry.stage === "proxy_after_call");
+    assert.equal(afterCall?.completed, false);
+    assert.equal(afterCall?.streamStatus, "incomplete");
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 proxy pipeline journals current input before reduction", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-order-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-order";
+    const longOutput = `RAW_ORDER_SENTINEL\n${"line\n".repeat(600)}`;
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: true,
+      },
+      reduction: {
+        triggerMinChars: 256,
+        maxToolChars: 400,
+        passes: {
+          readStateCompaction: false,
+          toolPayloadTrim: true,
+          htmlSlimming: false,
+          execOutputTruncation: true,
+          agentsStartupOptimization: false,
+        },
+        passOptions: {
+          execOutputTruncation: {
+            toolThresholds: {
+              bash: 400,
+            },
+          },
+        },
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const response = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [
+          { role: "developer", content: "root prompt" },
+          { role: "user", content: "check status" },
+          { role: "tool", type: "function_call_output", name: "bash", output: longOutput },
+        ],
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(upstream.requests.length, 1);
+    const forwardedTool = (upstream.requests[0]?.input as JsonObject[] | undefined)?.find(
+      (item) => item.type === "function_call_output",
+    );
+    assert.ok(forwardedTool);
+    assert.ok(String(forwardedTool.output ?? "").length < longOutput.length);
+
+    const journal = await loadCodexContextHistoryJournal(stateDir, sessionId);
+    const request = journal.find((entry) => entry.kind === "request");
+    assert.equal(request?.kind, "request");
+    const journalTool = request.inputItems.find((item) => item.type === "function_call_output");
+    assert.equal(journalTool?.output, longOutput);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 committed rebase history starts from the new response chain root", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-root-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-root";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "ROOT_OLD_SENTINEL" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const beforeRebase = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const oldItem = beforeRebase.replayableItems.find(
+      (entry) => JSON.stringify(entry.item).includes("ROOT_OLD_SENTINEL"),
+    );
+    assert.ok(oldItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: oldItem.stableItemId }],
+    };
+
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-pipeline-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "ROOT_CURRENT_SENTINEL" }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    assert.equal(upstream.requests.length, 2);
+    assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
+    assert.doesNotMatch(inputText(upstream.requests[1]), /ROOT_OLD_SENTINEL/);
+
+    const afterRebase = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-pipeline-2",
+    });
+    assert.equal(afterRebase.incomplete, false);
+    assert.doesNotMatch(JSON.stringify(afterRebase.replayableItems), /ROOT_OLD_SENTINEL/);
+    assert.match(JSON.stringify(afterRebase.replayableItems), /ROOT_CURRENT_SENTINEL/);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 mock smoke keeps five turns on the new response chain", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-smoke-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-smoke";
+    const evict = "EVICT_ME_mock_smoke";
+    const keep = "KEEP_ME_mock_smoke";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [
+          { role: "user", content: evict },
+          { role: "user", content: keep },
+        ],
+      }),
+    });
+    assert.equal(first.status, 200);
+    let previousResponseId = String((await first.json() as JsonObject).id);
+
+    const beforeRebase = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const evictedItem = beforeRebase.replayableItems.find(
+      (entry) => JSON.stringify(entry.item).includes(evict),
+    );
+    assert.ok(evictedItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: evictedItem.stableItemId }],
+    };
+
+    for (let turn = 2; turn <= 6; turn += 1) {
+      const response = await fetch(`${runtime.baseUrl}/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gpt-5.4-mini",
+          stream: false,
+          previous_response_id: previousResponseId,
+          input: [{ role: "user", content: `TURN_${turn}_mock_smoke` }],
+        }),
+      });
+      assert.equal(response.status, 200);
+      const responseBody = await response.json() as JsonObject;
+      previousResponseId = String(responseBody.id);
+      (config as any).contextRewrite.mutationPlan = { operations: [] };
+    }
+
+    assert.equal(await resolveCodexSessionIdByResponseId(stateDir, previousResponseId), sessionId);
+    assert.equal(upstream.requests.length, 6);
+    const rebasedPayload = upstream.requests[1];
+    assert.equal("previous_response_id" in (rebasedPayload ?? {}), false);
+    assert.doesNotMatch(inputText(rebasedPayload), new RegExp(evict));
+    assert.match(inputText(rebasedPayload), new RegExp(keep));
+    for (const payload of upstream.requests.slice(1)) {
+      assert.doesNotMatch(inputText(payload), new RegExp(evict));
+    }
+    for (let index = 2; index < upstream.requests.length; index += 1) {
+      assert.equal(upstream.requests[index]?.previous_response_id, `resp-pipeline-${index}`);
+    }
+
+    const finalHistory = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: previousResponseId,
+    });
+    assert.equal(finalHistory.incomplete, false);
+    assert.doesNotMatch(JSON.stringify(finalHistory.replayableItems), new RegExp(evict));
+    assert.match(JSON.stringify(finalHistory.replayableItems), new RegExp(keep));
+    assert.match(JSON.stringify(finalHistory.replayableItems), /TURN_6_mock_smoke/);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 proxy restart keeps the committed rebase response chain", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-restart-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-pipeline-restart";
+    const evict = "EVICT_ME_restart_smoke";
+    const keep = "KEEP_ME_restart_smoke";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [
+          { role: "user", content: evict },
+          { role: "user", content: keep },
+        ],
+      }),
+    });
+    assert.equal(first.status, 200);
+    let previousResponseId = String((await first.json() as JsonObject).id);
+
+    const beforeRebase = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const evictedItem = beforeRebase.replayableItems.find(
+      (entry) => JSON.stringify(entry.item).includes(evict),
+    );
+    assert.ok(evictedItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: evictedItem.stableItemId }],
+    };
+
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: previousResponseId,
+        input: [{ role: "user", content: "TURN_2_restart_smoke" }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    previousResponseId = String((await second.json() as JsonObject).id);
+
+    assert.equal(upstream.requests.length, 2);
+    assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
+    assert.doesNotMatch(inputText(upstream.requests[1]), new RegExp(evict));
+    assert.match(inputText(upstream.requests[1]), new RegExp(keep));
+
+    await runtime.close();
+    runtime = undefined;
+
+    const restartedConfig = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        cooldownMs: 300_000,
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config: restartedConfig,
+      logger: createConsoleLogger(false),
+    });
+
+    const third = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: previousResponseId,
+        input: [{ role: "user", content: "TURN_3_restart_smoke" }],
+      }),
+    });
+    assert.equal(third.status, 200);
+    const finalResponseId = String((await third.json() as JsonObject).id);
+
+    assert.equal(upstream.requests.length, 3);
+    assert.equal(upstream.requests[2]?.previous_response_id, previousResponseId);
+    assert.equal(await resolveCodexSessionIdByResponseId(stateDir, finalResponseId), sessionId);
+    const finalHistory = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: finalResponseId,
+    });
+    assert.equal(finalHistory.incomplete, false);
+    assert.doesNotMatch(JSON.stringify(finalHistory.replayableItems), new RegExp(evict));
+    assert.match(JSON.stringify(finalHistory.replayableItems), new RegExp(keep));
+    assert.match(JSON.stringify(finalHistory.replayableItems), /TURN_3_restart_smoke/);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/components/adapters/codex/tests/context-rebase-report.test.ts
+++ b/components/adapters/codex/tests/context-rebase-report.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  appendCodexRebaseCapability,
+  appendCodexRebaseCooldown,
+  appendPendingCodexRebaseEpoch,
+  commitCodexRebaseEpoch,
+  codexRebaseEpochJournalPath,
+} from "../src/context-rewrite/index.js";
+import { appendCodexRecentTurnBinding, upsertCodexSessionSnapshot } from "../src/session-state.js";
+import { renderCodexSessionReport } from "../src/session-report.js";
+
+test("CDR-07 Codex session report renders rebase state", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-report-"));
+  try {
+    await upsertCodexSessionSnapshot(dir, "sess-rebase-report", {
+      latestResponseId: "resp-new",
+      previousResponseId: "resp-old",
+      latestModel: "gpt-test",
+    });
+    await appendCodexRecentTurnBinding(dir, {
+      sessionId: "sess-rebase-report",
+      responseId: "resp-new",
+      previousResponseId: "resp-old",
+      model: "gpt-test",
+      requestChars: 20,
+      responseChars: 30,
+      assistantChars: 10,
+      stream: false,
+      updatedAt: "2026-07-28T10:00:00.000Z",
+    });
+    await appendPendingCodexRebaseEpoch({
+      stateDir: dir,
+      sessionId: "sess-rebase-report",
+      planId: "plan-report",
+      epochId: "epoch-report",
+      oldPreviousResponseId: "resp-old",
+      oldRevision: "rev-old",
+      createdAt: "2026-07-28T10:00:00.000Z",
+    });
+    await commitCodexRebaseEpoch({
+      stateDir: dir,
+      sessionId: "sess-rebase-report",
+      epochId: "epoch-report",
+      newResponseId: "resp-new",
+      newRevision: "rev-new",
+      updatedAt: "2026-07-28T10:00:01.000Z",
+    });
+    await appendCodexRebaseCooldown({
+      stateDir: dir,
+      sessionId: "sess-rebase-report",
+      planId: "plan-report",
+      reason: "rebase_upstream_rejected",
+      cooldownMs: 300_000,
+      startedAt: "2999-01-01T00:00:00.000Z",
+    });
+    await appendCodexRebaseCapability({
+      stateDir: dir,
+      provider: "OpenAI",
+      model: "gpt-test",
+      itemType: "web_search_call",
+      status: "unsupported",
+      reason: "schema_error",
+      observedAt: "2026-07-28T10:00:02.000Z",
+    });
+
+    const report = await renderCodexSessionReport(dir, "sess-rebase-report");
+
+    assert.match(report, /rebase epochs: committed=1, rolled_back=0, failed=0, pending=0/i);
+    assert.match(report, /latest rebase epoch: committed epoch-report old=resp-old new=resp-new/i);
+    assert.match(report, /rebase cooldowns: active=1\/1 latest=rebase_upstream_rejected/i);
+    assert.match(report, /rebase capability cache: OpenAI\/gpt-test web_search_call unsupported/i);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-07 Codex session report renders rebase accounting and break-even", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-report-accounting-"));
+  try {
+    await upsertCodexSessionSnapshot(dir, "sess-rebase-accounting", {
+      latestResponseId: "resp-new",
+      previousResponseId: "resp-old",
+      latestModel: "gpt-test",
+    });
+    await appendPendingCodexRebaseEpoch({
+      stateDir: dir,
+      sessionId: "sess-rebase-accounting",
+      planId: "plan-accounting",
+      epochId: "epoch-accounting",
+      oldPreviousResponseId: "resp-old",
+      oldRevision: "rev-old",
+      createdAt: "2026-07-28T10:00:00.000Z",
+      accounting: {
+        plannedSavedChars: 120,
+        plannedSavedTokens: 30,
+        actuallyRemovedChars: 80,
+        actuallyRemovedTokens: 20,
+        rebaseReplayCostChars: 200,
+        rebaseReplayCostTokens: 50,
+        subsequentSavedCharsPerTurn: 80,
+        subsequentSavedTokensPerTurn: 20,
+        estimatorCostChars: 8,
+        estimatorCostTokens: 2,
+        fallbackExtraRequestCount: 0,
+        cacheColdMissCount: 1,
+        breakEvenTurn: 3,
+      },
+    });
+    await commitCodexRebaseEpoch({
+      stateDir: dir,
+      sessionId: "sess-rebase-accounting",
+      epochId: "epoch-accounting",
+      newResponseId: "resp-new",
+      newRevision: "rev-new",
+      updatedAt: "2026-07-28T10:00:01.000Z",
+    });
+
+    const report = await renderCodexSessionReport(dir, "sess-rebase-accounting");
+
+    assert.match(report, /rebase accounting: planned_saved=120 chars \(~30 tokens\)/i);
+    assert.match(report, /removed=80 chars \(~20 tokens\)/i);
+    assert.match(report, /replay_cost=200 chars \(~50 tokens\)/i);
+    assert.match(report, /subsequent_saved=80 chars\/turn \(~20 tokens\/turn\)/i);
+    assert.match(report, /estimator_cost=8 chars \(~2 tokens\)/i);
+    assert.match(report, /fallback_extra_requests=0 cache_cold_misses=1 break_even_turn=3/i);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-07 Codex session report surfaces rebase journal read errors", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-report-error-"));
+  try {
+    await upsertCodexSessionSnapshot(dir, "sess-rebase-report-error", {
+      latestResponseId: "resp-error",
+      latestModel: "gpt-test",
+    });
+    await mkdir(codexRebaseEpochJournalPath(dir, "sess-rebase-report-error"), { recursive: true });
+
+    const report = await renderCodexSessionReport(dir, "sess-rebase-report-error");
+
+    assert.match(report, /rebase journal read errors: epoch=/i);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/components/adapters/codex/tests/doctor.test.ts
+++ b/components/adapters/codex/tests/doctor.test.ts
@@ -8,6 +8,7 @@ import { createServer as createHttpServer } from "node:http";
 
 import { normalizeTokenPilotCodexConfig } from "../src/config.js";
 import { formatCodexDoctorReport, inspectCodexDoctor } from "../src/doctor.js";
+import { appendCodexRebaseCapability } from "../src/context-rewrite/index.js";
 
 async function reserveUnusedPort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -404,6 +405,44 @@ test("formatCodexDoctorReport includes remediation hints for drifted installs", 
   const text = formatCodexDoctorReport(report);
   assert.match(text, /Suggested fixes:/);
   assert.match(text, /rerun the Codex install command/i);
+});
+
+test("inspectCodexDoctor reports cached rebase capabilities", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-doctor-capability-"));
+  try {
+    const proxyPort = await reserveUnusedPort();
+    const stateDir = join(dir, "state");
+    const codexConfigPath = join(dir, "config.toml");
+    const hooksConfigPath = join(dir, "hooks.json");
+    const tokenPilotConfigPath = join(dir, "tokenpilot.json");
+
+    await writeFile(codexConfigPath, "model_provider = \"OpenAI\"\n", "utf8");
+    await writeFile(hooksConfigPath, JSON.stringify({ hooks: {} }, null, 2), "utf8");
+    await appendCodexRebaseCapability({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      itemType: "web_search_call",
+      status: "unsupported",
+      reason: "schema_error",
+      observedAt: "2026-07-28T10:00:00.000Z",
+    });
+
+    const report = await inspectCodexDoctor({
+      config: normalizeTokenPilotCodexConfig({
+        stateDir,
+        proxyPort,
+      }),
+      configPath: codexConfigPath,
+      hooksConfigPath,
+      tokenPilotConfigPath,
+    });
+
+    assert.deepEqual(report.rebaseCapabilityStatus, ["OpenAI/gpt-5.4-mini web_search_call unsupported"]);
+    assert.match(formatCodexDoctorReport(report), /rebase capability cache: OpenAI\/gpt-5\.4-mini web_search_call unsupported/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("formatCodexDoctorReport shows degraded mode when core runtime is healthy but MCP recovery drifted", () => {


### PR DESCRIPTION
## Summary

- Add response chain rebase safety checks for Codex, including revision validation, incomplete history detection, deferred item blocking, and tool call/tool output closure checks.
- Add Codex rebase request builder that removes `previous_response_id`, replays retained effective history, appends current input, and records token/char accounting.
- Add rebase epoch journal, cooldown journal, and provider capability cache for safer retry/fallback behavior.
- Wire context rewrite into the Codex proxy pipeline while preserving original fallback behavior.
- Improve CDH handling for effective history, replayability classification, SSE item collection, malformed streams, interrupted streams, and failed/incomplete non-stream response bodies.
- Add doctor and session report output for rebase state, accounting, cooldowns, and provider capability cache.
- Add focused regression tests for stale mutation plans, unsafe replay items, tool closure, failed rebase fallback, cooldown reuse, capability bypass, restart behavior, and stream edge cases.

## Validation

- `node --import tsx --test tests\context-history-journal.test.ts tests\context-history-sse-item-collector.test.ts tests\context-history-effective-history.test.ts tests\context-history-fixtures.test.ts tests\context-history-replayability.test.ts tests\context-history-rollout.test.ts tests\context-rebase-behavior.test.ts tests\context-rebase-epoch.test.ts tests\context-rebase-cooldown.test.ts tests\context-rebase-capability.test.ts tests\context-rebase-pipeline.test.ts tests\context-rebase-report.test.ts`
  - 99 passed, 0 failed
- `node --import tsx --test tests\config.test.ts tests\doctor.test.ts tests\session-report.test.ts`
  - 18 passed, 0 failed
- `npm run typecheck`
- `npm run build`
- `git diff --check`