### PR TITLE
feat(context-rewrite): add persistent plan store

### DIFF
--- a/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
@@ -1,2 +1,3 @@
 export * from "./contracts.js";
 export * from "./revalidation.js";
+export * from "./plan-store.js";

--- a/components/packages/foundation/host-adapter/src/context-rewrite/plan-store.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/plan-store.ts
@@ -1,0 +1,789 @@
+import { createHash, randomUUID } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { hostname } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { writeJsonFileAtomic } from "../state/file-store.js";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextMutationOperation,
+  type ContextMutationPlan,
+} from "./contracts.js";
+
+export const CONTEXT_MUTATION_PLAN_STORE_SCHEMA_VERSION = 1 as const;
+
+export type ContextMutationPlanStatus = "active" | "applied" | "failed";
+
+export type StoredContextMutationPlan = {
+  schemaVersion: typeof CONTEXT_MUTATION_PLAN_STORE_SCHEMA_VERSION;
+  storedAt: string;
+  plan: ContextMutationPlan;
+};
+
+export type ContextMutationPlanStoreWriteResult = {
+  outcome: "stored" | "transitioned" | "unchanged" | "missing" | "bypassed";
+  status?: ContextMutationPlanStatus;
+  bypassed: boolean;
+  reasons: string[];
+};
+
+export type ContextMutationPlanStoreReadResult = {
+  plans: ContextMutationPlan[];
+  bypassed: boolean;
+  reasons: string[];
+  quarantinedFileCount: number;
+};
+
+export type ContextMutationPlanStoreLockOptions = {
+  lockTimeoutMs?: number;
+  lockRetryMs?: number;
+  lockStaleMs?: number;
+};
+
+type PlanStoreSessionLock = {
+  release(): Promise<void>;
+};
+
+type LockOwner = {
+  token: string;
+  pid: number;
+  hostname: string;
+  createdAt: string;
+};
+
+type StoredPlanReadResult =
+  | { kind: "ok"; entry: StoredContextMutationPlan }
+  | { kind: "missing" }
+  | { kind: "corrupt" }
+  | { kind: "unsupported_schema" }
+  | { kind: "read_error" };
+
+type LocatedPlan = {
+  status: ContextMutationPlanStatus;
+  path: string;
+  entry: StoredContextMutationPlan;
+};
+
+type LocatePlanResult =
+  | { kind: "missing" }
+  | { kind: "found"; located: LocatedPlan }
+  | { kind: "bypassed"; reasons: string[]; quarantinedFileCount: number };
+
+const PLAN_STATUSES: readonly ContextMutationPlanStatus[] = [
+  "active",
+  "applied",
+  "failed",
+];
+const DEFAULT_LOCK_TIMEOUT_MS = 1_000;
+const DEFAULT_LOCK_RETRY_MS = 10;
+const DEFAULT_LOCK_STALE_MS = 30 * 60 * 1_000;
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && Boolean(value.trim());
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isOptionalStringArray(value: unknown): value is string[] | undefined {
+  return value === undefined || isStringArray(value);
+}
+
+function isFingerprintMap(value: unknown): value is Record<string, string> {
+  return isRecord(value)
+    && Object.entries(value).every(
+      ([key, fingerprint]) => Boolean(key.trim()) && isNonBlankString(fingerprint),
+    );
+}
+
+function isPersistableOperation(
+  value: unknown,
+): value is ContextMutationOperation {
+  if (!isRecord(value)) return false;
+  return typeof value.id === "string"
+    && (value.type === "remove" || value.type === "replace")
+    && isStringArray(value.targetItemIds)
+    && (
+      value.targetItemFingerprints === undefined
+      || isFingerprintMap(value.targetItemFingerprints)
+    )
+    && !("replacementItems" in value)
+    && isOptionalStringArray(value.taskIds)
+    && typeof value.rationale === "string"
+    && typeof value.estimatedSavedChars === "number"
+    && Number.isFinite(value.estimatedSavedChars)
+    && value.estimatedSavedChars >= 0
+    && isOptionalStringArray(value.archiveRefs);
+}
+
+function isPersistablePlan(value: unknown): value is ContextMutationPlan {
+  if (!isRecord(value)) return false;
+  return value.schemaVersion === MODEL_CONTEXT_REWRITE_SCHEMA_VERSION
+    && isNonBlankString(value.planId)
+    && isNonBlankString(value.hostId)
+    && isNonBlankString(value.sessionId)
+    && isNonBlankString(value.baseRevision)
+    && isNonBlankString(value.sourceModuleId)
+    && (value.sourcePresetId === undefined || typeof value.sourcePresetId === "string")
+    && Array.isArray(value.operations)
+    && value.operations.every(isPersistableOperation)
+    && isNonBlankString(value.createdAt);
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error
+    && typeof error === "object"
+    && "code" in error
+    && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) === "EPERM";
+  }
+}
+
+function asLockOwner(value: unknown): LockOwner | undefined {
+  if (!isRecord(value)) return undefined;
+  return isNonBlankString(value.token)
+    && typeof value.pid === "number"
+    && Number.isInteger(value.pid)
+    && value.pid > 0
+    && isNonBlankString(value.hostname)
+    && timestampMs(value.createdAt) !== undefined
+    ? value as LockOwner
+    : undefined;
+}
+
+function requireNonBlank(value: string, name: string): string | undefined {
+  return value.trim() ? undefined : `${name}_empty`;
+}
+
+export function contextMutationPlanSessionRoot(
+  stateDir: string,
+  sessionId: string,
+): string {
+  return join(
+    stateDir,
+    "context-rewrite",
+    "sessions",
+    `session-${sha256(sessionId)}`,
+  );
+}
+
+export function contextMutationPlanStatusDir(
+  stateDir: string,
+  sessionId: string,
+  status: ContextMutationPlanStatus,
+): string {
+  return join(contextMutationPlanSessionRoot(stateDir, sessionId), "plans", status);
+}
+
+export function contextMutationPlanQuarantineDir(
+  stateDir: string,
+  sessionId: string,
+  status: ContextMutationPlanStatus,
+): string {
+  return join(
+    contextMutationPlanSessionRoot(stateDir, sessionId),
+    "plans",
+    "quarantine",
+    status,
+  );
+}
+
+export function contextMutationPlanFilePath(
+  stateDir: string,
+  sessionId: string,
+  status: ContextMutationPlanStatus,
+  planId: string,
+): string {
+  return join(
+    contextMutationPlanStatusDir(stateDir, sessionId, status),
+    `plan-${sha256(planId)}.json`,
+  );
+}
+
+export function contextMutationPlanLockPath(
+  stateDir: string,
+  sessionId: string,
+): string {
+  return join(contextMutationPlanSessionRoot(stateDir, sessionId), "plan-store.lock");
+}
+
+async function readLockOwner(lockPath: string): Promise<LockOwner | undefined> {
+  try {
+    return asLockOwner(
+      JSON.parse(await readFile(join(lockPath, "owner.json"), "utf8")) as unknown,
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+async function lockIsStale(params: {
+  lockPath: string;
+  staleAfterMs: number;
+  nowMs: number;
+}): Promise<boolean> {
+  const owner = await readLockOwner(params.lockPath);
+  if (owner) {
+    if (owner.hostname === hostname()) return !isProcessAlive(owner.pid);
+    return params.nowMs - (timestampMs(owner.createdAt) ?? params.nowMs)
+      > params.staleAfterMs;
+  }
+  try {
+    const lockStat = await stat(params.lockPath);
+    return params.nowMs - lockStat.mtimeMs > params.staleAfterMs;
+  } catch {
+    return true;
+  }
+}
+
+async function acquireSessionLock(params: {
+  stateDir: string;
+  sessionId: string;
+  options?: ContextMutationPlanStoreLockOptions;
+}): Promise<PlanStoreSessionLock | undefined> {
+  const lockPath = contextMutationPlanLockPath(params.stateDir, params.sessionId);
+  const timeoutMs = Math.max(0, params.options?.lockTimeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS);
+  const retryMs = Math.max(1, params.options?.lockRetryMs ?? DEFAULT_LOCK_RETRY_MS);
+  const staleAfterMs = Math.max(1_000, params.options?.lockStaleMs ?? DEFAULT_LOCK_STALE_MS);
+  const deadline = Date.now() + timeoutMs;
+  await mkdir(dirname(lockPath), { recursive: true });
+
+  while (true) {
+    try {
+      await mkdir(lockPath);
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+      if (await lockIsStale({ lockPath, staleAfterMs, nowMs: Date.now() })) {
+        await rm(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) return undefined;
+      await delay(retryMs);
+      continue;
+    }
+
+    const owner: LockOwner = {
+      token: randomUUID(),
+      pid: process.pid,
+      hostname: hostname(),
+      createdAt: new Date().toISOString(),
+    };
+    try {
+      await writeFile(
+        join(lockPath, "owner.json"),
+        JSON.stringify(owner),
+        { encoding: "utf8", flag: "wx" },
+      );
+    } catch (error) {
+      await rm(lockPath, { recursive: true, force: true });
+      throw error;
+    }
+    return {
+      async release() {
+        try {
+          const current = await readLockOwner(lockPath);
+          if (current?.token === owner.token) {
+            await rm(lockPath, { recursive: true, force: true });
+          }
+        } catch {
+          // Leaving an uncertain lock is safer than deleting a new owner's lock.
+        }
+      },
+    };
+  }
+}
+
+async function readStoredPlanFile(params: {
+  path: string;
+  sessionId: string;
+}): Promise<StoredPlanReadResult> {
+  let raw: string;
+  try {
+    raw = await readFile(params.path, "utf8");
+  } catch (error) {
+    return errorCode(error) === "ENOENT" ? { kind: "missing" } : { kind: "read_error" };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return { kind: "corrupt" };
+  }
+  if (!isRecord(parsed)) return { kind: "corrupt" };
+  if (
+    typeof parsed.schemaVersion === "number"
+    && parsed.schemaVersion !== CONTEXT_MUTATION_PLAN_STORE_SCHEMA_VERSION
+  ) {
+    return { kind: "unsupported_schema" };
+  }
+  const rawPlan = parsed.plan;
+  if (
+    isRecord(rawPlan)
+    && typeof rawPlan.schemaVersion === "number"
+    && rawPlan.schemaVersion !== MODEL_CONTEXT_REWRITE_SCHEMA_VERSION
+  ) {
+    return { kind: "unsupported_schema" };
+  }
+  if (
+    parsed.schemaVersion !== CONTEXT_MUTATION_PLAN_STORE_SCHEMA_VERSION
+    || !isNonBlankString(parsed.storedAt)
+    || timestampMs(parsed.storedAt) === undefined
+    || !isPersistablePlan(rawPlan)
+    || rawPlan.sessionId !== params.sessionId
+    || basename(params.path) !== `plan-${sha256(rawPlan.planId)}.json`
+  ) {
+    return { kind: "corrupt" };
+  }
+  return {
+    kind: "ok",
+    entry: parsed as StoredContextMutationPlan,
+  };
+}
+
+async function quarantinePlanFile(params: {
+  path: string;
+  stateDir: string;
+  sessionId: string;
+  status: ContextMutationPlanStatus;
+}): Promise<boolean> {
+  try {
+    const quarantineDir = contextMutationPlanQuarantineDir(
+      params.stateDir,
+      params.sessionId,
+      params.status,
+    );
+    await mkdir(quarantineDir, { recursive: true });
+    await rename(
+      params.path,
+      join(
+        quarantineDir,
+        `${basename(params.path)}.${Date.now()}.${randomUUID()}.corrupt`,
+      ),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function locatePlanUnlocked(params: {
+  stateDir: string;
+  sessionId: string;
+  planId: string;
+}): Promise<LocatePlanResult> {
+  const located: LocatedPlan[] = [];
+  let quarantinedFileCount = 0;
+  const reasons: string[] = [];
+  for (const status of PLAN_STATUSES) {
+    const path = contextMutationPlanFilePath(
+      params.stateDir,
+      params.sessionId,
+      status,
+      params.planId,
+    );
+    const read = await readStoredPlanFile({ path, sessionId: params.sessionId });
+    if (read.kind === "missing") continue;
+    if (read.kind === "ok") {
+      located.push({ status, path, entry: read.entry });
+      continue;
+    }
+    if (read.kind === "corrupt") {
+      const quarantined = await quarantinePlanFile({
+        path,
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        status,
+      });
+      if (quarantined) quarantinedFileCount += 1;
+      reasons.push(quarantined ? "corrupt_plan_quarantined" : "corrupt_plan_quarantine_failed");
+    } else {
+      reasons.push(read.kind === "unsupported_schema" ? "unsupported_schema" : "plan_read_failed");
+    }
+  }
+  if (reasons.length > 0) {
+    return { kind: "bypassed", reasons, quarantinedFileCount };
+  }
+  if (located.length === 0) return { kind: "missing" };
+  if (located.length > 1) {
+    return {
+      kind: "bypassed",
+      reasons: ["plan_status_conflict"],
+      quarantinedFileCount: 0,
+    };
+  }
+  return { kind: "found", located: located[0]! };
+}
+
+function bypassedWrite(...reasons: string[]): ContextMutationPlanStoreWriteResult {
+  return {
+    outcome: "bypassed",
+    bypassed: true,
+    reasons,
+  };
+}
+
+export async function saveActiveContextMutationPlan(params: {
+  stateDir: string;
+  plan: ContextMutationPlan;
+  storedAt?: string;
+  lock?: ContextMutationPlanStoreLockOptions;
+}): Promise<ContextMutationPlanStoreWriteResult> {
+  const stateDirError = requireNonBlank(params.stateDir, "state_dir");
+  if (stateDirError) return bypassedWrite(stateDirError);
+  if (!isPersistablePlan(params.plan)) return bypassedWrite("invalid_plan");
+  const storedAt = params.storedAt ?? new Date().toISOString();
+  if (timestampMs(storedAt) === undefined) return bypassedWrite("stored_at_invalid");
+
+  let lock: PlanStoreSessionLock | undefined;
+  try {
+    lock = await acquireSessionLock({
+      stateDir: params.stateDir,
+      sessionId: params.plan.sessionId,
+      options: params.lock,
+    });
+    if (!lock) return bypassedWrite("session_lock_unavailable");
+
+    const existing = await locatePlanUnlocked({
+      stateDir: params.stateDir,
+      sessionId: params.plan.sessionId,
+      planId: params.plan.planId,
+    });
+    if (existing.kind === "bypassed") return bypassedWrite(...existing.reasons);
+    if (existing.kind === "found") {
+      return {
+        outcome: "unchanged",
+        status: existing.located.status,
+        bypassed: false,
+        reasons: [],
+      };
+    }
+
+    const path = contextMutationPlanFilePath(
+      params.stateDir,
+      params.plan.sessionId,
+      "active",
+      params.plan.planId,
+    );
+    await writeJsonFileAtomic(path, {
+      schemaVersion: CONTEXT_MUTATION_PLAN_STORE_SCHEMA_VERSION,
+      storedAt,
+      plan: params.plan,
+    } satisfies StoredContextMutationPlan);
+    return {
+      outcome: "stored",
+      status: "active",
+      bypassed: false,
+      reasons: [],
+    };
+  } catch {
+    return bypassedWrite("plan_store_write_failed");
+  } finally {
+    await lock?.release();
+  }
+}
+
+async function transitionContextMutationPlan(params: {
+  stateDir: string;
+  sessionId: string;
+  planId: string;
+  targetStatus: "applied" | "failed";
+  lock?: ContextMutationPlanStoreLockOptions;
+}): Promise<ContextMutationPlanStoreWriteResult> {
+  const inputErrors = [
+    requireNonBlank(params.stateDir, "state_dir"),
+    requireNonBlank(params.sessionId, "session_id"),
+    requireNonBlank(params.planId, "plan_id"),
+  ].filter((reason): reason is string => reason !== undefined);
+  if (inputErrors.length > 0) return bypassedWrite(...inputErrors);
+
+  let lock: PlanStoreSessionLock | undefined;
+  try {
+    lock = await acquireSessionLock({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      options: params.lock,
+    });
+    if (!lock) return bypassedWrite("session_lock_unavailable");
+
+    const existing = await locatePlanUnlocked(params);
+    if (existing.kind === "bypassed") return bypassedWrite(...existing.reasons);
+    if (existing.kind === "missing") {
+      return {
+        outcome: "missing",
+        bypassed: true,
+        reasons: ["plan_not_found"],
+      };
+    }
+    if (existing.located.status === params.targetStatus) {
+      return {
+        outcome: "unchanged",
+        status: params.targetStatus,
+        bypassed: false,
+        reasons: [],
+      };
+    }
+    if (existing.located.status !== "active") {
+      return bypassedWrite("plan_terminal_status_conflict");
+    }
+
+    const targetPath = contextMutationPlanFilePath(
+      params.stateDir,
+      params.sessionId,
+      params.targetStatus,
+      params.planId,
+    );
+    await mkdir(dirname(targetPath), { recursive: true });
+    await rename(existing.located.path, targetPath);
+    return {
+      outcome: "transitioned",
+      status: params.targetStatus,
+      bypassed: false,
+      reasons: [],
+    };
+  } catch {
+    return bypassedWrite("plan_store_transition_failed");
+  } finally {
+    await lock?.release();
+  }
+}
+
+export async function markContextMutationPlanApplied(params: {
+  stateDir: string;
+  sessionId: string;
+  planId: string;
+  lock?: ContextMutationPlanStoreLockOptions;
+}): Promise<ContextMutationPlanStoreWriteResult> {
+  return transitionContextMutationPlan({ ...params, targetStatus: "applied" });
+}
+
+export async function markContextMutationPlanFailed(params: {
+  stateDir: string;
+  sessionId: string;
+  planId: string;
+  lock?: ContextMutationPlanStoreLockOptions;
+}): Promise<ContextMutationPlanStoreWriteResult> {
+  return transitionContextMutationPlan({ ...params, targetStatus: "failed" });
+}
+
+async function loadStatusUnlocked(params: {
+  stateDir: string;
+  sessionId: string;
+  status: ContextMutationPlanStatus;
+}): Promise<ContextMutationPlanStoreReadResult> {
+  const dir = contextMutationPlanStatusDir(
+    params.stateDir,
+    params.sessionId,
+    params.status,
+  );
+  let names: string[];
+  try {
+    names = (await readdir(dir, { withFileTypes: true }))
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => entry.name)
+      .sort();
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return { plans: [], bypassed: false, reasons: [], quarantinedFileCount: 0 };
+    }
+    return {
+      plans: [],
+      bypassed: true,
+      reasons: ["plan_directory_read_failed"],
+      quarantinedFileCount: 0,
+    };
+  }
+
+  const plans: ContextMutationPlan[] = [];
+  const reasons: string[] = [];
+  let quarantinedFileCount = 0;
+  for (const name of names) {
+    const path = join(dir, name);
+    const read = await readStoredPlanFile({ path, sessionId: params.sessionId });
+    if (read.kind === "ok") {
+      plans.push(read.entry.plan);
+      continue;
+    }
+    if (read.kind === "corrupt") {
+      const quarantined = await quarantinePlanFile({
+        path,
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        status: params.status,
+      });
+      if (quarantined) quarantinedFileCount += 1;
+      reasons.push(quarantined ? "corrupt_plan_quarantined" : "corrupt_plan_quarantine_failed");
+    } else if (read.kind === "unsupported_schema") {
+      reasons.push("unsupported_schema");
+    } else {
+      reasons.push("plan_read_failed");
+    }
+  }
+
+  if (reasons.length > 0) {
+    return { plans: [], bypassed: true, reasons, quarantinedFileCount };
+  }
+  const uniquePlanIds = new Set(plans.map((plan) => plan.planId));
+  if (uniquePlanIds.size !== plans.length) {
+    return {
+      plans: [],
+      bypassed: true,
+      reasons: ["duplicate_plan_id"],
+      quarantinedFileCount,
+    };
+  }
+  plans.sort((left, right) =>
+    left.createdAt.localeCompare(right.createdAt)
+      || left.planId.localeCompare(right.planId));
+  return { plans, bypassed: false, reasons: [], quarantinedFileCount };
+}
+
+export async function loadContextMutationPlans(params: {
+  stateDir: string;
+  sessionId: string;
+  status: ContextMutationPlanStatus;
+  lock?: ContextMutationPlanStoreLockOptions;
+}): Promise<ContextMutationPlanStoreReadResult> {
+  const inputErrors = [
+    requireNonBlank(params.stateDir, "state_dir"),
+    requireNonBlank(params.sessionId, "session_id"),
+  ].filter((reason): reason is string => reason !== undefined);
+  if (inputErrors.length > 0) {
+    return {
+      plans: [],
+      bypassed: true,
+      reasons: inputErrors,
+      quarantinedFileCount: 0,
+    };
+  }
+
+  let lock: PlanStoreSessionLock | undefined;
+  try {
+    lock = await acquireSessionLock({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      options: params.lock,
+    });
+    if (!lock) {
+      return {
+        plans: [],
+        bypassed: true,
+        reasons: ["session_lock_unavailable"],
+        quarantinedFileCount: 0,
+      };
+    }
+    const loaded = await loadStatusUnlocked(params);
+    if (loaded.bypassed || params.status !== "active") return loaded;
+
+    for (const plan of loaded.plans) {
+      for (const terminalStatus of ["applied", "failed"] as const) {
+        const terminal = await readStoredPlanFile({
+          path: contextMutationPlanFilePath(
+            params.stateDir,
+            params.sessionId,
+            terminalStatus,
+            plan.planId,
+          ),
+          sessionId: params.sessionId,
+        });
+        if (terminal.kind === "ok") {
+          return {
+            plans: [],
+            bypassed: true,
+            reasons: ["plan_status_conflict"],
+            quarantinedFileCount: loaded.quarantinedFileCount,
+          };
+        }
+        if (terminal.kind === "corrupt") {
+          const quarantined = await quarantinePlanFile({
+            path: contextMutationPlanFilePath(
+              params.stateDir,
+              params.sessionId,
+              terminalStatus,
+              plan.planId,
+            ),
+            stateDir: params.stateDir,
+            sessionId: params.sessionId,
+            status: terminalStatus,
+          });
+          return {
+            plans: [],
+            bypassed: true,
+            reasons: [
+              quarantined
+                ? "corrupt_plan_quarantined"
+                : "corrupt_plan_quarantine_failed",
+            ],
+            quarantinedFileCount:
+              loaded.quarantinedFileCount + (quarantined ? 1 : 0),
+          };
+        }
+        if (terminal.kind !== "missing") {
+          return {
+            plans: [],
+            bypassed: true,
+            reasons: [
+              terminal.kind === "unsupported_schema"
+                ? "unsupported_schema"
+                : "terminal_plan_read_failed",
+            ],
+            quarantinedFileCount: loaded.quarantinedFileCount,
+          };
+        }
+      }
+    }
+    return loaded;
+  } catch {
+    return {
+      plans: [],
+      bypassed: true,
+      reasons: ["plan_store_read_failed"],
+      quarantinedFileCount: 0,
+    };
+  } finally {
+    await lock?.release();
+  }
+}
+
+export async function loadActiveContextMutationPlans(params: {
+  stateDir: string;
+  sessionId: string;
+  lock?: ContextMutationPlanStoreLockOptions;
+}): Promise<ContextMutationPlanStoreReadResult> {
+  return loadContextMutationPlans({ ...params, status: "active" });
+}

--- a/components/packages/foundation/host-adapter/tests/context-rewrite-plan-store.test.ts
+++ b/components/packages/foundation/host-adapter/tests/context-rewrite-plan-store.test.ts
@@ -1,0 +1,359 @@
+import assert from "node:assert/strict";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_MUTATION_PLAN_STORE_SCHEMA_VERSION,
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  contextMutationPlanFilePath,
+  contextMutationPlanLockPath,
+  contextMutationPlanQuarantineDir,
+  contextMutationPlanSessionRoot,
+  contextMutationPlanStatusDir,
+  loadActiveContextMutationPlans,
+  loadContextMutationPlans,
+  markContextMutationPlanApplied,
+  markContextMutationPlanFailed,
+  saveActiveContextMutationPlan,
+  type ContextMutationPlan,
+} from "../src/index.js";
+
+function createPlan(
+  planId: string,
+  sessionId = "session-1",
+): ContextMutationPlan {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId,
+    hostId: "test-host",
+    sessionId,
+    baseRevision: "ctxrev-v1-base",
+    sourceModuleId: "eviction",
+    operations: [
+      {
+        id: `operation-${planId}`,
+        type: "remove",
+        targetItemIds: [`item-${planId}`],
+        targetItemFingerprints: {
+          [`item-${planId}`]: `fingerprint-${planId}`,
+        },
+        rationale: "evicted completed task",
+        estimatedSavedChars: 10,
+      },
+    ],
+    createdAt: "2026-08-02T00:00:00.000Z",
+  };
+}
+
+test("plan store schema version is locked to 1", () => {
+  assert.equal(CONTEXT_MUTATION_PLAN_STORE_SCHEMA_VERSION, 1);
+});
+
+test("active plans persist idempotently and recover after restart", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-restart-"));
+  try {
+    const plan = createPlan("plan-1");
+    const first = await saveActiveContextMutationPlan({
+      stateDir,
+      plan,
+      storedAt: "2026-08-02T00:01:00.000Z",
+    });
+    const duplicate = await saveActiveContextMutationPlan({
+      stateDir,
+      plan: { ...plan, operations: plan.operations.map((operation) => ({ ...operation })) },
+      storedAt: "2026-08-02T00:02:00.000Z",
+    });
+    const recovered = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: plan.sessionId,
+    });
+
+    assert.equal(first.outcome, "stored");
+    assert.equal(duplicate.outcome, "unchanged");
+    assert.equal(duplicate.status, "active");
+    assert.equal(recovered.bypassed, false);
+    assert.deepEqual(recovered.plans.map((entry) => entry.planId), ["plan-1"]);
+
+    const files = await readdir(
+      contextMutationPlanStatusDir(stateDir, plan.sessionId, "active"),
+    );
+    assert.equal(files.filter((name) => name.endsWith(".json")).length, 1);
+    assert.equal(files.some((name) => name.endsWith(".tmp")), false);
+
+    const sessionRoot = contextMutationPlanSessionRoot(stateDir, plan.sessionId);
+    await assert.rejects(access(join(sessionRoot, "latest.json")));
+    await assert.rejects(access(join(sessionRoot, "revisions.jsonl")));
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("active plans move atomically into separate terminal states", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-status-"));
+  try {
+    const appliedPlan = createPlan("plan-applied");
+    const failedPlan = createPlan("plan-failed");
+    await saveActiveContextMutationPlan({ stateDir, plan: appliedPlan });
+    await saveActiveContextMutationPlan({ stateDir, plan: failedPlan });
+
+    const applied = await markContextMutationPlanApplied({
+      stateDir,
+      sessionId: appliedPlan.sessionId,
+      planId: appliedPlan.planId,
+    });
+    const failed = await markContextMutationPlanFailed({
+      stateDir,
+      sessionId: failedPlan.sessionId,
+      planId: failedPlan.planId,
+    });
+    const appliedAgain = await markContextMutationPlanApplied({
+      stateDir,
+      sessionId: appliedPlan.sessionId,
+      planId: appliedPlan.planId,
+    });
+    const terminalReplay = await saveActiveContextMutationPlan({
+      stateDir,
+      plan: appliedPlan,
+    });
+
+    assert.equal(applied.outcome, "transitioned");
+    assert.equal(failed.outcome, "transitioned");
+    assert.equal(appliedAgain.outcome, "unchanged");
+    assert.equal(terminalReplay.outcome, "unchanged");
+    assert.equal(terminalReplay.status, "applied");
+
+    const active = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: appliedPlan.sessionId,
+    });
+    const appliedPlans = await loadContextMutationPlans({
+      stateDir,
+      sessionId: appliedPlan.sessionId,
+      status: "applied",
+    });
+    const failedPlans = await loadContextMutationPlans({
+      stateDir,
+      sessionId: appliedPlan.sessionId,
+      status: "failed",
+    });
+    assert.deepEqual(active.plans, []);
+    assert.deepEqual(appliedPlans.plans.map((plan) => plan.planId), ["plan-applied"]);
+    assert.deepEqual(failedPlans.plans.map((plan) => plan.planId), ["plan-failed"]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("session lock serializes concurrent active plan writes", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-concurrent-"));
+  try {
+    const plans = Array.from({ length: 12 }, (_, index) =>
+      createPlan(`plan-${String(index).padStart(2, "0")}`));
+    const results = await Promise.all(plans.map((plan) =>
+      saveActiveContextMutationPlan({
+        stateDir,
+        plan,
+        lock: { lockTimeoutMs: 5_000, lockRetryMs: 2 },
+      })));
+    const loaded = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: "session-1",
+    });
+
+    assert.equal(results.every((result) => result.outcome === "stored"), true);
+    assert.equal(loaded.bypassed, false);
+    assert.deepEqual(
+      loaded.plans.map((plan) => plan.planId),
+      plans.map((plan) => plan.planId),
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("corrupt active plan is quarantined and causes one safe bypass", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-corrupt-"));
+  try {
+    const validPlan = createPlan("plan-valid");
+    const corruptPlan = createPlan("plan-corrupt");
+    await saveActiveContextMutationPlan({ stateDir, plan: validPlan });
+    const corruptPath = contextMutationPlanFilePath(
+      stateDir,
+      corruptPlan.sessionId,
+      "active",
+      corruptPlan.planId,
+    );
+    await mkdir(dirname(corruptPath), { recursive: true });
+    await writeFile(corruptPath, "{not-json", "utf8");
+
+    const bypassed = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: validPlan.sessionId,
+    });
+    assert.equal(bypassed.bypassed, true);
+    assert.deepEqual(bypassed.plans, []);
+    assert.equal(bypassed.quarantinedFileCount, 1);
+    assert.ok(bypassed.reasons.includes("corrupt_plan_quarantined"));
+
+    const quarantineFiles = await readdir(
+      contextMutationPlanQuarantineDir(
+        stateDir,
+        validPlan.sessionId,
+        "active",
+      ),
+    );
+    assert.equal(quarantineFiles.length, 1);
+
+    const recovered = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: validPlan.sessionId,
+    });
+    assert.equal(recovered.bypassed, false);
+    assert.deepEqual(recovered.plans.map((plan) => plan.planId), ["plan-valid"]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("corrupt terminal conflict is quarantined before active plans resume", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-terminal-corrupt-"));
+  try {
+    const plan = createPlan("plan-terminal-corrupt");
+    await saveActiveContextMutationPlan({ stateDir, plan });
+    const corruptTerminalPath = contextMutationPlanFilePath(
+      stateDir,
+      plan.sessionId,
+      "applied",
+      plan.planId,
+    );
+    await mkdir(dirname(corruptTerminalPath), { recursive: true });
+    await writeFile(corruptTerminalPath, "{not-json", "utf8");
+
+    const bypassed = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: plan.sessionId,
+    });
+    assert.equal(bypassed.bypassed, true);
+    assert.deepEqual(bypassed.plans, []);
+    assert.equal(bypassed.quarantinedFileCount, 1);
+    assert.deepEqual(bypassed.reasons, ["corrupt_plan_quarantined"]);
+
+    const recovered = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: plan.sessionId,
+    });
+    assert.equal(recovered.bypassed, false);
+    assert.deepEqual(recovered.plans.map((entry) => entry.planId), [plan.planId]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("unsupported future schema bypasses without quarantining the file", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-future-"));
+  try {
+    const plan = createPlan("plan-future");
+    const path = contextMutationPlanFilePath(
+      stateDir,
+      plan.sessionId,
+      "active",
+      plan.planId,
+    );
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify({
+      schemaVersion: 2,
+      storedAt: "2026-08-02T00:01:00.000Z",
+      plan,
+      futureField: true,
+    }), "utf8");
+
+    const loaded = await loadActiveContextMutationPlans({
+      stateDir,
+      sessionId: plan.sessionId,
+    });
+    assert.equal(loaded.bypassed, true);
+    assert.deepEqual(loaded.reasons, ["unsupported_schema"]);
+    assert.equal(loaded.quarantinedFileCount, 0);
+    assert.equal(JSON.parse(await readFile(path, "utf8")).schemaVersion, 2);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("stale session lock is recovered while a live lock causes bypass", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-lock-"));
+  try {
+    const stalePlan = createPlan("plan-after-stale");
+    const lockPath = contextMutationPlanLockPath(stateDir, stalePlan.sessionId);
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(join(lockPath, "owner.json"), JSON.stringify({
+      token: "stale-owner",
+      pid: 2_147_483_647,
+      hostname: hostname(),
+      createdAt: "2026-08-01T00:00:00.000Z",
+    }), "utf8");
+
+    const recovered = await saveActiveContextMutationPlan({
+      stateDir,
+      plan: stalePlan,
+      lock: { lockTimeoutMs: 50, lockRetryMs: 2 },
+    });
+    assert.equal(recovered.outcome, "stored");
+
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(join(lockPath, "owner.json"), JSON.stringify({
+      token: "live-owner",
+      pid: process.pid,
+      hostname: hostname(),
+      createdAt: new Date().toISOString(),
+    }), "utf8");
+    const blocked = await saveActiveContextMutationPlan({
+      stateDir,
+      plan: createPlan("plan-blocked"),
+      lock: { lockTimeoutMs: 20, lockRetryMs: 2 },
+    });
+    assert.equal(blocked.outcome, "bypassed");
+    assert.deepEqual(blocked.reasons, ["session_lock_unavailable"]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("adapter-owned replacement payloads are rejected before persistence", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-plan-store-payload-"));
+  try {
+    const plan = createPlan("plan-raw-payload");
+    const unsafePlan = {
+      ...plan,
+      operations: [{
+        ...plan.operations[0]!,
+        replacementItems: [{ rawHostMessage: "secret" }],
+      }],
+    } as unknown as ContextMutationPlan;
+    const result = await saveActiveContextMutationPlan({
+      stateDir,
+      plan: unsafePlan,
+    });
+
+    assert.equal(result.outcome, "bypassed");
+    assert.deepEqual(result.reasons, ["invalid_plan"]);
+    await assert.rejects(access(contextMutationPlanFilePath(
+      stateDir,
+      plan.sessionId,
+      "active",
+      plan.planId,
+    )));
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
 ## Summary

  - add a shared persistent store for context mutation plans
  - persist active plans atomically and recover them across process restarts
  - support atomic transitions from active to applied or failed states
  - serialize concurrent session writes with a cross-process lock
  - quarantine corrupt plan files and safely bypass unsupported or unreadable state
  - reject adapter-owned replacement payloads before shared persistence
  - hash session and plan identifiers used in storage paths

  ## Storage layout

  Plans are stored under:

  ```text
  context-rewrite/sessions/<session-hash>/plans/
  ├── active/
  ├── applied/
  ├── failed/
  └── quarantine/
```
  latest.json and revisions.jsonl are intentionally not included in this change. Snapshot persistence and apply-history
  recording belong to later rewrite runtime integration.

  ## Safety behavior

  - duplicate plan writes are idempotent
  - terminal plans cannot return to the active state
  - corrupt files cause a safe bypass and are quarantined
  - unsupported future schema versions are preserved and bypassed
  - stale locks can be recovered, while live lock contention causes a bounded safe bypass
  - storage failures are returned as explicit results instead of failing the host request

  ## Tests

  - corepack pnpm --dir components/packages/foundation/host-adapter test
  - corepack pnpm --dir components/packages/foundation/host-adapter typecheck
  - corepack pnpm check:boundaries
  - corepack pnpm -r typecheck
  - git diff --check

  All checks pass.