### PR TITLE
 feat(context-rewrite): add revision revalidation

### DIFF
--- a/components/packages/foundation/history/package.json
+++ b/components/packages/foundation/history/package.json
@@ -10,7 +10,8 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "@lightmem2/kernel": "workspace:*"

--- a/components/packages/foundation/history/src/context-item-id.ts
+++ b/components/packages/foundation/history/src/context-item-id.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+
+export const CONTEXT_ITEM_ID_ALGORITHM_VERSION = 1 as const;
+
+export type ContextItemIdentitySource =
+  | "native_item_id"
+  | "call_id"
+  | "synthetic";
+
+export type ContextItemIdentityInput = {
+  sessionId: string;
+  kind: string;
+  role?: string;
+  nativeItemId?: string;
+  callId?: string;
+  content: unknown;
+  ordinal: number;
+};
+
+export type ContextItemFingerprintInput = Pick<
+  ContextItemIdentityInput,
+  "kind" | "role" | "content"
+>;
+
+export type ContextItemIdentity = {
+  stableId: string;
+  fingerprint: string;
+  source: ContextItemIdentitySource;
+};
+
+function canonicalJson(value: unknown, ancestors: Set<object>): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("context item content must contain finite numbers");
+    return JSON.stringify(value);
+  }
+  if (typeof value !== "object") {
+    throw new TypeError("context item content must be JSON-compatible");
+  }
+  if (ancestors.has(value)) throw new TypeError("context item content must not contain cycles");
+
+  ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return `[${Array.from(value, (item) => canonicalJson(item, ancestors)).join(",")}]`;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("context item content must contain plain objects");
+    }
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throw new TypeError("context item content must not contain symbol keys");
+    }
+
+    const object = value as Record<string, unknown>;
+    const entries = Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key], ancestors)}`);
+    return `{${entries.join(",")}}`;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function requiredIdentityPart(value: string, name: string): string {
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${name} must not be empty`);
+  return normalized;
+}
+
+function optionalIdentityPart(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function sha256(value: unknown): string {
+  return createHash("sha256")
+    .update(normalizeContextItemContent(value))
+    .digest("hex");
+}
+
+export function normalizeContextItemContent(content: unknown): string {
+  return canonicalJson(content, new Set<object>());
+}
+
+export function createContextItemFingerprint(
+  input: ContextItemFingerprintInput,
+): string {
+  const kind = requiredIdentityPart(input.kind, "kind").toLowerCase();
+  const role = optionalIdentityPart(input.role)?.toLowerCase();
+  const digest = sha256({
+    algorithmVersion: CONTEXT_ITEM_ID_ALGORITHM_VERSION,
+    content: normalizeContextItemContent(input.content),
+    kind,
+    role: role ?? null,
+  });
+  return `ctxfp-v${CONTEXT_ITEM_ID_ALGORITHM_VERSION}-${digest}`;
+}
+
+export function createContextItemIdentity(
+  input: ContextItemIdentityInput,
+): ContextItemIdentity {
+  const sessionId = requiredIdentityPart(input.sessionId, "sessionId");
+  const kind = requiredIdentityPart(input.kind, "kind").toLowerCase();
+  const role = optionalIdentityPart(input.role)?.toLowerCase();
+  const nativeItemId = optionalIdentityPart(input.nativeItemId);
+  const callId = optionalIdentityPart(input.callId);
+  const fingerprint = createContextItemFingerprint({
+    kind,
+    role,
+    content: input.content,
+  });
+
+  let source: ContextItemIdentitySource;
+  let identityValue: string | number;
+  if (nativeItemId) {
+    source = "native_item_id";
+    identityValue = nativeItemId;
+  } else if (callId) {
+    source = "call_id";
+    identityValue = callId;
+  } else {
+    if (!Number.isSafeInteger(input.ordinal) || input.ordinal < 0) {
+      throw new TypeError("ordinal must be a non-negative safe integer");
+    }
+    source = "synthetic";
+    identityValue = input.ordinal;
+  }
+
+  const digest = sha256({
+    algorithmVersion: CONTEXT_ITEM_ID_ALGORITHM_VERSION,
+    fingerprint: source === "synthetic" ? fingerprint : null,
+    identityValue,
+    kind,
+    sessionId,
+    source,
+  });
+  return {
+    stableId: `ctx-v${CONTEXT_ITEM_ID_ALGORITHM_VERSION}-${digest}`,
+    fingerprint,
+    source,
+  };
+}
+
+export function createStableContextItemId(
+  input: ContextItemIdentityInput,
+): string {
+  return createContextItemIdentity(input).stableId;
+}

--- a/components/packages/foundation/history/src/context-revision.ts
+++ b/components/packages/foundation/history/src/context-revision.ts
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+
+import { normalizeContextItemContent } from "./context-item-id.js";
+
+export const CONTEXT_REVISION_ALGORITHM_VERSION = 1 as const;
+
+export type ContextRevisionItem = {
+  stableId: string;
+  fingerprint: string;
+};
+
+function requiredRevisionPart(value: string, name: string, index: number): string {
+  if (!value.trim()) {
+    throw new TypeError(`context revision item ${index} ${name} must not be empty`);
+  }
+  return value;
+}
+
+export function createContextRevision(
+  items: readonly ContextRevisionItem[],
+): string {
+  const revisionItems = items.map((item, index) => ({
+    stableId: requiredRevisionPart(item.stableId, "stableId", index),
+    fingerprint: requiredRevisionPart(item.fingerprint, "fingerprint", index),
+  }));
+  const digest = createHash("sha256")
+    .update(normalizeContextItemContent({
+      algorithmVersion: CONTEXT_REVISION_ALGORITHM_VERSION,
+      items: revisionItems,
+    }))
+    .digest("hex");
+  return `ctxrev-v${CONTEXT_REVISION_ALGORITHM_VERSION}-${digest}`;
+}

--- a/components/packages/foundation/history/src/index.ts
+++ b/components/packages/foundation/history/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./types.js";
 export * from "./page-out-types.js";
 export * from "./context-item-id.js";
+export * from "./context-revision.js";
 export * from "./canonical-state.js";
 export * from "./canonical-anchors.js";
 export * from "./canonical-rewrite.js";

--- a/components/packages/foundation/history/src/index.ts
+++ b/components/packages/foundation/history/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./types.js";
 export * from "./page-out-types.js";
+export * from "./context-item-id.js";
 export * from "./canonical-state.js";
 export * from "./canonical-anchors.js";
 export * from "./canonical-rewrite.js";

--- a/components/packages/foundation/history/tests/context-item-id.test.ts
+++ b/components/packages/foundation/history/tests/context-item-id.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONTEXT_ITEM_ID_ALGORITHM_VERSION,
+  createContextItemFingerprint,
+  createContextItemIdentity,
+  createStableContextItemId,
+  normalizeContextItemContent,
+} from "../src/index.js";
+
+test("context item ID algorithm version is locked to 1", () => {
+  assert.equal(CONTEXT_ITEM_ID_ALGORITHM_VERSION, 1);
+});
+
+test("native item ID takes priority over call ID and mutable content", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "assistant",
+    nativeItemId: "item-1",
+    callId: "call-1",
+    content: { text: "before" },
+    ordinal: 0,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "assistant",
+    nativeItemId: "item-1",
+    callId: "call-changed",
+    content: { text: "after" },
+    ordinal: 99,
+  });
+
+  assert.equal(first.source, "native_item_id");
+  assert.equal(first.stableId, replayed.stableId);
+  assert.notEqual(first.fingerprint, replayed.fingerprint);
+});
+
+test("call ID is the stable fallback when no native item ID exists", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "tool_result",
+    callId: "call-1",
+    content: { output: "before" },
+    ordinal: 2,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "tool_result",
+    callId: "call-1",
+    content: { output: "after" },
+    ordinal: 20,
+  });
+
+  assert.equal(first.source, "call_id");
+  assert.equal(first.stableId, replayed.stableId);
+  assert.notEqual(first.fingerprint, replayed.fingerprint);
+});
+
+test("synthetic IDs are deterministic across object key order", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    role: "user",
+    content: { text: "hello", metadata: { a: 1, b: 2 } },
+    ordinal: 3,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    role: "user",
+    content: { metadata: { b: 2, a: 1 }, text: "hello" },
+    ordinal: 3,
+  });
+
+  assert.equal(first.source, "synthetic");
+  assert.deepEqual(first, replayed);
+  assert.equal(
+    createStableContextItemId({
+      sessionId: "session-1",
+      kind: "user",
+      role: "user",
+      content: { text: "hello", metadata: { a: 1, b: 2 } },
+      ordinal: 3,
+    }),
+    first.stableId,
+  );
+});
+
+test("content changes the fingerprint and synthetic stable ID", () => {
+  const first = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    content: "first",
+    ordinal: 0,
+  });
+  const changed = createContextItemIdentity({
+    sessionId: "session-1",
+    kind: "user",
+    content: "second",
+    ordinal: 0,
+  });
+
+  assert.notEqual(first.fingerprint, changed.fingerprint);
+  assert.notEqual(first.stableId, changed.stableId);
+});
+
+test("ordinal changes only the synthetic stable ID", () => {
+  const input = {
+    sessionId: "session-1",
+    kind: "assistant",
+    content: { text: "same content" },
+  };
+  const first = createContextItemIdentity({ ...input, ordinal: 0 });
+  const second = createContextItemIdentity({ ...input, ordinal: 1 });
+
+  assert.equal(first.fingerprint, second.fingerprint);
+  assert.notEqual(first.stableId, second.stableId);
+});
+
+test("Claude full-message replay keeps the same synthetic identity", () => {
+  const first = createContextItemIdentity({
+    sessionId: "claude-session",
+    kind: "user",
+    role: "user",
+    content: [
+      { type: "text", text: "summarize" },
+      { type: "tool_result", tool_use_id: "tool-1", content: "result" },
+    ],
+    ordinal: 4,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "claude-session",
+    kind: "user",
+    role: "user",
+    content: [
+      { text: "summarize", type: "text" },
+      { content: "result", tool_use_id: "tool-1", type: "tool_result" },
+    ],
+    ordinal: 4,
+  });
+
+  assert.deepEqual(first, replayed);
+});
+
+test("Codex journal replay keeps native state-event identity", () => {
+  const first = createContextItemIdentity({
+    sessionId: "codex-session",
+    kind: "assistant",
+    role: "assistant",
+    nativeItemId: "item-message-1",
+    content: { type: "message", content: [{ type: "output_text", text: "done" }] },
+    ordinal: 5,
+  });
+  const replayed = createContextItemIdentity({
+    sessionId: "codex-session",
+    kind: "assistant",
+    role: "assistant",
+    nativeItemId: "item-message-1",
+    content: { content: [{ text: "done", type: "output_text" }], type: "message" },
+    ordinal: 5,
+  });
+
+  assert.equal(first.source, "native_item_id");
+  assert.deepEqual(first, replayed);
+});
+
+test("normalization rejects non-JSON and cyclic content", () => {
+  const cyclic: { self?: unknown } = {};
+  cyclic.self = cyclic;
+
+  assert.throws(
+    () => normalizeContextItemContent({ missing: undefined }),
+    /JSON-compatible/,
+  );
+  assert.throws(
+    () => normalizeContextItemContent({ value: Number.POSITIVE_INFINITY }),
+    /finite numbers/,
+  );
+  assert.throws(
+    () => normalizeContextItemContent(cyclic),
+    /must not contain cycles/,
+  );
+});
+
+test("synthetic identity rejects an invalid ordinal", () => {
+  assert.throws(
+    () => createContextItemIdentity({
+      sessionId: "session-1",
+      kind: "user",
+      content: "hello",
+      ordinal: -1,
+    }),
+    /non-negative safe integer/,
+  );
+});
+
+test("fingerprints are independent of session and ordinal", () => {
+  const fingerprint = createContextItemFingerprint({
+    kind: "user",
+    role: "user",
+    content: { text: "hello" },
+  });
+  const identity = createContextItemIdentity({
+    sessionId: "another-session",
+    kind: "user",
+    role: "user",
+    content: { text: "hello" },
+    ordinal: 42,
+  });
+
+  assert.equal(identity.fingerprint, fingerprint);
+});

--- a/components/packages/foundation/history/tests/context-revision.test.ts
+++ b/components/packages/foundation/history/tests/context-revision.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONTEXT_REVISION_ALGORITHM_VERSION,
+  createContextRevision,
+} from "../src/index.js";
+
+const items = [
+  { stableId: "item-1", fingerprint: "fp-1" },
+  { stableId: "item-2", fingerprint: "fp-2" },
+] as const;
+
+test("context revision algorithm version is locked to 1", () => {
+  assert.equal(CONTEXT_REVISION_ALGORITHM_VERSION, 1);
+});
+
+test("ordered stable IDs and fingerprints produce a deterministic revision", () => {
+  const first = createContextRevision(items);
+  const replayed = createContextRevision(items.map((item) => ({ ...item })));
+
+  assert.match(first, /^ctxrev-v1-[0-9a-f]{64}$/);
+  assert.equal(first, replayed);
+});
+
+test("item order changes the revision", () => {
+  assert.notEqual(
+    createContextRevision(items),
+    createContextRevision([...items].reverse()),
+  );
+});
+
+test("a changed fingerprint changes the revision", () => {
+  assert.notEqual(
+    createContextRevision(items),
+    createContextRevision([
+      items[0],
+      { ...items[1], fingerprint: "fp-2-changed" },
+    ]),
+  );
+});
+
+test("volatile item metadata is excluded from the revision", () => {
+  const first = [
+    { ...items[0], timestamp: "2026-07-30T00:00:00.000Z", requestId: "req-1" },
+    { ...items[1], timestamp: "2026-07-30T00:00:01.000Z", requestId: "req-1" },
+  ];
+  const replayed = [
+    { ...items[0], timestamp: "2026-07-31T00:00:00.000Z", requestId: "req-2" },
+    { ...items[1], timestamp: "2026-07-31T00:00:01.000Z", requestId: "req-2" },
+  ];
+
+  assert.equal(createContextRevision(first), createContextRevision(replayed));
+});
+
+test("empty item identity fields are rejected", () => {
+  assert.throws(
+    () => createContextRevision([{ stableId: " ", fingerprint: "fp-1" }]),
+    /stableId must not be empty/,
+  );
+  assert.throws(
+    () => createContextRevision([{ stableId: "item-1", fingerprint: "" }]),
+    /fingerprint must not be empty/,
+  );
+});

--- a/components/packages/foundation/history/tsconfig.json
+++ b/components/packages/foundation/history/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../../../tsconfig.base.json",
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+    "tests/**/*.ts"
+  ]
 }

--- a/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
@@ -1,1 +1,2 @@
 export * from "./contracts.js";
+export * from "./revalidation.js";

--- a/components/packages/foundation/host-adapter/src/context-rewrite/revalidation.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/revalidation.ts
@@ -1,0 +1,104 @@
+import type {
+  ContextMutationPlan,
+  ContextRewriteValidation,
+  ModelContextSnapshot,
+} from "./contracts.js";
+
+export type ContextMutationRevalidationParams<
+  TAdapterMetadata = never,
+  TAdapterReplacementItem = never,
+> = {
+  snapshot: ModelContextSnapshot<TAdapterMetadata>;
+  plan: ContextMutationPlan<TAdapterReplacementItem>;
+};
+
+function uniqueOperationIds<TAdapterReplacementItem>(
+  plan: ContextMutationPlan<TAdapterReplacementItem>,
+): string[] {
+  return [...new Set(plan.operations.map((operation) => operation.id))];
+}
+
+/**
+ * Revalidates each operation against the current snapshot. Revision drift is
+ * safe when targets can still be located; only unsafe operations are deferred.
+ */
+export function revalidateContextMutationPlan<
+  TAdapterMetadata = never,
+  TAdapterReplacementItem = never,
+>(
+  params: ContextMutationRevalidationParams<
+    TAdapterMetadata,
+    TAdapterReplacementItem
+  >,
+): ContextRewriteValidation {
+  const { snapshot, plan } = params;
+  const reasons: string[] = [];
+  const operationIds = uniqueOperationIds(plan);
+
+  if (plan.hostId !== snapshot.hostId) reasons.push("host_id_mismatch");
+  if (plan.sessionId !== snapshot.sessionId) reasons.push("session_id_mismatch");
+  if (plan.baseRevision !== snapshot.revision) reasons.push("revision_mismatch");
+
+  if (reasons.includes("host_id_mismatch") || reasons.includes("session_id_mismatch")) {
+    return {
+      valid: false,
+      applicableOperationIds: [],
+      deferredOperationIds: operationIds,
+      reasons,
+    };
+  }
+
+  const itemCounts = new Map<string, number>();
+  for (const item of snapshot.items) {
+    itemCounts.set(item.stableId, (itemCounts.get(item.stableId) ?? 0) + 1);
+  }
+
+  const operationIdCounts = new Map<string, number>();
+  for (const operation of plan.operations) {
+    operationIdCounts.set(
+      operation.id,
+      (operationIdCounts.get(operation.id) ?? 0) + 1,
+    );
+  }
+
+  const applicableOperationIds: string[] = [];
+  const deferredOperationIds: string[] = [];
+  for (const operation of plan.operations) {
+    if (applicableOperationIds.includes(operation.id)
+      || deferredOperationIds.includes(operation.id)) {
+      continue;
+    }
+    if ((operationIdCounts.get(operation.id) ?? 0) > 1) {
+      deferredOperationIds.push(operation.id);
+      reasons.push(`operation:${operation.id}:duplicate_id`);
+      continue;
+    }
+    if (operation.targetItemIds.length === 0) {
+      deferredOperationIds.push(operation.id);
+      reasons.push(`operation:${operation.id}:targets_empty`);
+      continue;
+    }
+
+    const targetCounts = operation.targetItemIds.map(
+      (targetItemId) => itemCounts.get(targetItemId) ?? 0,
+    );
+    if (targetCounts.some((count) => count === 0)) {
+      deferredOperationIds.push(operation.id);
+      reasons.push(`operation:${operation.id}:target_missing`);
+      continue;
+    }
+    if (targetCounts.some((count) => count > 1)) {
+      deferredOperationIds.push(operation.id);
+      reasons.push(`operation:${operation.id}:target_ambiguous`);
+      continue;
+    }
+    applicableOperationIds.push(operation.id);
+  }
+
+  return {
+    valid: true,
+    applicableOperationIds,
+    deferredOperationIds,
+    reasons,
+  };
+}

--- a/components/packages/foundation/host-adapter/tests/context-rewrite-revalidation.test.ts
+++ b/components/packages/foundation/host-adapter/tests/context-rewrite-revalidation.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  revalidateContextMutationPlan,
+  type ContextMutationPlan,
+  type ModelContextSnapshot,
+} from "../src/index.js";
+
+const snapshot: ModelContextSnapshot = {
+  schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  hostId: "test-host",
+  sessionId: "session-1",
+  revision: "ctxrev-current",
+  items: [
+    {
+      stableId: "item-1",
+      kind: "user",
+      fingerprint: "fp-1",
+      chars: 10,
+    },
+    {
+      stableId: "item-2",
+      kind: "assistant",
+      fingerprint: "fp-2",
+      chars: 20,
+    },
+  ],
+};
+
+function createPlan(
+  operations: ContextMutationPlan["operations"],
+  overrides: Partial<ContextMutationPlan> = {},
+): ContextMutationPlan {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: "plan-1",
+    hostId: snapshot.hostId,
+    sessionId: snapshot.sessionId,
+    baseRevision: snapshot.revision,
+    sourceModuleId: "eviction",
+    operations,
+    createdAt: "2026-07-31T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function removeOperation(id: string, targetItemIds: string[]) {
+  return {
+    id,
+    type: "remove" as const,
+    targetItemIds,
+    rationale: "evicted task",
+    estimatedSavedChars: 10,
+  };
+}
+
+test("matching revision applies operations whose targets exist", () => {
+  const validation = revalidateContextMutationPlan({
+    snapshot,
+    plan: createPlan([removeOperation("op-1", ["item-1"])]),
+  });
+
+  assert.deepEqual(validation, {
+    valid: true,
+    applicableOperationIds: ["op-1"],
+    deferredOperationIds: [],
+    reasons: [],
+  });
+});
+
+test("revision mismatch keeps relocatable operations applicable", () => {
+  const validation = revalidateContextMutationPlan({
+    snapshot,
+    plan: createPlan(
+      [removeOperation("op-1", ["item-1"])],
+      { baseRevision: "ctxrev-stale" },
+    ),
+  });
+
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.applicableOperationIds, ["op-1"]);
+  assert.deepEqual(validation.deferredOperationIds, []);
+  assert.deepEqual(validation.reasons, ["revision_mismatch"]);
+});
+
+test("missing targets defer only operations that cannot be relocated", () => {
+  const validation = revalidateContextMutationPlan({
+    snapshot,
+    plan: createPlan(
+      [
+        removeOperation("op-applicable", ["item-1"]),
+        removeOperation("op-missing", ["item-missing"]),
+        removeOperation("op-atomic", ["item-2", "item-missing"]),
+      ],
+      { baseRevision: "ctxrev-stale" },
+    ),
+  });
+
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.applicableOperationIds, ["op-applicable"]);
+  assert.deepEqual(validation.deferredOperationIds, ["op-missing", "op-atomic"]);
+  assert.deepEqual(validation.reasons, [
+    "revision_mismatch",
+    "operation:op-missing:target_missing",
+    "operation:op-atomic:target_missing",
+  ]);
+});
+
+test("a fully deferred revalidation remains a safe no-op", () => {
+  const validation = revalidateContextMutationPlan({
+    snapshot,
+    plan: createPlan(
+      [removeOperation("op-missing", ["item-missing"])],
+      { baseRevision: "ctxrev-stale" },
+    ),
+  });
+
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.applicableOperationIds, []);
+  assert.deepEqual(validation.deferredOperationIds, ["op-missing"]);
+});
+
+test("ambiguous stable IDs cannot be relocated", () => {
+  const validation = revalidateContextMutationPlan({
+    snapshot: { ...snapshot, items: [...snapshot.items, snapshot.items[0]!] },
+    plan: createPlan([removeOperation("op-1", ["item-1"])]),
+  });
+
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.applicableOperationIds, []);
+  assert.deepEqual(validation.deferredOperationIds, ["op-1"]);
+  assert.deepEqual(validation.reasons, ["operation:op-1:target_ambiguous"]);
+});
+
+test("duplicate operation IDs and empty targets are deferred", () => {
+  const validation = revalidateContextMutationPlan({
+    snapshot,
+    plan: createPlan([
+      removeOperation("op-duplicate", ["item-1"]),
+      removeOperation("op-duplicate", ["item-2"]),
+      removeOperation("op-empty", []),
+    ]),
+  });
+
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.applicableOperationIds, []);
+  assert.deepEqual(validation.deferredOperationIds, ["op-duplicate", "op-empty"]);
+  assert.deepEqual(validation.reasons, [
+    "operation:op-duplicate:duplicate_id",
+    "operation:op-empty:targets_empty",
+  ]);
+});
+
+test("host or session mismatch invalidates and defers the whole plan", () => {
+  const operations = [
+    removeOperation("op-1", ["item-1"]),
+    removeOperation("op-2", ["item-2"]),
+  ];
+  const validation = revalidateContextMutationPlan({
+    snapshot,
+    plan: createPlan(operations, {
+      hostId: "other-host",
+      sessionId: "other-session",
+      baseRevision: "ctxrev-stale",
+    }),
+  });
+
+  assert.equal(validation.valid, false);
+  assert.deepEqual(validation.applicableOperationIds, []);
+  assert.deepEqual(validation.deferredOperationIds, ["op-1", "op-2"]);
+  assert.deepEqual(validation.reasons, [
+    "host_id_mismatch",
+    "session_id_mismatch",
+    "revision_mismatch",
+  ]);
+});


### PR DESCRIPTION
  > [!IMPORTANT]
  > This is a stacked draft PR that depends on FND-02: <FND-02 PR URL>
  >
  > Dependency commit: `ab1a1d0657f2f29f64a45a8e00d6996057a6fb21`
  >
  > FND-03 commit: `c016b4a99d61d023a28fddf33bd8e54caec9ccaa`
  >
  > Please merge FND-02 before merging this PR. Until then, the diff also includes the FND-02 changes.

  ## Summary

  - Add versioned context revisions based on ordered stable item IDs and fingerprints.
  - Exclude volatile item metadata from revision calculation.
  - Add mutation plan revalidation when `baseRevision` differs from the current snapshot.
  - Keep relocatable operations applicable after revision drift.
  - Defer missing, ambiguous, empty-target, or duplicate-ID operations.
  - Reject plans belonging to a different Host or session.

  ## Validation semantics

  - Revision mismatch does not invalidate the whole plan.
  - Each operation is revalidated independently.
  - Multi-target operations are atomic and deferred when any target cannot be relocated.
  - A fully deferred plan remains a valid, safe no-op.
  - Host or session mismatch sets `valid` to `false`.

  ## Validation

  - `corepack pnpm --dir components/packages/foundation/history test`
    - 17 tests passed
  - `corepack pnpm --dir components/packages/foundation/history typecheck`
  - `corepack pnpm --dir components/packages/foundation/host-adapter test`
    - 23 tests passed
  - `corepack pnpm --dir components/packages/foundation/host-adapter typecheck`
  - `corepack pnpm check:boundaries`
  - `corepack pnpm -r typecheck`
  - `git diff --check`

  ## Scope

  This PR implements FND-03 revision calculation and shared mutation plan revalidation. It does not modify Claude,
  Codex, or OpenClaw adapters.