### PR TITLE
feat(codex): complete safe context rebasing

### DIFF
--- a/components/adapters/codex/src/context-history/index.ts
+++ b/components/adapters/codex/src/context-history/index.ts
@@ -19,6 +19,11 @@ export type {
   CodexReplayabilityReason,
 } from "./replayability.js";
 export { buildCodexEffectiveHistory } from "./effective-history.js";
+export { validateCodexRolloutBootstrap } from "./rollout-bootstrap.js";
+export type {
+  CodexRolloutBootstrapRejectionReason,
+  CodexRolloutBootstrapValidation,
+} from "./rollout-bootstrap.js";
 export {
   parseCodexRollout,
   parseCodexRolloutFile,

--- a/components/adapters/codex/src/context-history/replayability.ts
+++ b/components/adapters/codex/src/context-history/replayability.ts
@@ -36,7 +36,7 @@ export function codexReplayabilityForItem(item: JsonObject): CodexItemReplayabil
       ? { mode: "replayable", reason: "tool_closure_required" }
       : { mode: "deferred", reason: "tool_call_id_missing" };
   }
-  if (type === "reasoning") {
+  if (type === "reasoning" || type === "compaction") {
     return typeof item.encrypted_content === "string" && item.encrypted_content.length > 0
       ? { mode: "replayable", reason: "exact_payload_required" }
       : { mode: "deferred", reason: "exact_payload_missing" };

--- a/components/adapters/codex/src/context-history/rollout-bootstrap.ts
+++ b/components/adapters/codex/src/context-history/rollout-bootstrap.ts
@@ -1,0 +1,100 @@
+import type {
+  CodexEffectiveHistory,
+  CodexRolloutSnapshot,
+} from "./types.js";
+
+export type CodexRolloutBootstrapRejectionReason =
+  | "snapshot_session_identity_missing"
+  | "snapshot_session_identity_mismatch"
+  | "rollout_session_identity_missing"
+  | "rollout_session_identity_mismatch"
+  | "encrypted_rollout_codex_provider_missing"
+  | "encrypted_rollout_codex_provider_mismatch"
+  | "encrypted_rollout_upstream_provider_missing"
+  | "encrypted_rollout_upstream_provider_mismatch"
+  | "encrypted_rollout_model_missing"
+  | "encrypted_rollout_model_mismatch";
+
+export type CodexRolloutBootstrapValidation = {
+  history: CodexEffectiveHistory | null;
+  rejectionReason?: CodexRolloutBootstrapRejectionReason;
+};
+
+function normalizeSessionIdentity(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+  return normalized || undefined;
+}
+
+function normalizeDimension(value: string | undefined): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function hasEncryptedReplayItems(rollout: CodexRolloutSnapshot): boolean {
+  return rollout.history.replayableItems.some(({ item }) => {
+    const type = normalizeDimension(typeof item.type === "string" ? item.type : undefined);
+    return (type === "reasoning" || type === "compaction")
+      && typeof item.encrypted_content === "string"
+      && item.encrypted_content.length > 0;
+  });
+}
+
+export function validateCodexRolloutBootstrap(params: {
+  rollout: CodexRolloutSnapshot;
+  expectedCodexSessionId?: string;
+  snapshotCodexSessionId?: string;
+  sourceModel?: string;
+  sourceUpstreamProvider?: string;
+  currentModel: string;
+  currentCodexProvider: string;
+  currentUpstreamProvider: string;
+}): CodexRolloutBootstrapValidation {
+  const expectedSessionId = normalizeSessionIdentity(params.expectedCodexSessionId);
+  const snapshotSessionId = normalizeSessionIdentity(params.snapshotCodexSessionId);
+  const rolloutSessionId = normalizeSessionIdentity(params.rollout.sessionMeta?.sessionId);
+  if (!snapshotSessionId) {
+    return { history: null, rejectionReason: "snapshot_session_identity_missing" };
+  }
+  if (expectedSessionId && snapshotSessionId !== expectedSessionId) {
+    return { history: null, rejectionReason: "snapshot_session_identity_mismatch" };
+  }
+  if (!rolloutSessionId) {
+    return { history: null, rejectionReason: "rollout_session_identity_missing" };
+  }
+  if (rolloutSessionId !== (expectedSessionId ?? snapshotSessionId)) {
+    return { history: null, rejectionReason: "rollout_session_identity_mismatch" };
+  }
+
+  if (!hasEncryptedReplayItems(params.rollout)) {
+    return { history: params.rollout.history };
+  }
+
+  const rolloutProvider = normalizeDimension(params.rollout.sessionMeta?.modelProvider);
+  const currentCodexProvider = normalizeDimension(params.currentCodexProvider);
+  if (!rolloutProvider || !currentCodexProvider) {
+    return { history: null, rejectionReason: "encrypted_rollout_codex_provider_missing" };
+  }
+  if (rolloutProvider !== currentCodexProvider) {
+    return { history: null, rejectionReason: "encrypted_rollout_codex_provider_mismatch" };
+  }
+
+  const sourceUpstreamProvider = normalizeDimension(params.sourceUpstreamProvider);
+  const currentUpstreamProvider = normalizeDimension(params.currentUpstreamProvider);
+  if (!sourceUpstreamProvider || !currentUpstreamProvider) {
+    return { history: null, rejectionReason: "encrypted_rollout_upstream_provider_missing" };
+  }
+  if (sourceUpstreamProvider !== currentUpstreamProvider) {
+    return { history: null, rejectionReason: "encrypted_rollout_upstream_provider_mismatch" };
+  }
+
+  const sourceModel = normalizeDimension(params.sourceModel);
+  const currentModel = normalizeDimension(params.currentModel);
+  if (!sourceModel || !currentModel) {
+    return { history: null, rejectionReason: "encrypted_rollout_model_missing" };
+  }
+  if (sourceModel !== currentModel) {
+    return { history: null, rejectionReason: "encrypted_rollout_model_mismatch" };
+  }
+
+  return { history: params.rollout.history };
+}

--- a/components/adapters/codex/src/context-rewrite/rebase-request.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-request.ts
@@ -18,6 +18,7 @@ function evictedStableItemIds(plan: CodexMutationPlan): Set<string> {
 
 type ToolCallRef = {
   callId?: string;
+  index?: number;
   kind?: "function" | "custom";
   side?: "call" | "output";
   type?: string;
@@ -38,8 +39,8 @@ function itemCallRef(item: JsonObject): ToolCallRef {
 function closureReasons(items: JsonObject[]): string[] {
   const refs = new Map<string, { calls: ToolCallRef[]; outputs: ToolCallRef[] }>();
   const reasons: string[] = [];
-  for (const item of items) {
-    const ref = itemCallRef(item);
+  for (const [index, item] of items.entries()) {
+    const ref = { ...itemCallRef(item), index };
     if (!ref.side) continue;
     if (!ref.callId) {
       reasons.push(`tool_call_id_missing:${ref.type}`);
@@ -60,6 +61,10 @@ function closureReasons(items: JsonObject[]): string[] {
     }
     if (entry.calls[0]?.kind !== entry.outputs[0]?.kind) {
       reasons.push(`tool_closure_type_mismatch:${callId}`);
+      continue;
+    }
+    if ((entry.outputs[0]?.index ?? -1) <= (entry.calls[0]?.index ?? -1)) {
+      reasons.push(`tool_output_before_call:${callId}`);
     }
   }
   return Array.from(new Set(reasons)).sort();

--- a/components/adapters/codex/src/daemon.ts
+++ b/components/adapters/codex/src/daemon.ts
@@ -61,12 +61,19 @@ async function terminateProcess(pid: number): Promise<void> {
   await waitForProcessExit(pid, 2_000).catch(() => undefined);
 }
 
-async function isProxyHealthy(config: TokenPilotCodexConfig): Promise<boolean> {
+async function isProxyHealthy(config: TokenPilotCodexConfig, timeoutMs = 500): Promise<boolean> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  timeout.unref?.();
   try {
-    const resp = await fetch(`http://127.0.0.1:${config.proxyPort}/health`);
+    const resp = await fetch(`http://127.0.0.1:${config.proxyPort}/health`, {
+      signal: controller.signal,
+    });
     return resp.ok;
   } catch {
     return false;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/components/adapters/codex/src/hooks-handler.ts
+++ b/components/adapters/codex/src/hooks-handler.ts
@@ -134,20 +134,25 @@ export async function processCodexHookEvent(event: Record<string, unknown>): Pro
     ? await resolveCodexSessionAlias(config.stateDir, codexSessionId) ?? codexSessionId
     : undefined;
   const workspaceHint = workspaceHintFromEvent(event);
+  const transcriptPath = stringValue(event.transcript_path);
+  const hookModel = stringValue(event.model);
   const tool = extractToolEvent(event);
   const common = {
     hookEventName,
     codexSessionId: codexSessionId ?? null,
     sessionId: sessionId ?? null,
-    transcriptPath: stringValue(event.transcript_path) ?? null,
+    transcriptPath: transcriptPath ?? null,
     cwd: workspaceHint ?? null,
-    model: stringValue(event.model) ?? null,
+    model: hookModel ?? null,
   };
 
   if (sessionId) {
     try {
       await upsertCodexSessionSnapshot(config.stateDir, sessionId, {
+        codexSessionId,
+        latestModel: hookModel,
         workspaceHint,
+        transcriptPath,
         lastHookEvent: hookEventName,
         lastToolName: tool.toolName ?? undefined,
         lastToolInputChars: tool.toolInputChars,

--- a/components/adapters/codex/src/install.ts
+++ b/components/adapters/codex/src/install.ts
@@ -223,8 +223,17 @@ async function canListenOnPort(port: number): Promise<boolean> {
   });
 }
 
-async function resolveAvailableCodexProxyPort(preferredPort: number): Promise<number> {
-  if (await canListenOnPort(preferredPort)) return preferredPort;
+async function resolveAvailableCodexProxyPort(
+  preferredPort: number,
+  params?: { waitForPreferredMs?: number },
+): Promise<number> {
+  const waitForPreferredMs = params?.waitForPreferredMs ?? 0;
+  const deadline = Date.now() + waitForPreferredMs;
+  do {
+    if (await canListenOnPort(preferredPort)) return preferredPort;
+    if (Date.now() >= deadline) break;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  } while (true);
   for (let port = preferredPort + 1; port <= preferredPort + 20; port += 1) {
     if (await canListenOnPort(port)) return port;
   }
@@ -391,8 +400,10 @@ export async function installCodexTokenPilot(params?: {
   const tokenPilotConfig = await loadTokenPilotCodexConfig(tokenPilotConfigPath);
   const previousProxyPort = tokenPilotConfig.proxyPort;
   const commandSkillsDir = defaultCodexSkillBridgeDir(dirname(codexConfigPath));
-  await stopDaemon(tokenPilotConfig).catch(() => undefined);
-  tokenPilotConfig.proxyPort = await resolveAvailableCodexProxyPort(tokenPilotConfig.proxyPort);
+  const stoppedDaemon = await stopDaemon(tokenPilotConfig).catch(() => undefined);
+  tokenPilotConfig.proxyPort = await resolveAvailableCodexProxyPort(tokenPilotConfig.proxyPort, {
+    waitForPreferredMs: stoppedDaemon?.stopped ? 1_000 : 0,
+  });
   const existingRootProvider = await readCodexRootModelProvider(codexConfigPath);
   const persistedProviderName = tokenPilotConfig.providerName !== "tokenpilot"
     ? tokenPilotConfig.providerName

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -48,6 +48,7 @@ import {
   indexCodexPromptCacheKeySession,
   indexCodexResponseSession,
   mergeCodexSessionSnapshot,
+  loadCodexSessionSnapshot,
   resolveCodexSessionIdByPromptCacheKey,
   resolveCodexSessionIdByResponseId,
   upsertCodexSessionSnapshot,
@@ -61,6 +62,8 @@ import {
   appendCodexResponseJournalEntry,
   buildCodexEffectiveHistory,
   collectCodexResponseItemsFromStream,
+  parseCodexRollout,
+  validateCodexRolloutBootstrap,
 } from "./context-history/index.js";
 import type {
   CodexJournalStatus,
@@ -239,6 +242,7 @@ export async function startCodexResponsesProxy(params: {
   }));
   await mkdir(config.stateDir, { recursive: true });
   const upstream = await resolveUpstreamProvider(config, params.codexConfigPath ?? defaultCodexConfigPath());
+  const upstreamProviderName = upstream.name ?? config.upstreamProvider ?? "OpenAI";
   const epochRecoveryBySession = new Map<string, Promise<void>>();
 
   async function recoverSessionEpochsAfterRestart(sessionId: string): Promise<void> {
@@ -297,7 +301,7 @@ export async function startCodexResponsesProxy(params: {
     healthPayload: {
       ok: true,
       adapter: "tokenpilot-codex",
-      upstream: upstream.name ?? config.upstreamProvider ?? "OpenAI",
+      upstream: upstreamProviderName,
       stateDir: config.stateDir,
     },
     async handleRequest({ req, res, body }) {
@@ -377,6 +381,34 @@ export async function startCodexResponsesProxy(params: {
             sessionId,
             headResponseId: String(originalPayload.previous_response_id),
             currentRequestId: requestJournalEntry.requestId,
+            async rolloutParserBootstrap() {
+              const snapshot = await loadCodexSessionSnapshot(config.stateDir, sessionId);
+              if (!snapshot?.transcriptPath) return null;
+              const rollout = await parseCodexRollout(snapshot.transcriptPath);
+              if (!rollout) return null;
+              const expectedCodexSessionId = inboundPromptCacheKey
+                && !inboundPromptCacheKey.startsWith("lightmem2-codex-")
+                ? inboundPromptCacheKey
+                : snapshot.codexSessionId;
+              const validation = validateCodexRolloutBootstrap({
+                rollout,
+                expectedCodexSessionId,
+                snapshotCodexSessionId: snapshot.codexSessionId,
+                sourceModel: snapshot.latestModel,
+                sourceUpstreamProvider: snapshot.latestUpstreamProvider,
+                currentModel: model,
+                currentCodexProvider: config.providerName,
+                currentUpstreamProvider: upstreamProviderName,
+              });
+              if (validation.rejectionReason) {
+                await appendTrace(config.stateDir, {
+                  stage: "context_history_rollout_bootstrap_rejected",
+                  sessionId,
+                  reason: validation.rejectionReason,
+                });
+              }
+              return validation.history;
+            },
           });
           rebaseRequest = buildCodexRebaseRequest({
             sessionId,
@@ -633,7 +665,7 @@ export async function startCodexResponsesProxy(params: {
           },
           capabilityStore: {
             stateDir: config.stateDir,
-            provider: upstream.name ?? config.upstreamProvider ?? "OpenAI",
+            provider: upstreamProviderName,
             model,
           },
         }).then((result) => {
@@ -702,6 +734,7 @@ export async function startCodexResponsesProxy(params: {
           latestResponseId: snapshot.responseId,
           previousResponseId: snapshot.previousResponseId,
           latestModel: model,
+          latestUpstreamProvider: upstreamProviderName,
           disclosedReadPaths: reductionSummary?.disclosedReadPaths,
         });
         if (typeof snapshot.responseId === "string" && snapshot.responseId) {
@@ -839,6 +872,7 @@ export async function startCodexResponsesProxy(params: {
         latestResponseId: responseId,
         previousResponseId,
         latestModel: model,
+        latestUpstreamProvider: upstreamProviderName,
         disclosedReadPaths: reductionSummary?.disclosedReadPaths,
       });
       if (typeof responseId === "string" && responseId) {

--- a/components/adapters/codex/src/session-state.ts
+++ b/components/adapters/codex/src/session-state.ts
@@ -14,10 +14,13 @@ import { join } from "node:path";
 
 export type CodexSessionSnapshot = {
   sessionId: string;
+  codexSessionId?: string;
   latestResponseId?: string;
   previousResponseId?: string;
   latestModel?: string;
+  latestUpstreamProvider?: string;
   workspaceHint?: string;
+  transcriptPath?: string;
   disclosedReadPaths?: string[];
   lastHookEvent?: string;
   lastToolName?: string;
@@ -94,10 +97,13 @@ export async function upsertCodexSessionSnapshot(
   const updatedAt = new Date().toISOString();
   const next: CodexSessionSnapshot = {
     sessionId,
+    codexSessionId: patch.codexSessionId ?? current?.codexSessionId,
     latestResponseId: patch.latestResponseId ?? current?.latestResponseId,
     previousResponseId: patch.previousResponseId ?? current?.previousResponseId,
     latestModel: patch.latestModel ?? current?.latestModel,
+    latestUpstreamProvider: patch.latestUpstreamProvider ?? current?.latestUpstreamProvider,
     workspaceHint: patch.workspaceHint ?? current?.workspaceHint,
+    transcriptPath: patch.transcriptPath ?? current?.transcriptPath,
     disclosedReadPaths: patch.disclosedReadPaths ?? current?.disclosedReadPaths,
     lastHookEvent: patch.lastHookEvent ?? current?.lastHookEvent,
     lastToolName: patch.lastToolName ?? current?.lastToolName,
@@ -131,10 +137,13 @@ export async function mergeCodexSessionSnapshot(
   if (!source) return target;
 
   return upsertCodexSessionSnapshot(stateDir, normalizedTargetSessionId, {
+    codexSessionId: target?.codexSessionId ?? source.codexSessionId,
     latestResponseId: target?.latestResponseId ?? source.latestResponseId,
     previousResponseId: target?.previousResponseId ?? source.previousResponseId,
     latestModel: target?.latestModel ?? source.latestModel,
+    latestUpstreamProvider: target?.latestUpstreamProvider ?? source.latestUpstreamProvider,
     workspaceHint: target?.workspaceHint ?? source.workspaceHint,
+    transcriptPath: target?.transcriptPath ?? source.transcriptPath,
     disclosedReadPaths: target?.disclosedReadPaths ?? source.disclosedReadPaths,
     lastHookEvent: target?.lastHookEvent ?? source.lastHookEvent,
     lastToolName: target?.lastToolName ?? source.lastToolName,

--- a/components/adapters/codex/tests/cli-bridge.test.ts
+++ b/components/adapters/codex/tests/cli-bridge.test.ts
@@ -8,12 +8,35 @@ import { createCodexCliBridge } from "../../../products/cli/src/hosts/codex.js";
 import { loadTokenPilotCodexConfig, defaultTokenPilotConfigPath } from "../src/config.js";
 import { indexCodexHostSessionAlias } from "../src/session-state.js";
 
+const ISOLATED_ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "TOKENPILOT_CODEX_CONFIG",
+  "CODEX_CONFIG_PATH",
+  "CODEX_HOOKS_CONFIG_PATH",
+  "OPENCLAW_CONFIG_PATH",
+] as const;
+
+function isolateCodexTestEnvironment(homeDir: string): () => void {
+  const originals = new Map(ISOLATED_ENV_KEYS.map((key) => [key, process.env[key]]));
+  process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
+  process.env.TOKENPILOT_CODEX_CONFIG = join(homeDir, ".codex", "tokenpilot.json");
+  process.env.CODEX_CONFIG_PATH = join(homeDir, ".codex", "config.toml");
+  process.env.CODEX_HOOKS_CONFIG_PATH = join(homeDir, ".codex", "hooks.json");
+  process.env.OPENCLAW_CONFIG_PATH = join(homeDir, ".openclaw", "openclaw.json");
+  return () => {
+    for (const key of ISOLATED_ENV_KEYS) {
+      const original = originals.get(key);
+      if (original === undefined) delete process.env[key];
+      else process.env[key] = original;
+    }
+  };
+}
+
 test("codex cli bridge exposes only the supported Codex command surface", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-"));
-  const originalHome = process.env.HOME;
-  const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
-  process.env.HOME = dir;
-  process.env.OPENCLAW_CONFIG_PATH = join(dir, ".openclaw", "openclaw.json");
+  const restoreEnvironment = isolateCodexTestEnvironment(dir);
   try {
     await mkdir(join(dir, ".openclaw"), { recursive: true });
     await writeFile(
@@ -21,7 +44,12 @@ test("codex cli bridge exposes only the supported Codex command surface", async 
       `${JSON.stringify({ plugins: { entries: {} } }, null, 2)}\n`,
       "utf8",
     );
-    const { handleCommand } = createCodexCliBridge({ host: "codex" });
+    const { handleCommand } = createCodexCliBridge({
+      host: "codex",
+      async handleVisualCommand({ host, sessionId }) {
+        return { text: `LightMem2 visual: http://127.0.0.1:19998/?host=${host ?? ""}&session=${sessionId ?? ""}` };
+      },
+    });
 
     const status = await handleCommand({ args: "status" });
     assert.match(status.text, /TokenPilot Codex status:/);
@@ -63,27 +91,14 @@ test("codex cli bridge exposes only the supported Codex command surface", async 
     const unsupportedReductionPass = await handleCommand({ args: "reduction pass formatSlimming on" });
     assert.equal(unsupportedReductionPass.text, "Codex reduction supports only these passes: readStateCompaction, toolPayloadTrim, htmlSlimming, execOutputTruncation, agentsStartupOptimization");
   } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-    if (originalConfigPath === undefined) {
-      delete process.env.OPENCLAW_CONFIG_PATH;
-    } else {
-      process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
-    }
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test("codex cli bridge follows custom config env paths instead of the default home paths", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-custom-paths-"));
-  const originalHome = process.env.HOME;
-  const originalCodexConfigPath = process.env.CODEX_CONFIG_PATH;
-  const originalHooksConfigPath = process.env.CODEX_HOOKS_CONFIG_PATH;
-  const originalTokenPilotConfigPath = process.env.TOKENPILOT_CODEX_CONFIG;
-  process.env.HOME = join(dir, "real-home");
+  const restoreEnvironment = isolateCodexTestEnvironment(join(dir, "real-home"));
   process.env.CODEX_CONFIG_PATH = join(dir, "isolated", "config.toml");
   process.env.CODEX_HOOKS_CONFIG_PATH = join(dir, "isolated", "hooks.json");
   process.env.TOKENPILOT_CODEX_CONFIG = join(dir, "isolated", "tokenpilot.json");
@@ -117,24 +132,14 @@ test("codex cli bridge follows custom config env paths instead of the default ho
     const reloaded = await loadTokenPilotCodexConfig(process.env.TOKENPILOT_CODEX_CONFIG!);
     assert.equal(reloaded.stateDir, join(dir, "isolated", "tokenpilot-state", "tokenpilot"));
   } finally {
-    if (originalHome === undefined) delete process.env.HOME;
-    else process.env.HOME = originalHome;
-    if (originalCodexConfigPath === undefined) delete process.env.CODEX_CONFIG_PATH;
-    else process.env.CODEX_CONFIG_PATH = originalCodexConfigPath;
-    if (originalHooksConfigPath === undefined) delete process.env.CODEX_HOOKS_CONFIG_PATH;
-    else process.env.CODEX_HOOKS_CONFIG_PATH = originalHooksConfigPath;
-    if (originalTokenPilotConfigPath === undefined) delete process.env.TOKENPILOT_CODEX_CONFIG;
-    else process.env.TOKENPILOT_CODEX_CONFIG = originalTokenPilotConfigPath;
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test("codex cli bridge visual opens the shared browser visual pinned to the codex session", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-visual-"));
-  const originalHome = process.env.HOME;
-  const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
-  process.env.HOME = dir;
-  process.env.OPENCLAW_CONFIG_PATH = join(dir, ".openclaw", "openclaw.json");
+  const restoreEnvironment = isolateCodexTestEnvironment(dir);
   try {
     const stateDir = join(dir, ".codex", "tokenpilot-state", "tokenpilot");
     const claudeStateDir = join(dir, ".claude", "tokenpilot-state", "tokenpilot");
@@ -202,31 +207,34 @@ test("codex cli bridge visual opens the shared browser visual pinned to the code
       "utf8",
     );
 
-    const { handleCommand } = createCodexCliBridge({ host: "codex" });
+    let visualSelection: { host?: string; sessionId?: string } | undefined;
+    const { handleCommand } = createCodexCliBridge({
+      host: "codex",
+      async handleVisualCommand(selection) {
+        visualSelection = selection;
+        return {
+          text: [
+            `LightMem2 visual: http://127.0.0.1:19998/?host=${selection.host ?? ""}&session=${selection.sessionId ?? ""}`,
+            "- Codex: 0 session snapshots",
+          ].join("\n"),
+        };
+      },
+    });
     const visual = await handleCommand({ args: "visual" });
     assert.match(visual.text, /LightMem2 visual: http:\/\/127\.0\.0\.1:/);
     assert.match(visual.text, /host=codex/);
     assert.match(visual.text, /session=session-1/);
     assert.match(visual.text, /Codex: 0 session snapshots/);
+    assert.deepEqual(visualSelection, { host: "codex", sessionId: "session-1" });
   } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
-    if (originalConfigPath === undefined) {
-      delete process.env.OPENCLAW_CONFIG_PATH;
-    } else {
-      process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
-    }
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test("codex cli bridge report explains when a session has no recorded savings yet", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-report-empty-"));
-  const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  const restoreEnvironment = isolateCodexTestEnvironment(dir);
   try {
     const stateDir = join(dir, ".codex", "tokenpilot-state", "tokenpilot");
     await mkdir(join(stateDir, "ux-effects"), { recursive: true });
@@ -248,19 +256,14 @@ test("codex cli bridge report explains when a session has no recorded savings ye
     const report = await handleCommand({ args: "report" });
     assert.equal(report.text, "No TokenPilot savings recorded yet for session session-empty.");
   } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test("codex cli bridge accepts a real codex session id and resolves it to the synthesized session", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-real-session-"));
-  const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  const restoreEnvironment = isolateCodexTestEnvironment(dir);
   try {
     const stateDir = join(dir, ".codex", "tokenpilot-state", "tokenpilot");
     await mkdir(join(stateDir, "ux-effects", "sessions"), { recursive: true });
@@ -302,19 +305,14 @@ test("codex cli bridge accepts a real codex session id and resolves it to the sy
     const report = await handleCommand({ args: "report" });
     assert.match(report.text, /session: codex-synth-a/);
   } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test("codex cli bridge persists only supported settings across reload", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-persist-"));
-  const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  const restoreEnvironment = isolateCodexTestEnvironment(dir);
   try {
     const bridge = createCodexCliBridge({ host: "codex" });
 
@@ -332,19 +330,14 @@ test("codex cli bridge persists only supported settings across reload", async ()
     assert.equal(reloaded.hooks.dynamicContextTarget, "user");
     assert.equal("ux" in (reloaded as unknown as Record<string, unknown>), false);
   } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test("codex mode writes only codex-supported fields", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-mode-"));
-  const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  const restoreEnvironment = isolateCodexTestEnvironment(dir);
   try {
     const bridge = createCodexCliBridge({ host: "codex" });
 
@@ -365,19 +358,14 @@ test("codex mode writes only codex-supported fields", async () => {
     assert.equal("policy" in modules, false);
     assert.equal("eviction" in modules, false);
   } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });
 
 test("codex config normalization strips unsupported reduction pass options", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-bridge-sanitize-"));
-  const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  const restoreEnvironment = isolateCodexTestEnvironment(dir);
   try {
     const bridge = createCodexCliBridge({ host: "codex" });
     const current = await loadTokenPilotCodexConfig(defaultTokenPilotConfigPath());
@@ -399,11 +387,7 @@ test("codex config normalization strips unsupported reduction pass options", asy
     assert.equal("pathTruncation" in reloaded.reduction.passOptions, false);
     assert.deepEqual(reloaded.reduction.passOptions.htmlSlimming, { preserveTables: true });
   } finally {
-    if (originalHome === undefined) {
-      delete process.env.HOME;
-    } else {
-      process.env.HOME = originalHome;
-    }
+    restoreEnvironment();
     await rm(dir, { recursive: true, force: true });
   }
 });

--- a/components/adapters/codex/tests/context-history-replayability.test.ts
+++ b/components/adapters/codex/tests/context-history-replayability.test.ts
@@ -72,6 +72,18 @@ test("CDH-05 Replayability keeps exact encrypted reasoning payloads replayable",
   assert.equal(isCodexObservationOnlyItem(reasoning), false);
 });
 
+test("CDH-05 Replayability keeps exact encrypted compaction payloads replayable", () => {
+  const compaction = {
+    id: "cmp-1",
+    type: "compaction",
+    encrypted_content: "opaque-compaction-payload",
+    internal_chat_message_metadata_passthrough: { source: "codex" },
+  };
+
+  assertReplayability(compaction, "replayable", "exact_payload_required");
+  assert.equal(isCodexObservationOnlyItem(compaction), false);
+});
+
 test("CDH-05 Replayability defers reasoning without its exact encrypted payload", () => {
   const reasoning = {
     id: "rs-summary-only",
@@ -81,6 +93,16 @@ test("CDH-05 Replayability defers reasoning without its exact encrypted payload"
 
   assertReplayability(reasoning, "deferred", "exact_payload_missing");
   assert.equal(isCodexDeferredItem(reasoning), true);
+});
+
+test("CDH-05 Replayability defers compaction without its exact encrypted payload", () => {
+  const compaction = {
+    id: "cmp-missing-payload",
+    type: "compaction",
+  };
+
+  assertReplayability(compaction, "deferred", "exact_payload_missing");
+  assert.equal(isCodexDeferredItem(compaction), true);
 });
 
 test("CDH-05 Replayability defers unknown provider item types", () => {

--- a/components/adapters/codex/tests/context-history-rollout-bootstrap.test.ts
+++ b/components/adapters/codex/tests/context-history-rollout-bootstrap.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  validateCodexRolloutBootstrap,
+  type CodexRolloutSnapshot,
+} from "../src/context-history/index.js";
+
+function rolloutSnapshot(params?: {
+  sessionId?: string;
+  modelProvider?: string;
+  encrypted?: boolean;
+}): CodexRolloutSnapshot {
+  const encrypted = params?.encrypted !== false;
+  return {
+    history: {
+      revision: "rollout-revision",
+      replayableItems: [
+        {
+          stableItemId: "message-1",
+          item: { type: "message", role: "user", content: "continue" },
+        },
+        ...(encrypted
+          ? [{
+            stableItemId: "compaction-1",
+            item: { type: "compaction", encrypted_content: "opaque" },
+          }]
+          : []),
+      ],
+      observationOnlyItems: [],
+      deferredItems: [],
+      unresolvedCallIds: [],
+      source: "rollout_bootstrap",
+      incomplete: false,
+    },
+    sessionMeta: {
+      sessionId: params?.sessionId,
+      modelProvider: params?.modelProvider,
+    },
+    malformedLineCount: 0,
+    unknownRecordTypeCounts: {},
+    taskEvidence: { completedTurnIds: [], abortedTurnIds: [] },
+    compactionBaselineApplied: true,
+  };
+}
+
+function validate(params?: {
+  rollout?: CodexRolloutSnapshot;
+  expectedCodexSessionId?: string;
+  snapshotCodexSessionId?: string;
+  sourceModel?: string;
+  sourceUpstreamProvider?: string;
+  currentModel?: string;
+  currentCodexProvider?: string;
+  currentUpstreamProvider?: string;
+}) {
+  return validateCodexRolloutBootstrap({
+    rollout: params?.rollout ?? rolloutSnapshot({
+      sessionId: "codex-session-1",
+      modelProvider: "tokenpilot",
+    }),
+    expectedCodexSessionId: params?.expectedCodexSessionId ?? "codex-session-1",
+    snapshotCodexSessionId: params?.snapshotCodexSessionId ?? "codex-session-1",
+    sourceModel: params?.sourceModel ?? "gpt-5.6-sol",
+    sourceUpstreamProvider: params?.sourceUpstreamProvider ?? "OpenAI",
+    currentModel: params?.currentModel ?? "gpt-5.6-sol",
+    currentCodexProvider: params?.currentCodexProvider ?? "tokenpilot",
+    currentUpstreamProvider: params?.currentUpstreamProvider ?? "openai",
+  });
+}
+
+test("rollout bootstrap accepts matching session and encrypted payload provenance", () => {
+  const result = validate();
+
+  assert.equal(result.rejectionReason, undefined);
+  assert.equal(result.history?.revision, "rollout-revision");
+});
+
+test("rollout bootstrap rejects missing and mismatched session identities", () => {
+  assert.equal(validate({ snapshotCodexSessionId: " " }).rejectionReason, "snapshot_session_identity_missing");
+  assert.equal(
+    validate({ snapshotCodexSessionId: "codex-session-other" }).rejectionReason,
+    "snapshot_session_identity_mismatch",
+  );
+  assert.equal(
+    validate({ snapshotCodexSessionId: "CODEX-SESSION-1" }).rejectionReason,
+    "snapshot_session_identity_mismatch",
+  );
+  assert.equal(
+    validate({ rollout: rolloutSnapshot({ modelProvider: "tokenpilot" }) }).rejectionReason,
+    "rollout_session_identity_missing",
+  );
+  assert.equal(
+    validate({
+      rollout: rolloutSnapshot({ sessionId: "codex-session-other", modelProvider: "tokenpilot" }),
+    }).rejectionReason,
+    "rollout_session_identity_mismatch",
+  );
+});
+
+test("rollout bootstrap rejects encrypted history with uncertain or changed provenance", () => {
+  assert.equal(
+    validate({
+      rollout: rolloutSnapshot({ sessionId: "codex-session-1" }),
+    }).rejectionReason,
+    "encrypted_rollout_codex_provider_missing",
+  );
+  assert.equal(
+    validate({ currentCodexProvider: "different-provider" }).rejectionReason,
+    "encrypted_rollout_codex_provider_mismatch",
+  );
+  assert.equal(
+    validate({ sourceUpstreamProvider: " " }).rejectionReason,
+    "encrypted_rollout_upstream_provider_missing",
+  );
+  assert.equal(
+    validate({ sourceUpstreamProvider: "Azure" }).rejectionReason,
+    "encrypted_rollout_upstream_provider_mismatch",
+  );
+  assert.equal(
+    validate({ sourceModel: " " }).rejectionReason,
+    "encrypted_rollout_model_missing",
+  );
+  assert.equal(
+    validate({ sourceModel: "gpt-5.5" }).rejectionReason,
+    "encrypted_rollout_model_mismatch",
+  );
+});
+
+test("rollout bootstrap allows visible-only history without encrypted provenance", () => {
+  const result = validate({
+    rollout: rolloutSnapshot({
+      sessionId: "codex-session-1",
+      encrypted: false,
+    }),
+    sourceModel: " ",
+    sourceUpstreamProvider: " ",
+    currentCodexProvider: " ",
+  });
+
+  assert.equal(result.rejectionReason, undefined);
+  assert.equal(result.history?.revision, "rollout-revision");
+});

--- a/components/adapters/codex/tests/context-rebase-behavior.test.ts
+++ b/components/adapters/codex/tests/context-rebase-behavior.test.ts
@@ -317,6 +317,10 @@ test("CDR-01 rejects malformed, duplicate, and protocol-mismatched tool closure"
     { type: "function_call", call_id: "mismatch", name: "run", arguments: "{}" },
     { type: "custom_tool_call_output", call_id: "mismatch", output: "done" },
   ], /tool_closure_type_mismatch:mismatch/);
+  assertUnsafeCurrentInput([
+    { type: "function_call_output", call_id: "reversed", output: "done" },
+    { type: "function_call", call_id: "reversed", name: "run", arguments: "{}" },
+  ], /tool_output_before_call:reversed/);
 });
 
 test("CDR-04 retries the original request once when rebase replay is rejected upstream", async () => {

--- a/components/adapters/codex/tests/context-rebase-capability.test.ts
+++ b/components/adapters/codex/tests/context-rebase-capability.test.ts
@@ -168,6 +168,77 @@ test("CDR-05 Provider Capability Cache learns 400 schema item rejection and skip
   });
 });
 
+test("CDR-05 Provider Capability Cache falls back and remembers encrypted compaction rejection", async () => {
+  await withTempState(async (stateDir) => {
+    const originalPayload = {
+      model: "gpt-5.6-sol",
+      previous_response_id: "resp-old",
+      input: [{ role: "user", content: "current" }],
+    };
+    const rebasedPayload = {
+      model: "gpt-5.6-sol",
+      input: [
+        { type: "compaction", encrypted_content: "provider-bound-payload" },
+        { role: "user", content: "current" },
+      ],
+    };
+    const firstPayloads: JsonObject[] = [];
+    const first = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-compaction-capability",
+      planId: "plan-compaction-capability",
+      epochId: "epoch-compaction-capability",
+      originalPayload,
+      rebasedPayload,
+      capabilityStore: {
+        stateDir,
+        provider: "OpenAI",
+        model: "gpt-5.6-sol",
+      },
+      async sendUpstream(payload) {
+        firstPayloads.push(payload);
+        return firstPayloads.length === 1
+          ? {
+            status: 400,
+            headers: { "content-type": "application/json" },
+            text: JSON.stringify({
+              error: {
+                code: "invalid_encrypted_content",
+                message: "Unsupported compaction encrypted content",
+              },
+            }),
+          }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(first.outcome, "bypassed");
+    assert.deepEqual(first.capability?.unsupportedItemTypes, ["compaction"]);
+    assert.deepEqual(firstPayloads, [rebasedPayload, originalPayload]);
+
+    const secondPayloads: JsonObject[] = [];
+    const second = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-compaction-capability",
+      planId: "plan-compaction-capability-next",
+      epochId: "epoch-compaction-capability-next",
+      originalPayload,
+      rebasedPayload,
+      capabilityStore: {
+        stateDir,
+        provider: "OpenAI",
+        model: "gpt-5.6-sol",
+      },
+      async sendUpstream(payload) {
+        secondPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-next", output: [] }) };
+      },
+    });
+
+    assert.equal(second.outcome, "bypassed");
+    assert.deepEqual(second.capability?.skippedItemTypes, ["compaction"]);
+    assert.deepEqual(secondPayloads, [originalPayload]);
+  });
+});
+
 test("CDR-05 Provider Capability Cache skips unsupported rebases before opening an epoch", async () => {
   await withTempState(async (stateDir) => {
     await appendCodexRebaseCapability({

--- a/components/adapters/codex/tests/context-rebase-epoch.test.ts
+++ b/components/adapters/codex/tests/context-rebase-epoch.test.ts
@@ -389,6 +389,52 @@ test("CDR-01 Rebase Epoch bypasses when another epoch is already in flight", asy
   });
 });
 
+test("CDR-01 Rebase Epoch allows different sessions to rebase concurrently", async () => {
+  await withTempState(async (stateDir) => {
+    let releaseBoth!: () => void;
+    const bothCanFinish = new Promise<void>((resolve) => {
+      releaseBoth = resolve;
+    });
+    let signalFirstStarted!: () => void;
+    let signalSecondStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      signalFirstStarted = resolve;
+    });
+    const secondStarted = new Promise<void>((resolve) => {
+      signalSecondStarted = resolve;
+    });
+
+    const run = (sessionId: string, epochId: string, signalStarted: () => void) =>
+      executeCodexRebaseWithFallback({
+        sessionId,
+        planId: `plan-${sessionId}`,
+        epochId,
+        originalPayload: { previous_response_id: `resp-old-${sessionId}`, input: [] },
+        rebasedPayload: { input: [{ role: "user", content: `rebased-${sessionId}` }] },
+        epochStore: {
+          stateDir,
+          oldPreviousResponseId: `resp-old-${sessionId}`,
+          oldRevision: `rev-old-${sessionId}`,
+        },
+        async sendUpstream() {
+          signalStarted();
+          await bothCanFinish;
+          return { status: 200, headers: {}, text: JSON.stringify({ id: `resp-new-${sessionId}`, output: [] }) };
+        },
+      });
+
+    const first = run("session-a", "epoch-a", signalFirstStarted);
+    const second = run("session-b", "epoch-b", signalSecondStarted);
+    await Promise.all([firstStarted, secondStarted]);
+    releaseBoth();
+
+    const results = await Promise.all([first, second]);
+    assert.deepEqual(results.map((result) => result.outcome), ["committed", "committed"]);
+    assert.equal((await readLatestCodexRebaseEpoch({ stateDir, sessionId: "session-a" }))?.status, "committed");
+    assert.equal((await readLatestCodexRebaseEpoch({ stateDir, sessionId: "session-b" }))?.status, "committed");
+  });
+});
+
 test("CDR-01 Rebase Epoch serializes concurrent attempts for the same session", async () => {
   await withTempState(async (stateDir) => {
     const sentInputs: string[] = [];

--- a/components/adapters/codex/tests/context-rebase-pipeline.test.ts
+++ b/components/adapters/codex/tests/context-rebase-pipeline.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createServer as createHttpServer } from "node:http";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -10,6 +10,7 @@ import { normalizeTokenPilotCodexConfig } from "../src/config.js";
 import {
   buildCodexEffectiveHistory,
   loadCodexContextHistoryJournal,
+  parseCodexRollout,
 } from "../src/context-history/index.js";
 import { createConsoleLogger } from "../src/logger.js";
 import { startCodexResponsesProxy } from "../src/proxy-runtime.js";
@@ -18,7 +19,12 @@ import {
   appendPendingCodexRebaseEpoch,
   readLatestCodexRebaseEpoch,
 } from "../src/context-rewrite/index.js";
-import { resolveCodexSessionIdByResponseId } from "../src/session-state.js";
+import {
+  loadCodexSessionSnapshot,
+  resolveCodexSessionAlias,
+  resolveCodexSessionIdByResponseId,
+  upsertCodexSessionSnapshot,
+} from "../src/session-state.js";
 
 type JsonObject = Record<string, unknown>;
 
@@ -408,6 +414,123 @@ test("CDR-06 proxy pipeline rebases a non-stream request from effective history"
     assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
     assert.doesNotMatch(inputText(upstream.requests[1]), /OLD_SENTINEL_PIPELINE/);
     assert.match(inputText(upstream.requests[1]), /CURRENT_SENTINEL_PIPELINE/);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 proxy bootstraps a rebase from the hook-persisted Codex rollout", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rollout-bootstrap-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const codexSessionId = "019f-rollout-bootstrap-session";
+    const rolloutPath = join(stateDir, "rollout.jsonl");
+    const rolloutRecords = [
+      {
+        timestamp: "2026-08-02T00:00:00.000Z",
+        type: "session_meta",
+        payload: { id: codexSessionId, cwd: "/workspace/example", model_provider: "tokenpilot" },
+      },
+      {
+        timestamp: "2026-08-02T00:00:01.000Z",
+        type: "compacted",
+        payload: {
+          replacement_history: [
+            {
+              id: "msg-rollout-old",
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "OLD_ROLLOUT_SENTINEL" }],
+            },
+            {
+              id: "cmp-rollout-1",
+              type: "compaction",
+              encrypted_content: "opaque-compaction-payload",
+              internal_chat_message_metadata_passthrough: { source: "codex" },
+            },
+            {
+              id: "msg-rollout-keep",
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "KEEP_ROLLOUT_SENTINEL" }],
+            },
+          ],
+        },
+      },
+    ];
+    await writeFile(
+      rolloutPath,
+      `${rolloutRecords.map((record) => JSON.stringify(record)).join("\n")}\n`,
+      "utf8",
+    );
+    await upsertCodexSessionSnapshot(stateDir, codexSessionId, {
+      codexSessionId,
+      transcriptPath: rolloutPath,
+      latestModel: "gpt-5.4-mini",
+      latestUpstreamProvider: "OpenAI",
+    }, { markLatest: false });
+
+    const parsedRollout = await parseCodexRollout(rolloutPath);
+    assert.ok(parsedRollout);
+    assert.equal(parsedRollout.history.incomplete, false);
+    const oldItem = parsedRollout.history.replayableItems.find(
+      (entry) => JSON.stringify(entry.item).includes("OLD_ROLLOUT_SENTINEL"),
+    );
+    assert.ok(oldItem);
+
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: { stabilizer: false, reduction: false },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+        mutationPlan: {
+          operations: [{ type: "evict", stableItemId: oldItem.stableItemId }],
+        },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({ config, logger: createConsoleLogger(false) });
+
+    const response = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-before-proxy-journal",
+        prompt_cache_key: codexSessionId,
+        input: [{ role: "user", content: "CURRENT_ROLLOUT_SENTINEL" }],
+      }),
+    });
+    assert.equal(response.status, 200);
+    await response.text();
+
+    assert.equal(upstream.requests.length, 1);
+    const rebasedPayload = upstream.requests[0];
+    assert.equal("previous_response_id" in (rebasedPayload ?? {}), false);
+    assert.doesNotMatch(inputText(rebasedPayload), /OLD_ROLLOUT_SENTINEL/);
+    assert.match(inputText(rebasedPayload), /KEEP_ROLLOUT_SENTINEL/);
+    assert.match(inputText(rebasedPayload), /CURRENT_ROLLOUT_SENTINEL/);
+    assert.match(inputText(rebasedPayload), /\"type\":\"compaction\"/);
+
+    const synthesizedSessionId = await resolveCodexSessionAlias(stateDir, codexSessionId);
+    assert.ok(synthesizedSessionId);
+    assert.equal(
+      (await loadCodexSessionSnapshot(stateDir, synthesizedSessionId))?.transcriptPath,
+      rolloutPath,
+    );
   } finally {
     await runtime?.close();
     await upstream.close();

--- a/components/adapters/codex/tests/e2e.test.ts
+++ b/components/adapters/codex/tests/e2e.test.ts
@@ -203,7 +203,19 @@ test("Codex host e2e wires install, proxy reduction, report/visual, and MCP reco
       },
     });
 
-    const { handleCommand } = createCodexCliBridge({ host: "codex" });
+    const { handleCommand } = createCodexCliBridge({
+      host: "codex",
+      async handleVisualCommand(selection) {
+        const visualSessions = await readVisualSessionList(stateDir);
+        const sessionId = selection.sessionId ?? visualSessions[0]?.sessionId ?? "";
+        return {
+          text: [
+            `LightMem2 visual: http://127.0.0.1:43111/?host=${selection.host ?? "codex"}&session=${sessionId}`,
+            `- Codex: ${visualSessions.length} session snapshots`,
+          ].join("\n"),
+        };
+      },
+    });
 
     await assertProductSurfaceSmoke({
       run(args) {
@@ -1181,7 +1193,14 @@ test("Codex CLI report and visual return clear empty-state messages before any r
       tokenPilotConfigPath,
     );
 
-    const { handleCommand } = createCodexCliBridge({ host: "codex" });
+    const { handleCommand } = createCodexCliBridge({
+      host: "codex",
+      async handleVisualCommand(selection) {
+        return {
+          text: `LightMem2 visual: http://127.0.0.1:43111/?host=${selection.host ?? "codex"}`,
+        };
+      },
+    });
 
     const report = await handleCommand({ args: "report" });
     assert.equal(report.text, "No TokenPilot session stats yet.");

--- a/components/adapters/codex/tests/hooks-handler.test.ts
+++ b/components/adapters/codex/tests/hooks-handler.test.ts
@@ -30,6 +30,8 @@ test("processCodexHookEvent records hook snapshot metadata without overriding th
     await processCodexHookEvent({
       hook_event_name: "PostToolUse",
       session_id: "019f-real-codex-session",
+      transcript_path: "/tmp/codex-rollout.jsonl",
+      model: "gpt-5.6-sol",
       cwd: "/repo/from-hook",
       tool_name: "read",
       tool_input: "file.ts",
@@ -45,11 +47,17 @@ test("processCodexHookEvent records hook snapshot metadata without overriding th
       "utf8",
     );
     const hookSnapshot = JSON.parse(hookSnapshotRaw) as {
+      codexSessionId?: string;
+      latestModel?: string;
       workspaceHint?: string;
+      transcriptPath?: string;
       lastHookEvent?: string;
       lastToolName?: string;
     };
+    assert.equal(hookSnapshot.codexSessionId, "019f-real-codex-session");
+    assert.equal(hookSnapshot.latestModel, "gpt-5.6-sol");
     assert.equal(hookSnapshot.workspaceHint, "/repo/from-hook");
+    assert.equal(hookSnapshot.transcriptPath, "/tmp/codex-rollout.jsonl");
     assert.equal(hookSnapshot.lastHookEvent, "PostToolUse");
     assert.equal(hookSnapshot.lastToolName, "read");
   } finally {

--- a/components/adapters/codex/tests/install.test.ts
+++ b/components/adapters/codex/tests/install.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { after, before } from "node:test";
 import { spawn } from "node:child_process";
 import { chmod, lstat, mkdtemp, mkdir, readFile, readlink, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "node:net";
+import { reserveUnusedPort } from "@lightmem2/host-adapter";
 import { readCliContextState } from "../../../products/cli/src/context-store.js";
 import {
   loadTokenPilotCodexConfig,
@@ -18,17 +19,34 @@ import {
   resolveCodexHookCommandForInstall,
 } from "../src/install.js";
 
+const originalSuiteHome = process.env.HOME;
+const originalSuiteUserProfile = process.env.USERPROFILE;
+let installSuiteHome = "";
+
+before(async () => {
+  installSuiteHome = await mkdtemp(join(tmpdir(), "lightmem2-codex-install-suite-"));
+  process.env.HOME = installSuiteHome;
+  process.env.USERPROFILE = installSuiteHome;
+});
+
+after(async () => {
+  if (originalSuiteHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalSuiteHome;
+  if (originalSuiteUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalSuiteUserProfile;
+  if (installSuiteHome) {
+    await rm(installSuiteHome, { recursive: true, force: true });
+  }
+});
+
 function installCodexTokenPilot(
   params: NonNullable<Parameters<typeof installCodexTokenPilotBase>[0]>,
 ) {
+  const testRoot = dirname(params.codexConfigPath ?? params.tokenPilotConfigPath ?? tmpdir());
   return installCodexTokenPilotBase({
     ...params,
-    cliContextPath: join(
-      dirname(params.codexConfigPath ?? params.tokenPilotConfigPath ?? tmpdir()),
-      ".lightmem2",
-      "state",
-      "cli-context.json",
-    ),
+    cliBinDir: params.cliBinDir ?? join(testRoot, "bin"),
+    cliContextPath: join(testRoot, ".lightmem2", "state", "cli-context.json"),
   });
 }
 
@@ -67,11 +85,11 @@ test("installCodexTokenPilot writes provider, MCP, and hooks with expected comma
     assert.doesNotMatch(codexToml, /\[model_providers\.tokenpilot\]/);
     assert.match(codexToml, /\[mcp_servers\.tokenpilot_memory_fault_recover\]/);
     assert.match(codexToml, /startup_timeout_sec\s*=\s*90/);
-    assert.match(codexToml, new RegExp(result.expectedMcpCommand.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.equal(codexToml.includes(`command = ${JSON.stringify(result.expectedMcpCommand)}`), true);
     assert.equal(result.expectedMcpArgs.length, 1);
     assert.match(result.expectedMcpArgs[0] ?? "", /dist[\/\\]server\.js$/);
     for (const arg of result.expectedMcpArgs) {
-      assert.match(codexToml, new RegExp(arg.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+      assert.equal(codexToml.includes(JSON.stringify(arg)), true);
     }
     assert.equal(result.expectedMcpStartupTimeoutSec, 90);
     assert.equal(result.mcpProbe.ok, true);
@@ -89,10 +107,15 @@ test("installCodexTokenPilot writes provider, MCP, and hooks with expected comma
     assert.equal(result.cliBinDir, cliBinDir);
     assert.equal(result.cliBinDirOnPath, false);
     assert.equal(result.hostCliBinPath, join(cliBinDir, "tokenpilot-codex"));
-    assert.equal((await lstat(result.cliBinPath)).isSymbolicLink(), true);
-    assert.match(await readlink(result.cliBinPath), /products[\/\\]cli[\/\\]dist[\/\\]cli\.js$/);
-    assert.equal((await lstat(result.hostCliBinPath!)).isSymbolicLink(), true);
-    assert.match(await readlink(result.hostCliBinPath!), /adapters[\/\\]codex[\/\\]dist[\/\\]cli\.js$/);
+    if (process.platform === "win32") {
+      assert.equal((await lstat(result.cliBinPath)).isFile(), true);
+      assert.equal((await lstat(result.hostCliBinPath!)).isFile(), true);
+    } else {
+      assert.equal((await lstat(result.cliBinPath)).isSymbolicLink(), true);
+      assert.match(await readlink(result.cliBinPath), /products[\/\\]cli[\/\\]dist[\/\\]cli\.js$/);
+      assert.equal((await lstat(result.hostCliBinPath!)).isSymbolicLink(), true);
+      assert.match(await readlink(result.hostCliBinPath!), /adapters[\/\\]codex[\/\\]dist[\/\\]cli\.js$/);
+    }
     const tokenPilotConfig = await loadTokenPilotCodexConfig(tokenPilotConfigPath);
     assert.equal(tokenPilotConfig.enabled, true);
     assert.equal(tokenPilotConfig.upstreamProvider, "OPENAI");
@@ -156,7 +179,9 @@ test("installCodexTokenPilot restores execute permission on the shared lightmem2
     });
 
     assert.equal(result.cliBinInstalled, true);
-    assert.equal(((await stat(cliDistPath)).mode & 0o111) !== 0, true);
+    if (process.platform !== "win32") {
+      assert.equal(((await stat(cliDistPath)).mode & 0o111) !== 0, true);
+    }
   } finally {
     await chmod(cliDistPath, originalMode).catch(() => undefined);
     await rm(dir, { recursive: true, force: true });
@@ -365,7 +390,7 @@ test("installCodexTokenPilot rewrites the MCP server block idempotently", async 
 test("installCodexTokenPilot shifts the proxy port when the preferred port is already occupied", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-install-port-shift-"));
   const blocker = await new Promise<{ server: import("node:net").Server; port: number }>((resolve, reject) => {
-    const server = createServer();
+    const server = createServer((socket) => socket.destroy());
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
       const address = server.address();
@@ -415,6 +440,7 @@ test("installCodexTokenPilot shifts the proxy port when the preferred port is al
 
 test("installCodexTokenPilot stops an existing daemon before resolving the proxy port", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-install-stop-daemon-"));
+  const daemonPort = await reserveUnusedPort();
   let dummy: ReturnType<typeof spawn> | undefined;
   try {
     const codexConfigPath = join(dir, "config.toml");
@@ -422,7 +448,7 @@ test("installCodexTokenPilot stops an existing daemon before resolving the proxy
     const tokenPilotConfigPath = join(dir, "tokenpilot.json");
     const stateDir = join(dir, "state");
     const config = normalizeTokenPilotCodexConfig({
-      proxyPort: 17680,
+      proxyPort: daemonPort,
       stateDir,
     });
     await writeTokenPilotCodexConfig(config, tokenPilotConfigPath);
@@ -442,7 +468,7 @@ test("installCodexTokenPilot stops an existing daemon before resolving the proxy
         "  res.writeHead(404);",
         "  res.end('not found');",
         "});",
-        "server.listen(17680, '127.0.0.1');",
+        `server.listen(${daemonPort}, '127.0.0.1');`,
         "setInterval(() => {}, 1000);",
       ].join(" "),
     ], {
@@ -469,8 +495,8 @@ test("installCodexTokenPilot stops an existing daemon before resolving the proxy
     });
 
     const persisted = await loadTokenPilotCodexConfig(tokenPilotConfigPath);
-    assert.equal(persisted.proxyPort, 17680);
-    assert.equal(result.baseUrl, "http://127.0.0.1:17680/v1");
+    assert.equal(persisted.proxyPort, daemonPort);
+    assert.equal(result.baseUrl, `http://127.0.0.1:${daemonPort}/v1`);
     assert.equal((await readDaemonStatus(persisted)).running, false);
   } finally {
     if (dummy?.pid) {
@@ -491,7 +517,8 @@ test("resolveCodexHookCommandForInstall finds the adapter root from the bundled 
   try {
     process.chdir(dirname(repoRoot));
     const command = await resolveCodexHookCommandForInstall(process.platform, bundledCliModuleDir);
-    assert.match(command, /adapters[\/\\]codex[\/\\]dist[\/\\](hooks-handler\.js|tokenpilot-codex-hook\.cmd)/);
+    const executable = command.startsWith("\"") ? JSON.parse(command) as string : command;
+    assert.match(executable, /adapters[\/\\]codex[\/\\]dist[\/\\](hooks-handler\.js|tokenpilot-codex-hook\.cmd)/);
   } finally {
     process.chdir(originalCwd);
   }

--- a/components/adapters/codex/tests/reduction.test.ts
+++ b/components/adapters/codex/tests/reduction.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import test from "node:test";
+import test, { after, before } from "node:test";
 
 import { createCodexResponsesPayloadCodec } from "../src/responses-codec.js";
 import {
@@ -12,6 +12,30 @@ import {
 } from "../src/reduction.js";
 import { normalizeTokenPilotCodexConfig } from "../src/config.js";
 import { loadCodexSessionSnapshot, upsertCodexSessionSnapshot } from "../src/session-state.js";
+
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const originalLightmem2StateDir = process.env.LIGHTMEM2_STATE_DIR;
+let reductionSuiteHome = "";
+
+before(async () => {
+  reductionSuiteHome = await mkdtemp(join(tmpdir(), "lightmem2-codex-reduction-suite-"));
+  process.env.HOME = reductionSuiteHome;
+  process.env.USERPROFILE = reductionSuiteHome;
+  process.env.LIGHTMEM2_STATE_DIR = join(reductionSuiteHome, ".lightmem2", "state");
+});
+
+after(async () => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  if (originalLightmem2StateDir === undefined) delete process.env.LIGHTMEM2_STATE_DIR;
+  else process.env.LIGHTMEM2_STATE_DIR = originalLightmem2StateDir;
+  if (reductionSuiteHome) {
+    await rm(reductionSuiteHome, { recursive: true, force: true });
+  }
+});
 
 test("normalizeResponsesInputForUpstream stringifies structured function payloads", () => {
   const input: any[] = [

--- a/components/adapters/codex/tests/session-state.test.ts
+++ b/components/adapters/codex/tests/session-state.test.ts
@@ -22,8 +22,11 @@ test("session-state persists snapshots and recent turn bindings per session", as
   const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-session-state-"));
   try {
     await upsertCodexSessionSnapshot(stateDir, "session-a", {
+      codexSessionId: "019f-session-a",
       workspaceHint: "/tmp/workspace-a",
+      transcriptPath: "/tmp/rollout-session-a.jsonl",
       latestModel: "gpt-5.4-mini",
+      latestUpstreamProvider: "OpenAI",
       lastHookEvent: "PostToolUse",
       lastToolName: "read",
       lastToolInputChars: 32,
@@ -59,7 +62,10 @@ test("session-state persists snapshots and recent turn bindings per session", as
     const bindings = await loadCodexRecentTurnBindings(stateDir, "session-a", 8);
     const latestSessionId = await resolveLatestCodexSessionId(stateDir);
 
+    assert.equal(snapshot?.codexSessionId, "019f-session-a");
     assert.equal(snapshot?.workspaceHint, "/tmp/workspace-a");
+    assert.equal(snapshot?.transcriptPath, "/tmp/rollout-session-a.jsonl");
+    assert.equal(snapshot?.latestUpstreamProvider, "OpenAI");
     assert.equal(snapshot?.lastToolName, "read");
     assert.equal(bindings.length, 2);
     assert.equal(bindings[0]?.responseId, "resp-3");
@@ -117,8 +123,11 @@ test("session-state can merge hook snapshot metadata into the synthesized proxy 
   const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-session-merge-"));
   try {
     await upsertCodexSessionSnapshot(stateDir, "019f-hook-session", {
+      codexSessionId: "019f-hook-session",
       workspaceHint: "/tmp/hook-workspace",
+      transcriptPath: "/tmp/hook-rollout.jsonl",
       latestModel: "gpt-5.4-mini",
+      latestUpstreamProvider: "OpenAI",
       lastHookEvent: "PostToolUse",
       lastToolName: "read",
       lastToolInputChars: 64,
@@ -133,7 +142,10 @@ test("session-state can merge hook snapshot metadata into the synthesized proxy 
 
     const merged = await mergeCodexSessionSnapshot(stateDir, "019f-hook-session", "codex-synth-1");
 
+    assert.equal(merged?.codexSessionId, "019f-hook-session");
     assert.equal(merged?.workspaceHint, "/tmp/hook-workspace");
+    assert.equal(merged?.transcriptPath, "/tmp/hook-rollout.jsonl");
+    assert.equal(merged?.latestUpstreamProvider, "OpenAI");
     assert.equal(merged?.lastHookEvent, "PostToolUse");
     assert.equal(merged?.lastToolName, "read");
     assert.equal(merged?.latestResponseId, "resp-1");

--- a/components/adapters/shared/cli-bin-install.ts
+++ b/components/adapters/shared/cli-bin-install.ts
@@ -1,11 +1,23 @@
 import { existsSync } from "node:fs";
-import { chmod, mkdir, symlink, unlink } from "node:fs/promises";
+import { chmod, link, mkdir, symlink, unlink } from "node:fs/promises";
 import { join, resolve, delimiter } from "node:path";
 
 function cliDistPathFromAdapterRoot(adapterRoot: string): string {
   const bundledPath = resolve(adapterRoot, "dist", "lightmem2.js");
   if (existsSync(bundledPath)) return bundledPath;
   return resolve(adapterRoot, "..", "..", "products", "cli", "dist", "cli.js");
+}
+
+async function createCliLink(targetPath: string, binPath: string): Promise<void> {
+  try {
+    await symlink(targetPath, binPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (process.platform !== "win32" || !["EACCES", "EPERM", "UNKNOWN"].includes(code ?? "")) {
+      throw error;
+    }
+    await link(targetPath, binPath);
+  }
 }
 
 export async function installLightmem2CliBin(params: {
@@ -41,7 +53,7 @@ export async function installLightmem2CliBin(params: {
   await mkdir(binDir, { recursive: true });
   await chmod(cliDistPath, 0o755).catch(() => undefined);
   await unlink(binPath).catch(() => undefined);
-  await symlink(cliDistPath, binPath);
+  await createCliLink(cliDistPath, binPath);
   await chmod(binPath, 0o755).catch(() => undefined);
 
   return {

--- a/components/adapters/shared/host-cli-bin-install.ts
+++ b/components/adapters/shared/host-cli-bin-install.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, symlink, unlink } from "node:fs/promises";
+import { chmod, link, mkdir, symlink, unlink } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import type { CliHostId } from "../../products/cli/src/hosts/registry.js";
 
@@ -10,6 +10,18 @@ function hostCliBinName(host: CliHostId): string {
   if (host === "codex") return "tokenpilot-codex";
   if (host === "claude-code") return "tokenpilot-claude-code";
   throw new Error(`unsupported host CLI bin install: ${host}`);
+}
+
+async function createCliLink(targetPath: string, binPath: string): Promise<void> {
+  try {
+    await symlink(targetPath, binPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (process.platform !== "win32" || !["EACCES", "EPERM", "UNKNOWN"].includes(code ?? "")) {
+      throw error;
+    }
+    await link(targetPath, binPath);
+  }
 }
 
 export async function installHostCliBin(params: {
@@ -29,7 +41,7 @@ export async function installHostCliBin(params: {
   await mkdir(dirname(binPath), { recursive: true });
   await chmod(cliDistPath, 0o755).catch(() => undefined);
   await unlink(binPath).catch(() => undefined);
-  await symlink(cliDistPath, binPath);
+  await createCliLink(cliDistPath, binPath);
   await chmod(binPath, 0o755).catch(() => undefined);
 
   return {

--- a/components/packages/foundation/host-adapter/src/testing/host-e2e.ts
+++ b/components/packages/foundation/host-adapter/src/testing/host-e2e.ts
@@ -31,7 +31,9 @@ export async function withTempHome<T>(
 ): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), prefix));
   const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
   process.env.HOME = homeDir;
+  process.env.USERPROFILE = homeDir;
   try {
     return await fn(homeDir);
   } finally {
@@ -39,6 +41,11 @@ export async function withTempHome<T>(
       delete process.env.HOME;
     } else {
       process.env.HOME = originalHome;
+    }
+    if (originalUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalUserProfile;
     }
     await rm(homeDir, { recursive: true, force: true });
   }

--- a/components/products/cli/src/hosts/codex.ts
+++ b/components/products/cli/src/hosts/codex.ts
@@ -120,6 +120,10 @@ export function createCodexCliBridge(target: {
   host: "codex";
   sessionId?: string;
   pathOverrides?: CliHostPathOverrides;
+  handleVisualCommand?(params: {
+    host?: string;
+    sessionId?: string;
+  }): Promise<{ text: string }>;
 }): {
   bridge: ProductSurfaceHostBridge;
   configAdapter: ProductSurfaceConfigAdapter;
@@ -156,7 +160,7 @@ export function createCodexCliBridge(target: {
         currentConfig,
         explicitSessionId: target.sessionId,
       });
-      return handleStandaloneVisualCommandWithSelection({
+      return (target.handleVisualCommand ?? handleStandaloneVisualCommandWithSelection)({
         host: "codex",
         sessionId,
       });


### PR DESCRIPTION
## Summary

- wire Codex rollout history bootstrap into the production rebase path
- validate session, provider, upstream, and model provenance before replay
- support encrypted compaction replay and reject invalid tool-call ordering
- persist the session and rollout metadata required for safe recovery
- harden daemon restart, proxy-port reuse, and Windows CLI installation
- add unit, integration, capability-fallback, epoch, install, and E2E coverage

## Why

Codex context rebasing could previously bootstrap history without enough
session or provenance validation. Some replayable compaction payloads were
also misclassified, and invalid tool output ordering was not rejected.

These changes make rollout bootstrap fail closed and preserve the original
request whenever compatibility or provenance cannot be established.

## Validation

- Codex tests: 201/201 passed
- Codex TypeScript check passed
- host-adapter TypeScript check passed
- package boundary check passed: 16 packages, 57 edges
- `git diff --check` passed

## Scope

The parser-owned files below are intentionally unchanged:

- `context-history/rollout-parser.ts`
- `tests/context-history-rollout.test.ts`
- `tests/fixtures/rollout/**`

Parser-side replacement-history validation and resource limits remain
separate follow-up work.