### PR TITLE
feat(history): add stable context item ids

### DIFF
--- a/components/packages/foundation/history/package.json
+++ b/components/packages/foundation/history/package.json
@@ -10,7 +10,8 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "@lightmem2/kernel": "workspace:*"

--- a/components/packages/foundation/history/src/context-item-id.ts
+++ b/components/packages/foundation/history/src/context-item-id.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+
+export const CONTEXT_ITEM_ID_ALGORITHM_VERSION = 1 as const;
+
+export type ContextItemIdentitySource =
+  | "native_item_id"
+  | "call_id"
+  | "synthetic";
+
+export type ContextItemIdentityInput = {
+  sessionId: string;
+  kind: string;
+  role?: string;
+  nativeItemId?: string;
+  callId?: string;
+  content: unknown;
+  ordinal: number;
+};
+
+export type ContextItemFingerprintInput = Pick<
+  ContextItemIdentityInput,
+  "kind" | "role" | "content"
+>;
+
+export type ContextItemIdentity = {
+  stableId: string;
+  fingerprint: string;
+  source: ContextItemIdentitySource;
+};
+
+function canonicalJson(value: unknown, ancestors: Set<object>): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("context item content must contain finite numbers");
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object") {
+    throw new TypeError("context item content must be JSON-compatible");
+  }
+  if (ancestors.has(value)) throw new TypeError("context item content must not contain cycles");
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return `[${Array.from(value, (item) => canonicalJson(item, ancestors)).join(",")}]`;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("context item content must contain plain objects");
+    }
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throw new TypeError("context item content must not contain symbol keys");
+    }
+
+    const object = value as Record<string, unknown>;
+    const entries = Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key], ancestors)}`);
+    return `{${entries.join(",")}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function requiredIdentityPart(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${name} must not be empty`);
+  return normalized;
+}
+
+function optionalIdentityPart(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function sha256(value: unknown): string {
+  return createHash("sha256")
+    .update(normalizeContextItemContent(value))
+    .digest("hex");
+}
+
+export function normalizeContextItemContent(content: unknown): string {
+  return canonicalJson(content, new Set<object>());
+}
+
+export function createContextItemFingerprint(
+  input: ContextItemFingerprintInput,
+): string {
+  const kind = requiredIdentityPart(input.kind, "kind").toLowerCase();
+  const role = optionalIdentityPart(input.role)?.toLowerCase();
+  const digest = sha256({
+    algorithmVersion: CONTEXT_ITEM_ID_ALGORITHM_VERSION,
+    content: normalizeContextItemContent(input.content),
+    kind,
+    role: role ?? null,
+  });
+  return `ctxfp-v${CONTEXT_ITEM_ID_ALGORITHM_VERSION}-${digest}`;
+}
+
+export function createContextItemIdentity(
+  input: ContextItemIdentityInput,
+): ContextItemIdentity {
+  const sessionId = requiredIdentityPart(input.sessionId, "sessionId");
+  const kind = requiredIdentityPart(input.kind, "kind").toLowerCase();
+  const role = optionalIdentityPart(input.role)?.toLowerCase();
+  const nativeItemId = optionalIdentityPart(input.nativeItemId);
+  const callId = optionalIdentityPart(input.callId);
+  const fingerprint = createContextItemFingerprint({
+    kind,
+    role,
+    content: input.content,
+  });
+
+  let source: ContextItemIdentitySource;
+  let identityValue: string | number;
+  if (nativeItemId) {
+    source = "native_item_id";
+    identityValue = nativeItemId;
+  } else if (callId) {
+    source = "call_id";
+    identityValue = callId;
+  } else {
+    if (!Number.isSafeInteger(input.ordinal) || input.ordinal < 0) {
+      throw new TypeError("ordinal must be a non-negative safe integer");
+    }
+    source = "synthetic";
+    identityValue = input.ordinal;
+  }
+
+  const digest = sha256({
+    algorithmVersion: CONTEXT_ITEM_ID_ALGORITHM_VERSION,
+    fingerprint: source === "synthetic" ? fingerprint : null,
+    identityValue,
+    kind,
+    sessionId,
+    source,
+  });
+  return {
+    stableId: `ctx-v${CONTEXT_ITEM_ID_ALGORITHM_VERSION}-${digest}`,
+    fingerprint,
+    source,
+  };
+}
+
+export function createStableContextItemId(
+  input: ContextItemIdentityInput,
+): string {
+  return createContextItemIdentity(input).stableId;
+}

--- a/components/packages/foundation/history/src/index.ts
+++ b/components/packages/foundation/history/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types.js";
 export * from "./page-out-types.js";
+export * from "./context-item-id.js";
 export * from "./canonical-state.js";
 export * from "./canonical-anchors.js";
 export * from "./canonical-rewrite.js";

--- a/components/packages/foundation/history/tests/context-item-id.test.ts
+++ b/components/packages/foundation/history/tests/context-item-id.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONTEXT_ITEM_ID_ALGORITHM_VERSION,
+  createContextItemFingerprint,
+  createContextItemIdentity,
+  createStableContextItemId,
+  normalizeContextItemContent,
+} from "../src/index.js";
+
+test("context item ID algorithm version is locked to 1", () => {
+  assert.equal(CONTEXT_ITEM_ID_ALGORITHM_VERSION, 1);
+});
+
+test("native item ID takes priority over call ID and mutable content", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "assistant",
+    nativeItemId: "item-1",
+    callId: "call-1",
+    content: { text: "before" },
+    ordinal: 0,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "assistant",
+    nativeItemId: "item-1",
+    callId: "call-changed",
+    content: { text: "after" },
+    ordinal: 99,
+  });
+
+  assert.equal(first.source, "native_item_id");
+  assert.equal(first.stableId, replayed.stableId);
+  assert.notEqual(first.fingerprint, replayed.fingerprint);
+});
+
+test("call ID is the stable fallback when no native item ID exists", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "tool_result",
+    callId: "call-1",
+    content: { output: "before" },
+    ordinal: 2,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "tool_result",
+    callId: "call-1",
+    content: { output: "after" },
+    ordinal: 20,
+  });
+
+  assert.equal(first.source, "call_id");
+  assert.equal(first.stableId, replayed.stableId);
+  assert.notEqual(first.fingerprint, replayed.fingerprint);
+});
+
+test("synthetic IDs are deterministic across object key order", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    role: "user",
+    content: { text: "hello", metadata: { a: 1, b: 2 } },
+    ordinal: 3,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    role: "user",
+    content: { metadata: { b: 2, a: 1 }, text: "hello" },
+    ordinal: 3,
+  });
+
+  assert.equal(first.source, "synthetic");
+  assert.deepEqual(first, replayed);
+  assert.equal(
+    createStableContextItemId({
+      sessionId: "session-1",
+      kind: "user",
+      role: "user",
+      content: { text: "hello", metadata: { a: 1, b: 2 } },
+      ordinal: 3,
+    }),
+    first.stableId,
+  );
+});
+
+test("content changes the fingerprint and synthetic stable ID", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    content: "first",
+    ordinal: 0,
+  });
+  const changed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    content: "second",
+    ordinal: 0,
+  });
+
+  assert.notEqual(first.fingerprint, changed.fingerprint);
+  assert.notEqual(first.stableId, changed.stableId);
+});
+
+test("ordinal changes only the synthetic stable ID", () => {
+  const input = {
+    sessionId: "session-1",
+    kind: "assistant",
+    content: { text: "same content" },
+  };
+  const first = createContextItemIdentity({ ...input, ordinal: 0 });
+  const second = createContextItemIdentity({ ...input, ordinal: 1 });
+
+  assert.equal(first.fingerprint, second.fingerprint);
+  assert.notEqual(first.stableId, second.stableId);
+});
+
+test("Claude full-message replay keeps the same synthetic identity", () => {
+  const first = createContextItemIdentity({
+    sessionId: "claude-session",
+    kind: "user",
+    role: "user",
+    content: [
+      { type: "text", text: "summarize" },
+      { type: "tool_result", tool_use_id: "tool-1", content: "result" },
+    ],
+    ordinal: 4,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "claude-session",
+    kind: "user",
+    role: "user",
+    content: [
+      { text: "summarize", type: "text" },
+      { content: "result", tool_use_id: "tool-1", type: "tool_result" },
+    ],
+    ordinal: 4,
+  });
+
+  assert.deepEqual(first, replayed);
+});
+
+test("Codex journal replay keeps native state-event identity", () => {
+  const first = createContextItemIdentity({
+    sessionId: "codex-session",
+    kind: "assistant",
+    role: "assistant",
+    nativeItemId: "item-message-1",
+    content: { type: "message", content: [{ type: "output_text", text: "done" }] },
+    ordinal: 5,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "codex-session",
+    kind: "assistant",
+    role: "assistant",
+    nativeItemId: "item-message-1",
+    content: { content: [{ text: "done", type: "output_text" }], type: "message" },
+    ordinal: 5,
+  });
+
+  assert.equal(first.source, "native_item_id");
+  assert.deepEqual(first, replayed);
+});
+
+test("normalization rejects non-JSON and cyclic content", () => {
+  const cyclic: { self?: unknown } = {};
+  cyclic.self = cyclic;
+
+  assert.throws(
+    () => normalizeContextItemContent({ missing: undefined }),
+    /JSON-compatible/,
+  );
+  assert.throws(
+    () => normalizeContextItemContent({ value: Number.POSITIVE_INFINITY }),
+    /finite numbers/,
+  );
+  assert.throws(
+    () => normalizeContextItemContent(cyclic),
+    /must not contain cycles/,
+  );
+});
+
+test("synthetic identity rejects an invalid ordinal", () => {
+  assert.throws(
+    () => createContextItemIdentity({
+      sessionId: "session-1",
+      kind: "user",
+      content: "hello",
+      ordinal: -1,
+    }),
+    /non-negative safe integer/,
+  );
+});
+
+test("fingerprints are independent of session and ordinal", () => {
+  const fingerprint = createContextItemFingerprint({
+    kind: "user",
+    role: "user",
+    content: { text: "hello" },
+  });
+  const identity = createContextItemIdentity({
+    sessionId: "another-session",
+    kind: "user",
+    role: "user",
+    content: { text: "hello" },
+    ordinal: 42,
+  });
+
+  assert.equal(identity.fingerprint, fingerprint);
+});

--- a/components/packages/foundation/history/tsconfig.json
+++ b/components/packages/foundation/history/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ]
 }


### PR DESCRIPTION
 ## Summary

  - Add deterministic shared context item IDs and content fingerprints.
  - Prefer native item IDs, then call IDs, with a synthetic fallback.
  - Canonicalize JSON content before SHA-256 fingerprinting.
  - Export the new identity API from `@lightmem2/history`.
  - Add replay and validation coverage for Claude and Codex scenarios.

  ## Validation

  - `corepack pnpm --dir components/packages/foundation/history test`
    - 11 tests passed
  - `corepack pnpm --dir components/packages/foundation/history typecheck`
  - `corepack pnpm check:boundaries`
  - `corepack pnpm -r typecheck`
  - `git diff --check`

  ## Scope

  This PR implements the shared FND-02 stable item ID foundation. It does not modify Host-specific adapters.
