### PR TITLE
feat(context-rewrite): validate tool protocol closure

### DIFF
--- a/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
@@ -1,2 +1,3 @@
 export * from "./contracts.js";
 export * from "./revalidation.js";
+export * from "./protocol-closure.js";

--- a/components/packages/foundation/host-adapter/src/context-rewrite/protocol-closure.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/protocol-closure.ts
@@ -1,0 +1,175 @@
+import type {
+  ContextMutationOperation,
+  ContextMutationPlan,
+  ContextRewriteValidation,
+  ModelContextSnapshot,
+} from "./contracts.js";
+
+export type ContextProtocolClosureValidationParams<
+  TAdapterMetadata = never,
+  TAdapterReplacementItem = never,
+> = {
+  snapshot: ModelContextSnapshot<TAdapterMetadata>;
+  plan: ContextMutationPlan<TAdapterReplacementItem>;
+  activeTaskIds: readonly string[];
+  evictableTaskIds: readonly string[];
+  /** Restricts validation when structural revalidation already deferred operations. */
+  candidateOperationIds?: readonly string[];
+};
+
+type ProtocolGroup = {
+  callItemIds: string[];
+  resultItemIds: string[];
+  taskIds: Set<string>;
+};
+
+function uniqueNonEmpty(values: readonly string[] | undefined): string[] {
+  return [...new Set(
+    (values ?? [])
+      .filter((value) => typeof value === "string" && value.trim())
+      .map((value) => value.trim()),
+  )];
+}
+
+function operationReason(
+  operation: ContextMutationOperation<unknown>,
+  reason: string,
+): string {
+  const operationId = typeof operation.id === "string"
+    ? operation.id.trim()
+    : "";
+  return `operation:${operationId || "<empty>"}:${reason}`;
+}
+
+function operationIds<TAdapterReplacementItem>(
+  plan: ContextMutationPlan<TAdapterReplacementItem>,
+): string[] {
+  return [...new Set(plan.operations.map((operation) => operation.id))];
+}
+
+/**
+ * Validates protocol closure using adapter-normalized context items. Anthropic
+ * tool_use/tool_result and Responses function/custom calls all map to the
+ * shared tool_call/tool_result kinds before reaching this boundary.
+ */
+export function validateContextMutationProtocolClosure<
+  TAdapterMetadata = never,
+  TAdapterReplacementItem = never,
+>(
+  params: ContextProtocolClosureValidationParams<
+    TAdapterMetadata,
+    TAdapterReplacementItem
+  >,
+): ContextRewriteValidation {
+  const { snapshot, plan } = params;
+  const candidates = new Set(
+    params.candidateOperationIds ?? operationIds(plan),
+  );
+  const activeTaskIds = new Set(uniqueNonEmpty(params.activeTaskIds));
+  const evictableTaskIds = new Set(uniqueNonEmpty(params.evictableTaskIds));
+  const itemsByStableId = new Map(
+    snapshot.items.map((item) => [item.stableId, item]),
+  );
+  const protocolGroups = new Map<string, ProtocolGroup>();
+  const protocolItemsWithoutCallId = new Set<string>();
+  const protocolTasksWithoutCallId = new Set<string>();
+
+  for (const item of snapshot.items) {
+    if (item.kind !== "tool_call" && item.kind !== "tool_result") continue;
+    const callId = typeof item.callId === "string" ? item.callId.trim() : "";
+    if (!callId) {
+      protocolItemsWithoutCallId.add(item.stableId);
+      for (const taskId of uniqueNonEmpty(item.taskIds)) {
+        protocolTasksWithoutCallId.add(taskId);
+      }
+      continue;
+    }
+    const group = protocolGroups.get(callId) ?? {
+      callItemIds: [],
+      resultItemIds: [],
+      taskIds: new Set<string>(),
+    };
+    if (item.kind === "tool_call") group.callItemIds.push(item.stableId);
+    else group.resultItemIds.push(item.stableId);
+    for (const taskId of uniqueNonEmpty(item.taskIds)) group.taskIds.add(taskId);
+    protocolGroups.set(callId, group);
+  }
+
+  const applicableOperationIds: string[] = [];
+  const deferredOperationIds: string[] = [];
+  const reasons: string[] = [];
+
+  for (const operation of plan.operations) {
+    if (!candidates.has(operation.id)
+      || applicableOperationIds.includes(operation.id)
+      || deferredOperationIds.includes(operation.id)) {
+      continue;
+    }
+
+    const targetItemIds = new Set(operation.targetItemIds);
+    const operationTaskIds = new Set(uniqueNonEmpty(operation.taskIds));
+    for (const targetItemId of targetItemIds) {
+      for (const taskId of uniqueNonEmpty(
+        itemsByStableId.get(targetItemId)?.taskIds,
+      )) {
+        operationTaskIds.add(taskId);
+      }
+    }
+
+    let reason: string | undefined;
+    const crossesActiveAndEvictableTasks = [...operationTaskIds].some(
+      (taskId) => activeTaskIds.has(taskId),
+    ) && [...operationTaskIds].some(
+      (taskId) => evictableTaskIds.has(taskId),
+    );
+    if (crossesActiveAndEvictableTasks) {
+      reason = "active_evictable_task_overlap";
+    }
+
+    const targetsProtocolItemWithoutCallId = [...targetItemIds].some(
+      (targetItemId) => protocolItemsWithoutCallId.has(targetItemId),
+    );
+    if (!reason && targetsProtocolItemWithoutCallId) {
+      reason = "protocol_call_id_missing";
+    }
+    if (!reason && [...operationTaskIds].some(
+      (taskId) => protocolTasksWithoutCallId.has(taskId),
+    )) {
+      reason = "unresolved_protocol_call";
+    }
+
+    for (const group of protocolGroups.values()) {
+      if (reason) break;
+      const groupItemIds = [...group.callItemIds, ...group.resultItemIds];
+      const targetsGroup = groupItemIds.some((itemId) => targetItemIds.has(itemId));
+      const operationOwnsUnresolvedTask = [...group.taskIds].some(
+        (taskId) => operationTaskIds.has(taskId),
+      );
+      const groupIsComplete = group.callItemIds.length === 1
+        && group.resultItemIds.length === 1;
+
+      if (!groupIsComplete && (targetsGroup || operationOwnsUnresolvedTask)) {
+        reason = "unresolved_protocol_call";
+        break;
+      }
+      if (groupIsComplete && targetsGroup
+        && groupItemIds.some((itemId) => !targetItemIds.has(itemId))) {
+        reason = "protocol_pair_partial";
+      }
+    }
+
+    if (reason) {
+      deferredOperationIds.push(operation.id);
+      reasons.push(operationReason(operation, reason));
+    } else {
+      applicableOperationIds.push(operation.id);
+    }
+  }
+
+  return {
+    valid: true,
+    applicableOperationIds,
+    deferredOperationIds,
+    reasons,
+  };
+}

--- a/components/packages/foundation/host-adapter/tests/context-rewrite-protocol-closure.test.ts
+++ b/components/packages/foundation/host-adapter/tests/context-rewrite-protocol-closure.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  validateContextMutationProtocolClosure,
+  type ContextItemRef,
+  type ContextMutationPlan,
+  type ModelContextSnapshot,
+} from "../src/index.js";
+
+function item(
+  stableId: string,
+  kind: ContextItemRef["kind"],
+  options: Pick<ContextItemRef, "callId" | "taskIds"> = {},
+): ContextItemRef {
+  return {
+    stableId,
+    kind,
+    fingerprint: `fp-${stableId}`,
+    chars: 10,
+    ...options,
+  };
+}
+
+function snapshot(items: ContextItemRef[]): ModelContextSnapshot {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    hostId: "test-host",
+    sessionId: "session-1",
+    revision: "ctxrev-current",
+    items,
+  };
+}
+
+function plan(
+  operations: ContextMutationPlan["operations"],
+): ContextMutationPlan {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: "plan-1",
+    hostId: "test-host",
+    sessionId: "session-1",
+    baseRevision: "ctxrev-current",
+    sourceModuleId: "eviction",
+    operations,
+    createdAt: "2026-08-02T00:00:00.000Z",
+  };
+}
+
+function remove(
+  id: string,
+  targetItemIds: string[],
+  taskIds: string[] = ["evictable-task"],
+): ContextMutationPlan["operations"][number] {
+  return {
+    id,
+    type: "remove",
+    targetItemIds,
+    taskIds,
+    rationale: "evicted task",
+    estimatedSavedChars: 10,
+  };
+}
+
+test("accepts complete normalized pairs for all required host protocols", () => {
+  const protocols = [
+    "anthropic-tool-use",
+    "responses-function-call",
+    "responses-custom-tool-call",
+  ];
+  const items = protocols.flatMap((protocol) => [
+    item(`${protocol}-call`, "tool_call", {
+      callId: protocol,
+      taskIds: ["evictable-task"],
+    }),
+    item(`${protocol}-result`, "tool_result", {
+      callId: protocol,
+      taskIds: ["evictable-task"],
+    }),
+  ]);
+  const validation = validateContextMutationProtocolClosure({
+    snapshot: snapshot(items),
+    plan: plan(protocols.map((protocol) => remove(
+      `remove-${protocol}`,
+      [`${protocol}-call`, `${protocol}-result`],
+    ))),
+    activeTaskIds: ["active-task"],
+    evictableTaskIds: ["evictable-task"],
+  });
+
+  assert.deepEqual(validation, {
+    valid: true,
+    applicableOperationIds: protocols.map((protocol) => `remove-${protocol}`),
+    deferredOperationIds: [],
+    reasons: [],
+  });
+});
+
+test("defers an operation that removes only one side of a pair", () => {
+  const validation = validateContextMutationProtocolClosure({
+    snapshot: snapshot([
+      item("call", "tool_call", { callId: "call-1", taskIds: ["evictable-task"] }),
+      item("result", "tool_result", { callId: "call-1", taskIds: ["evictable-task"] }),
+    ]),
+    plan: plan([remove("remove-call", ["call"])]),
+    activeTaskIds: [],
+    evictableTaskIds: ["evictable-task"],
+  });
+
+  assert.deepEqual(validation.applicableOperationIds, []);
+  assert.deepEqual(validation.deferredOperationIds, ["remove-call"]);
+  assert.deepEqual(validation.reasons, [
+    "operation:remove-call:protocol_pair_partial",
+  ]);
+});
+
+test("defers every operation owned by an unresolved call task", () => {
+  const validation = validateContextMutationProtocolClosure({
+    snapshot: snapshot([
+      item("call", "tool_call", { callId: "call-1", taskIds: ["evictable-task"] }),
+      item("message", "assistant", { taskIds: ["evictable-task"] }),
+      item("other", "user", { taskIds: ["other-task"] }),
+    ]),
+    plan: plan([
+      remove("remove-message", ["message"]),
+      remove("remove-other", ["other"], ["other-task"]),
+    ]),
+    activeTaskIds: [],
+    evictableTaskIds: ["evictable-task", "other-task"],
+  });
+
+  assert.deepEqual(validation.applicableOperationIds, ["remove-other"]);
+  assert.deepEqual(validation.deferredOperationIds, ["remove-message"]);
+  assert.deepEqual(validation.reasons, [
+    "operation:remove-message:unresolved_protocol_call",
+  ]);
+});
+
+test("defers tasks with orphaned or duplicate protocol items", () => {
+  const validation = validateContextMutationProtocolClosure({
+    snapshot: snapshot([
+      item("orphan-result", "tool_result", {
+        callId: "orphan-call",
+        taskIds: ["orphan-task"],
+      }),
+      item("orphan-message", "assistant", { taskIds: ["orphan-task"] }),
+      item("duplicate-call-1", "tool_call", {
+        callId: "duplicate-call",
+        taskIds: ["duplicate-task"],
+      }),
+      item("duplicate-call-2", "tool_call", {
+        callId: "duplicate-call",
+        taskIds: ["duplicate-task"],
+      }),
+      item("duplicate-result", "tool_result", {
+        callId: "duplicate-call",
+        taskIds: ["duplicate-task"],
+      }),
+      item("duplicate-message", "assistant", { taskIds: ["duplicate-task"] }),
+      item("unrelated-message", "user", { taskIds: ["unrelated-task"] }),
+    ]),
+    plan: plan([
+      remove("remove-orphan-task", ["orphan-message"], ["orphan-task"]),
+      remove("remove-duplicate-task", ["duplicate-message"], ["duplicate-task"]),
+      remove("remove-unrelated-task", ["unrelated-message"], ["unrelated-task"]),
+    ]),
+    activeTaskIds: [],
+    evictableTaskIds: ["orphan-task", "duplicate-task", "unrelated-task"],
+  });
+
+  assert.deepEqual(validation.applicableOperationIds, ["remove-unrelated-task"]);
+  assert.deepEqual(validation.deferredOperationIds, [
+    "remove-orphan-task",
+    "remove-duplicate-task",
+  ]);
+  assert.deepEqual(validation.reasons, [
+    "operation:remove-orphan-task:unresolved_protocol_call",
+    "operation:remove-duplicate-task:unresolved_protocol_call",
+  ]);
+});
+
+test("defers an operation spanning active and evictable tasks", () => {
+  const validation = validateContextMutationProtocolClosure({
+    snapshot: snapshot([
+      item("active", "user", { taskIds: ["active-task"] }),
+      item("evictable", "assistant", { taskIds: ["evictable-task"] }),
+    ]),
+    plan: plan([remove(
+      "remove-mixed",
+      ["active", "evictable"],
+      ["active-task", "evictable-task"],
+    )]),
+    activeTaskIds: ["active-task"],
+    evictableTaskIds: ["evictable-task"],
+  });
+
+  assert.deepEqual(validation.applicableOperationIds, []);
+  assert.deepEqual(validation.deferredOperationIds, ["remove-mixed"]);
+  assert.deepEqual(validation.reasons, [
+    "operation:remove-mixed:active_evictable_task_overlap",
+  ]);
+});
+
+test("defers targeted protocol items without a call id", () => {
+  const validation = validateContextMutationProtocolClosure({
+    snapshot: snapshot([
+      item("call", "tool_call", { taskIds: ["evictable-task"] }),
+    ]),
+    plan: plan([remove("remove-call", ["call"])]),
+    activeTaskIds: [],
+    evictableTaskIds: ["evictable-task"],
+  });
+
+  assert.deepEqual(validation.applicableOperationIds, []);
+  assert.deepEqual(validation.deferredOperationIds, ["remove-call"]);
+  assert.deepEqual(validation.reasons, [
+    "operation:remove-call:protocol_call_id_missing",
+  ]);
+});
+
+test("validates only candidates that survived structural revalidation", () => {
+  const validation = validateContextMutationProtocolClosure({
+    snapshot: snapshot([
+      item("call", "tool_call", { callId: "call-1", taskIds: ["evictable-task"] }),
+      item("result", "tool_result", { callId: "call-1", taskIds: ["evictable-task"] }),
+      item("message", "user", { taskIds: ["evictable-task"] }),
+    ]),
+    plan: plan([
+      remove("already-deferred", ["call"]),
+      remove("candidate", ["message"]),
+    ]),
+    activeTaskIds: [],
+    evictableTaskIds: ["evictable-task"],
+    candidateOperationIds: ["candidate"],
+  });
+
+  assert.deepEqual(validation, {
+    valid: true,
+    applicableOperationIds: ["candidate"],
+    deferredOperationIds: [],
+    reasons: [],
+  });
+});


### PR DESCRIPTION
## Summary

  Implements FND-05 shared protocol-closure validation for context mutation plans.

  - validates normalized `tool_call` / `tool_result` pairs
  - supports Anthropic tool use and Responses function/custom tool semantics
  - defers partial pair mutations and malformed or unresolved protocol items
  - defers operations spanning active and evictable tasks
  - supports composition with FND-03 through `candidateOperationIds`
  - exports the validator from the context-rewrite package

  ## Scope

  Changed only:

  - `components/packages/foundation/host-adapter/src/context-rewrite/protocol-closure.ts`
  - `components/packages/foundation/host-adapter/src/context-rewrite/index.ts`
  - `components/packages/foundation/host-adapter/tests/context-rewrite-protocol-closure.test.ts`

  This PR does not modify adapter runtimes, eviction behavior, or the FND-04 plan store.

  ## Validation

  - targeted protocol-closure tests: 7 passed
  - host-adapter tests: 49 passed
  - host-adapter typecheck: passed
  - package boundaries: passed
  - workspace recursive typecheck: passed
  - `git diff --check`: passed

  ## Dependency

  - base commit: `d2c5d704e21fc55648d5ba744f22db83a03396d4`
  - depends on FND-04: no