### PR TITLE
Claude request overlay

### DIFF
--- a/components/adapters/claude-code/package.json
+++ b/components/adapters/claude-code/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@lightmem2/artifact-store": "workspace:*",
     "@lightmem2/tokenpilot": "workspace:*",
+    "@lightmem2/eviction": "workspace:*",
     "@lightmem2/host-adapter": "workspace:*",
     "@lightmem2/kernel": "workspace:*",
     "@lightmem2/mcp": "workspace:*",

--- a/components/adapters/claude-code/src/context-rewrite/backend.ts
+++ b/components/adapters/claude-code/src/context-rewrite/backend.ts
@@ -1,0 +1,124 @@
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextMutationPlan,
+  type ContextRewriteResult,
+  type ContextRewriteValidation,
+  type ModelContextRewriteBackend,
+  type ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+import type { RuntimeMessage } from "@lightmem2/kernel";
+
+import { buildClaudeContextSnapshot } from "./snapshot.js";
+
+const CLAUDE_HOST_ID = "claude-code";
+
+export type ClaudeOverlayRequest = {
+  sessionId: string;
+  revision: string;
+  messages: RuntimeMessage[];
+};
+
+// Front-checks that must all hold before any operation may apply. Mirrors the
+// openclaw reference backend, minus canonical-state specifics.
+function fatalReasonsFor(
+  snapshot: ModelContextSnapshot,
+  plan: ContextMutationPlan,
+): string[] {
+  const reasons: string[] = [];
+  if (plan.schemaVersion !== MODEL_CONTEXT_REWRITE_SCHEMA_VERSION) {
+    reasons.push(`unsupported schema version: ${plan.schemaVersion}`);
+  }
+  if (snapshot.hostId !== CLAUDE_HOST_ID || plan.hostId !== CLAUDE_HOST_ID) {
+    reasons.push("hostId must be claude-code");
+  }
+  if (plan.sessionId !== snapshot.sessionId) {
+    reasons.push("plan sessionId does not match snapshot");
+  }
+  if (plan.baseRevision !== snapshot.revision) {
+    reasons.push("plan baseRevision does not match snapshot");
+  }
+  const ids = new Set(snapshot.items.map((item) => item.stableId));
+  if (ids.size !== snapshot.items.length) {
+    reasons.push("snapshot item ids must be unique");
+  }
+  return reasons;
+}
+
+export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverlayRequest> = {
+  hostId: CLAUDE_HOST_ID,
+  mode: "request_overlay",
+
+  async readSnapshot({ sessionId, request }) {
+    return buildClaudeContextSnapshot({
+      sessionId,
+      revision: request.revision,
+      messages: request.messages,
+    });
+  },
+
+  async validate({ snapshot, plan }) {
+    const fatal = fatalReasonsFor(snapshot, plan);
+    if (fatal.length > 0) {
+      return {
+        valid: false,
+        applicableOperationIds: [],
+        deferredOperationIds: plan.operations.map((op) => op.id),
+        reasons: fatal,
+      };
+    }
+
+    // An operation is applicable only if every target item still exists in the
+    // snapshot and its fingerprint matches (proves the target survived any
+    // revision drift). Otherwise it is deferred, never fuzzily applied.
+    const itemById = new Map(snapshot.items.map((item) => [item.stableId, item]));
+    const applicableOperationIds: string[] = [];
+    const deferredOperationIds: string[] = [];
+    const reasons: string[] = [];
+
+    for (const op of plan.operations) {
+      const targetsOk = op.targetItemIds.every((id) => {
+        const item = itemById.get(id);
+        if (!item) return false;
+        const expected = op.targetItemFingerprints?.[id];
+        return expected === undefined || expected === item.fingerprint;
+      });
+      if (targetsOk) {
+        applicableOperationIds.push(op.id);
+      } else {
+        deferredOperationIds.push(op.id);
+        reasons.push(`operation ${op.id} targets are missing or drifted`);
+      }
+    }
+
+    return {
+      valid: true,
+      applicableOperationIds,
+      deferredOperationIds,
+      reasons,
+    };
+  },
+
+  async apply({ snapshot, plan, request }) {
+    const validation = await this.validate({ snapshot, plan });
+
+    // Skeleton: no request mutation yet. Returns the original request unchanged
+    // and reports what validate deemed applicable/deferred. remove/replace lands
+    // in the next step (CLA-02 apply).
+    const result: ContextRewriteResult = {
+      schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+      mode: "request_overlay",
+      planId: plan.planId,
+      applied: false,
+      changed: false,
+      previousRevision: snapshot.revision,
+      nextRevision: snapshot.revision,
+      appliedOperationIds: [],
+      deferredOperationIds: validation.deferredOperationIds,
+      removedItemIds: [],
+      savedChars: 0,
+      fallbackUsed: false,
+    };
+
+    return { request, result };
+  },
+};

--- a/components/adapters/claude-code/src/context-rewrite/backend.ts
+++ b/components/adapters/claude-code/src/context-rewrite/backend.ts
@@ -7,10 +7,11 @@ import {
   type ModelContextSnapshot,
 } from "@lightmem2/host-adapter";
 import type { RuntimeMessage } from "@lightmem2/kernel";
-
 import { buildClaudeContextSnapshot } from "./snapshot.js";
 
 const CLAUDE_HOST_ID = "claude-code";
+const TOOL_RESULT_POINTER = "[evicted: earlier tool result content removed]";
+const TEXT_POINTER = "[evicted: earlier content removed]";
 
 export type ClaudeOverlayRequest = {
   sessionId: string;
@@ -44,6 +45,55 @@ function fatalReasonsFor(
   return reasons;
 }
 
+type ParsedStableId = { msgIdx: number; blockIdx: number };
+
+function parseStableId(id: string): ParsedStableId | undefined {
+  const parts = id.split(":");
+  if (parts.length < 3) return undefined;
+  const msgIdx = Number(parts[parts.length - 2]);
+  const blockIdx = Number(parts[parts.length - 1]);
+  if (!Number.isInteger(msgIdx) || !Number.isInteger(blockIdx)) return undefined;
+  return { msgIdx, blockIdx };
+}
+
+function asBlockRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function lastUserMessageIndex(messages: RuntimeMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (messages[i]?.role === "user") return i;
+  }
+  return -1;
+}
+
+function blockCharCount(block: Record<string, unknown>): number {
+  const value =
+    block.type === "tool_result"
+      ? block.content
+      : block.type === "tool_use"
+        ? block.input
+        : (block.text ?? block.content);
+  if (typeof value === "string") return value.length;
+  return JSON.stringify(value ?? "").length;
+}
+
+// Rewrite a single block to its pointer stub. tool_result keeps its type and
+// tool_use_id so the tool-use/tool-result pair stays closed; only the content
+// is replaced. Other blocks become a short text stub.
+function stubBlock(block: Record<string, unknown>): Record<string, unknown> {
+  if (block.type === "tool_result") {
+    return {
+      type: "tool_result",
+      tool_use_id: block.tool_use_id,
+      content: TOOL_RESULT_POINTER,
+    };
+  }
+  return { type: "text", text: TEXT_POINTER };
+}
+
 export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverlayRequest> = {
   hostId: CLAUDE_HOST_ID,
   mode: "request_overlay",
@@ -66,7 +116,6 @@ export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverl
         reasons: fatal,
       };
     }
-
     // An operation is applicable only if every target item still exists in the
     // snapshot and its fingerprint matches (proves the target survived any
     // revision drift). Otherwise it is deferred, never fuzzily applied.
@@ -74,7 +123,6 @@ export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverl
     const applicableOperationIds: string[] = [];
     const deferredOperationIds: string[] = [];
     const reasons: string[] = [];
-
     for (const op of plan.operations) {
       const targetsOk = op.targetItemIds.every((id) => {
         const item = itemById.get(id);
@@ -89,7 +137,6 @@ export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverl
         reasons.push(`operation ${op.id} targets are missing or drifted`);
       }
     }
-
     return {
       valid: true,
       applicableOperationIds,
@@ -101,10 +148,7 @@ export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverl
   async apply({ snapshot, plan, request }) {
     const validation = await this.validate({ snapshot, plan });
 
-    // Skeleton: no request mutation yet. Returns the original request unchanged
-    // and reports what validate deemed applicable/deferred. remove/replace lands
-    // in the next step (CLA-02 apply).
-    const result: ContextRewriteResult = {
+    const unchanged = (fallbackUsed: boolean): ContextRewriteResult => ({
       schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
       mode: "request_overlay",
       planId: plan.planId,
@@ -113,12 +157,85 @@ export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverl
       previousRevision: snapshot.revision,
       nextRevision: snapshot.revision,
       appliedOperationIds: [],
-      deferredOperationIds: validation.deferredOperationIds,
+      deferredOperationIds: plan.operations.map((op) => op.id),
       removedItemIds: [],
       savedChars: 0,
-      fallbackUsed: false,
-    };
+      fallbackUsed,
+    });
 
-    return { request, result };
+    if (!validation.valid || validation.applicableOperationIds.length === 0) {
+      return { request, result: unchanged(false) };
+    }
+
+    try {
+      // Guard against drift: the request we are about to rewrite must still
+      // describe the same revision the plan was validated against.
+      const current = buildClaudeContextSnapshot({
+        sessionId: request.sessionId,
+        revision: request.revision,
+        messages: request.messages,
+      });
+      if (current.revision !== snapshot.revision) {
+        return { request, result: unchanged(false) };
+      }
+
+      const messages = structuredClone(request.messages);
+      const protectedIdx = lastUserMessageIndex(messages);
+      const applicable = new Set(validation.applicableOperationIds);
+
+      const removedItemIds: string[] = [];
+      const appliedOperationIds: string[] = [];
+      const deferredOperationIds = [...validation.deferredOperationIds];
+      let savedChars = 0;
+
+      for (const op of plan.operations) {
+        if (!applicable.has(op.id)) continue;
+        let opTouched = false;
+
+        for (const itemId of op.targetItemIds) {
+          const parsed = parseStableId(itemId);
+          if (!parsed) continue;
+          const { msgIdx, blockIdx } = parsed;
+          // Never rewrite the current user turn.
+          if (msgIdx === protectedIdx) continue;
+          const message = messages[msgIdx];
+          if (!message || typeof message.content === "string") continue;
+          const block = asBlockRecord(message.content[blockIdx]);
+          if (!block) continue;
+          // tool_use is half of a pair; leave it so closure stays intact.
+          if (block.type === "tool_use") continue;
+
+          const stub = stubBlock(block);
+          savedChars += Math.max(0, blockCharCount(block) - blockCharCount(stub));
+          message.content[blockIdx] = stub as never;
+          removedItemIds.push(itemId);
+          opTouched = true;
+        }
+
+        if (opTouched) appliedOperationIds.push(op.id);
+        else deferredOperationIds.push(op.id);
+      }
+
+      const changed = removedItemIds.length > 0;
+      const nextRequest = changed ? { ...request, messages } : request;
+
+      const result: ContextRewriteResult = {
+        schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+        mode: "request_overlay",
+        planId: plan.planId,
+        applied: appliedOperationIds.length > 0,
+        changed,
+        previousRevision: snapshot.revision,
+        nextRevision: snapshot.revision,
+        appliedOperationIds,
+        deferredOperationIds,
+        removedItemIds,
+        savedChars,
+        fallbackUsed: false,
+      };
+      return { request: nextRequest, result };
+    } catch {
+      return { request, result: unchanged(true) };
+    }
   },
 };

--- a/components/adapters/claude-code/src/context-rewrite/snapshot.ts
+++ b/components/adapters/claude-code/src/context-rewrite/snapshot.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextItemKind,
+  type ContextItemRef,
+  type ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+import type { RuntimeMessage } from "@lightmem2/kernel";
+
+const CLAUDE_HOST_ID = "claude-code";
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+// Content-only digest. The persisted snapshot stores fingerprints, never raw
+// host payloads, so evicted text cannot leak through the shared contract.
+function fingerprint(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(value) ?? "undefined")
+    .digest("hex")
+    .slice(0, 32);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function contentBlocks(message: Record<string, unknown>): Record<string, unknown>[] {
+  return Array.isArray(message.content)
+    ? message.content
+        .map(asRecord)
+        .filter((block): block is Record<string, unknown> => block !== undefined)
+    : [];
+}
+
+function textLength(value: unknown): number {
+  if (typeof value === "string") return value.length;
+  return JSON.stringify(value ?? "").length;
+}
+
+// Map an Anthropic content block to the shared ContextItemKind vocabulary.
+function blockKind(role: string, block: Record<string, unknown>): ContextItemKind {
+  const type = String(block.type ?? "").toLowerCase();
+  if (type === "tool_use") return "tool_call";
+  if (type === "tool_result") return "tool_result";
+  if (role === "system") return "system";
+  if (role === "user") return "user";
+  if (role === "assistant") return "assistant";
+  return "unknown";
+}
+
+function blockToItemRef(
+  sessionId: string,
+  messageIndex: number,
+  blockIndex: number,
+  role: string,
+  block: Record<string, unknown>,
+): ContextItemRef {
+  const kind = blockKind(role, block);
+  const callId =
+    stringValue(block.tool_use_id) ?? stringValue(block.id);
+  const content =
+    block.type === "tool_result"
+      ? block.content
+      : block.type === "tool_use"
+        ? block.input
+        : (block.text ?? block.content);
+
+  return {
+    // Position-based identity within the session; stable across resends of the
+    // same history because message/block order is preserved.
+    stableId: `${sessionId}:${messageIndex}:${blockIndex}`,
+    kind,
+    role,
+    callId,
+    fingerprint: fingerprint({ kind, callId, content }),
+    chars: textLength(content),
+  };
+}
+
+function messageToItemRefs(
+  sessionId: string,
+  messageIndex: number,
+  message: RuntimeMessage,
+): ContextItemRef[] {
+  const record = asRecord(message) ?? {};
+  const role = String(record.role ?? "unknown");
+
+  // String content is a single implicit block.
+  if (typeof record.content === "string") {
+    return [
+      {
+        stableId: `${sessionId}:${messageIndex}:0`,
+        kind: role === "user" ? "user" : role === "assistant" ? "assistant" : "system",
+        role,
+        fingerprint: fingerprint({ role, content: record.content }),
+        chars: record.content.length,
+      },
+    ];
+  }
+
+  return contentBlocks(record).map((block, blockIndex) =>
+    blockToItemRef(sessionId, messageIndex, blockIndex, role, block),
+  );
+}
+
+// Build a full snapshot of the current inbound request. One snapshot per
+// request; it reflects the latest complete history, not an accumulation.
+export function buildClaudeContextSnapshot(params: {
+  sessionId: string;
+  revision: string;
+  messages: RuntimeMessage[];
+}): ModelContextSnapshot {
+  const items: ContextItemRef[] = [];
+  params.messages.forEach((message, messageIndex) => {
+    items.push(...messageToItemRefs(params.sessionId, messageIndex, message));
+  });
+
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    hostId: CLAUDE_HOST_ID,
+    sessionId: params.sessionId,
+    revision: params.revision,
+    items,
+  };
+}

--- a/components/adapters/claude-code/src/doctor.ts
+++ b/components/adapters/claude-code/src/doctor.ts
@@ -38,6 +38,9 @@ export type ClaudeCodeDoctorReport = {
   installedHookEvents: string[];
   missingHookEvents: string[];
   routedViaGateway: boolean;
+  overlayBackendMode: string;
+  overlayEvictionEnabled: boolean;
+  overlayEvictionFailureMode: string;
   toolSearchEnabled: boolean;
   proxyHealthy: boolean;
   upstreamBaseUrl: string;
@@ -123,6 +126,9 @@ export function formatClaudeCodeDoctorReport(report: ClaudeCodeDoctorReport): st
     `- recovery MCP args match: ${report.mcpArgsMatch ? "yes" : "no"}`,
     `- recovery MCP startup timeout matches: ${report.mcpStartupTimeoutSecMatches ? "yes" : "no"}`,
     `- routed via gateway: ${report.routedViaGateway ? "yes" : "no"}`,
+    `- overlay backend mode: ${report.overlayBackendMode}`,
+    `- overlay eviction enabled: ${report.overlayEvictionEnabled ? "yes" : "no"}`,
+    `- overlay eviction failure mode: ${report.overlayEvictionFailureMode}`,
     `- tool search enabled: ${report.toolSearchEnabled ? "yes" : "no"}`,
     `- proxy healthy: ${report.proxyHealthy ? "yes" : "no"}`,
     `- proxy base URL: ${report.proxyBaseUrl}`,
@@ -240,6 +246,9 @@ export async function inspectClaudeCodeDoctor(params: {
   const recoveryMcpHealthy = mcpHealth.healthy;
 
   return {
+    overlayBackendMode: "request_overlay",
+    overlayEvictionEnabled: params.config.modules.eviction && params.config.eviction.enabled,
+    overlayEvictionFailureMode: params.config.eviction.failureMode,
     settingsPath: params.settingsPath,
     mcpConfigPath,
     tokenPilotConfigPath: params.tokenPilotConfigPath,

--- a/components/adapters/claude-code/src/eviction.ts
+++ b/components/adapters/claude-code/src/eviction.ts
@@ -44,7 +44,7 @@ type ToolUseDescriptor = {
   dataKey?: string;
 };
 
-type ToolResultBinding = {
+export type ToolResultBinding = {
   segmentId: string;
   messageIndex: number;
   blockIndex: number;
@@ -134,7 +134,7 @@ function collectToolProtocol(
   return { toolUses, validResultIds };
 }
 
-function buildToolResultSegments(
+export function buildToolResultSegments(
   messages: unknown[],
 ): { segments: ContextSegment[]; bindings: Map<string, ToolResultBinding> } {
   const { toolUses, validResultIds } = collectToolProtocol(messages);

--- a/components/adapters/claude-code/src/gateway-runtime.ts
+++ b/components/adapters/claude-code/src/gateway-runtime.ts
@@ -24,8 +24,13 @@ import { createClaudeMessagesPayloadCodec } from "./messages-codec.js";
 import { reduceClaudeRequestEnvelope, type ClaudeReductionSummary } from "./reduction.js";
 import {
   applyClaudeEviction,
+  analyzeClaudeEviction,
+  buildToolResultSegments,
   type ClaudeEvictionApplySummary,
 } from "./eviction.js";
+import { claudeContextRewriteBackend } from "./context-rewrite/backend.js";
+import { buildContextMutationPlan } from "@lightmem2/eviction";
+import { createHash as _createHash } from "node:crypto";
 import {
   appendClaudeCodeRecentTurnBinding,
   upsertClaudeCodeSessionSnapshot,
@@ -318,21 +323,66 @@ export async function startClaudeCodeGatewayRuntime(params: {
         try {
           const candidatePayload = (
             params.dependencies?.cloneRequestPayload ?? structuredClone
-          )(payload);
-          evictionSummary = applyClaudeEviction({
-            payload: candidatePayload,
+          )(payload) as { messages?: unknown[] };
+          const overlayMessages =
+            (candidatePayload.messages ?? []) as typeof envelope.messages;
+          const revision = _createHash("sha256")
+            .update(JSON.stringify(overlayMessages))
+            .digest("hex")
+            .slice(0, 32);
+
+          const analysis = analyzeClaudeEviction({
             sessionId,
             model: envelope.model,
-            config: {
-              enabled: true,
-              minBlockChars: config.eviction.minBlockChars,
-            },
+            messages: overlayMessages,
+            config: { enabled: true, minBlockChars: config.eviction.minBlockChars },
           });
-          if (evictionSummary.changed) {
-            payload = candidatePayload;
-            envelope = codec.decodeRequest(payload, {
-              headers: req.headers as Record<string, string | string[] | undefined>,
+
+          if (analysis.changed && analysis.selections.length > 0) {
+            const { bindings } = buildToolResultSegments(overlayMessages);
+            const segmentLocations = new Map(
+              [...bindings.entries()].map(([segmentId, binding]) => [
+                segmentId,
+                { messageIndex: binding.messageIndex, blockIndex: binding.blockIndex },
+              ]),
+            );
+
+            const overlayRequest = { sessionId, revision, messages: overlayMessages };
+            const snapshot = await claudeContextRewriteBackend.readSnapshot({
+              sessionId,
+              request: overlayRequest,
             });
+            const plan = buildContextMutationPlan({
+              hostId: "claude-code",
+              sessionId,
+              snapshot,
+              selections: analysis.selections.map((selection) => ({
+                segmentIds: selection.segmentIds,
+                chars: selection.chars,
+              })),
+              segmentLocations,
+            });
+            const { request: rewritten, result } = await claudeContextRewriteBackend.apply({
+              snapshot,
+              plan,
+              request: overlayRequest,
+            });
+
+            evictionSummary = {
+              ...evictionSummary,
+              changed: result.changed,
+              savedChars: result.savedChars,
+              evictedBlockIds: result.removedItemIds,
+              evictedToolResultCount: result.removedItemIds.length,
+              evictedMessageCount: result.removedItemIds.length,
+            };
+
+            if (result.changed) {
+              payload = { ...(payload as Record<string, unknown>), messages: rewritten.messages };
+              envelope = codec.decodeRequest(payload, {
+                headers: req.headers as Record<string, string | string[] | undefined>,
+              });
+            }
           }
         } catch {
           evictionBypassReason = "analysis_or_apply_error";

--- a/components/adapters/claude-code/src/gateway-runtime.ts
+++ b/components/adapters/claude-code/src/gateway-runtime.ts
@@ -166,6 +166,7 @@ async function recordClaudeGatewayTurn(params: {
   responseChars: number;
   assistantChars: number;
   reductionSavedChars: number;
+  evictionSavedChars: number;
   stablePrefixApplied: boolean;
   reductionApplied: boolean;
   stream: boolean;
@@ -182,6 +183,7 @@ async function recordClaudeGatewayTurn(params: {
     responseChars: params.responseChars,
     assistantChars: params.assistantChars,
     reductionSavedChars: params.reductionSavedChars,
+    evictionSavedChars: params.evictionSavedChars,
   });
   await appendClaudeCodeRecentTurnBinding(params.stateDir, {
     sessionId: params.sessionId,
@@ -192,6 +194,7 @@ async function recordClaudeGatewayTurn(params: {
     responseChars: params.responseChars,
     assistantChars: params.assistantChars,
     reductionSavedChars: params.reductionSavedChars,
+    evictionSavedChars: params.evictionSavedChars,
     stablePrefixApplied: params.stablePrefixApplied,
     reductionApplied: params.reductionApplied,
     stream: params.stream,
@@ -560,6 +563,7 @@ export async function startClaudeCodeGatewayRuntime(params: {
             responseChars: rawStreamText.length,
             assistantChars: snapshot.assistantText.length,
             reductionSavedChars: reductionSummary?.savedChars ?? 0,
+            evictionSavedChars: evictionSummary?.savedChars ?? 0,
             stablePrefixApplied: prepared.diagnostics.stablePrefixApplied === true,
             reductionApplied: prepared.diagnostics.reductionApplied === true,
             stream: true,
@@ -643,6 +647,7 @@ export async function startClaudeCodeGatewayRuntime(params: {
         responseChars: upstreamResp.text.length,
         assistantChars,
         reductionSavedChars: reductionSummary?.savedChars ?? 0,
+        evictionSavedChars: evictionSummary?.savedChars ?? 0,
         stablePrefixApplied: prepared.diagnostics.stablePrefixApplied === true,
         reductionApplied: prepared.diagnostics.reductionApplied === true,
         stream: false,

--- a/components/adapters/claude-code/src/session-report.ts
+++ b/components/adapters/claude-code/src/session-report.ts
@@ -33,6 +33,8 @@ export type ClaudeCodeSessionTopology = {
   responseChars?: number;
   assistantChars?: number;
   reductionSavedChars?: number;
+  evictionSavedChars?: number;
+  evictionSavedCharsCumulative?: number;
   updatedAt?: string;
   turnCount: number;
 };
@@ -73,6 +75,11 @@ export async function resolveClaudeCodeSessionTopology(
       responseChars: value?.responseChars ?? latestBinding?.responseChars,
       assistantChars: value?.assistantChars ?? latestBinding?.assistantChars,
       reductionSavedChars: value?.reductionSavedChars ?? latestBinding?.reductionSavedChars,
+      evictionSavedChars: value?.evictionSavedChars ?? latestBinding?.evictionSavedChars,
+      evictionSavedCharsCumulative: bindings.reduce(
+        (total, b) => total + (typeof b?.evictionSavedChars === "number" ? b.evictionSavedChars : 0),
+        0,
+      ),
     }),
   });
 }
@@ -86,6 +93,8 @@ export async function renderClaudeCodeSessionReport(stateDir: string, sessionRef
     { label: "Latest response chars", value: topology.responseChars ?? 0 },
     { label: "Latest assistant chars", value: topology.assistantChars ?? 0 },
     { label: "Latest reduction savings", value: topology.reductionSavedChars ?? 0 },
+    { label: "Latest eviction savings", value: topology.evictionSavedChars ?? 0 },
+    { label: "Cumulative eviction savings", value: topology.evictionSavedCharsCumulative ?? 0 },
   ]);
 
   if (topology.lastToolName) {

--- a/components/adapters/claude-code/src/session-state.ts
+++ b/components/adapters/claude-code/src/session-state.ts
@@ -22,6 +22,7 @@ export type ClaudeCodeSessionSnapshot = {
   responseChars?: number;
   assistantChars?: number;
   reductionSavedChars?: number;
+  evictionSavedChars?: number;
   updatedAt: string;
 };
 
@@ -34,6 +35,7 @@ export type ClaudeCodeRecentTurnBinding = {
   responseChars?: number;
   assistantChars?: number;
   reductionSavedChars?: number;
+  evictionSavedChars?: number;
   stablePrefixApplied?: boolean;
   reductionApplied?: boolean;
   stream?: boolean;
@@ -73,6 +75,7 @@ export async function upsertClaudeCodeSessionSnapshot(
     responseChars: patch.responseChars ?? current?.responseChars,
     assistantChars: patch.assistantChars ?? current?.assistantChars,
     reductionSavedChars: patch.reductionSavedChars ?? current?.reductionSavedChars,
+    evictionSavedChars: patch.evictionSavedChars ?? current?.evictionSavedChars,
     updatedAt,
   };
   await writeSessionSnapshot(stateDir, sessionId, next);

--- a/components/adapters/claude-code/tests/context-rewrite-acceptance.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-acceptance.test.ts
@@ -204,6 +204,13 @@ test("GUA-06 independently accepts Claude rewrite failure bypass", async () => {
     const beforeCall = trace.find((entry) => entry.stage === "gateway_before_call");
     assert.equal(beforeCall?.evictionApplied, false);
     assert.equal(beforeCall?.evictionBypassReason, "analysis_or_apply_error");
+    // CLA-06 isolation: the bypass trace records only the error CLASS, never the
+    // raw exception text — the injected error message must not leak anywhere.
+    const rawTrace = fs.readFileSync(
+      path.join(environment.stateDir, "event-trace.jsonl"),
+      "utf8",
+    );
+    assert.equal(rawTrace.includes("synthetic GUA-06"), false);
   } finally {
     await runtime?.close();
     await upstream.close();

--- a/components/adapters/claude-code/tests/context-rewrite-apply.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-apply.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { claudeContextRewriteBackend } from "../src/context-rewrite/backend.js";
+
+const SCHEMA = 1;
+
+function sampleRequest() {
+  return {
+    sessionId: "s1",
+    revision: "rev-1",
+    messages: [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "old assistant note that can be evicted" },
+          { type: "tool_use", id: "call-1", name: "Read", input: { path: "a.txt" } },
+        ],
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: "big old file body ".repeat(50) }] },
+      { role: "user", content: "current question, must be kept" },
+    ],
+  } as any;
+}
+
+async function snap() {
+  return claudeContextRewriteBackend.readSnapshot({ sessionId: "s1", request: sampleRequest() });
+}
+
+function plan(targetItemIds: string[], fingerprints?: Record<string, string>) {
+  return {
+    schemaVersion: SCHEMA,
+    planId: "plan-1",
+    hostId: "claude-code",
+    sessionId: "s1",
+    baseRevision: "rev-1",
+    sourceModuleId: "test",
+    operations: [
+      { id: "op-1", type: "replace", targetItemIds, targetItemFingerprints: fingerprints, rationale: "t", estimatedSavedChars: 5 },
+    ],
+    createdAt: new Date(0).toISOString(),
+  } as any;
+}
+
+test("apply rewrites a tool_result but keeps its tool_use_id (closure intact)", async () => {
+  const s = await snap();
+  // find the tool_result item id
+  const trItem = s.items.find((i) => i.kind === "tool_result")!;
+  const req = sampleRequest();
+  const { request: out, result } = await claudeContextRewriteBackend.apply({
+    snapshot: s,
+    plan: plan([trItem.stableId], { [trItem.stableId]: trItem.fingerprint }),
+    request: req,
+  });
+  assert.equal(result.applied, true);
+  assert.equal(result.changed, true);
+  assert.ok(result.savedChars > 0);
+  // the tool_result block still exists with the same tool_use_id
+  const trMsg = (out.messages as any[]).find((m) =>
+    Array.isArray(m.content) && m.content.some((b: any) => b.type === "tool_result"),
+  );
+  const trBlock = trMsg.content.find((b: any) => b.type === "tool_result");
+  assert.equal(trBlock.tool_use_id, "call-1");
+  assert.match(trBlock.content, /evicted/);
+});
+
+test("apply never rewrites the current user message", async () => {
+  const s = await snap();
+  // last user message is index 2 (string content). Its item id:
+  const currentItem = s.items[s.items.length - 1];
+  const req = sampleRequest();
+  const { request: out, result } = await claudeContextRewriteBackend.apply({
+    snapshot: s,
+    plan: plan([currentItem.stableId], { [currentItem.stableId]: currentItem.fingerprint }),
+    request: req,
+  });
+  // op targeted the current turn → nothing removed
+  assert.equal(result.changed, false);
+  assert.equal((out.messages as any[])[2].content, "current question, must be kept");
+});
+
+test("apply does not mutate the original request object", async () => {
+  const s = await snap();
+  const trItem = s.items.find((i) => i.kind === "tool_result")!;
+  const req = sampleRequest();
+  const before = JSON.stringify(req);
+  await claudeContextRewriteBackend.apply({
+    snapshot: s,
+    plan: plan([trItem.stableId], { [trItem.stableId]: trItem.fingerprint }),
+    request: req,
+  });
+  assert.equal(JSON.stringify(req), before, "original request must be untouched");
+});
+
+test("apply leaves tool_use blocks alone to preserve the pair", async () => {
+  const s = await snap();
+  const toolUseItem = s.items.find((i) => i.kind === "tool_call")!;
+  const req = sampleRequest();
+  const { request: out, result } = await claudeContextRewriteBackend.apply({
+    snapshot: s,
+    plan: plan([toolUseItem.stableId], { [toolUseItem.stableId]: toolUseItem.fingerprint }),
+    request: req,
+  });
+  // tool_use is skipped → op did not touch anything → deferred, unchanged
+  assert.equal(result.changed, false);
+  const tu = (out.messages as any[])[0].content.find((b: any) => b.type === "tool_use");
+  assert.equal(tu.id, "call-1");
+});

--- a/components/adapters/claude-code/tests/context-rewrite-backend.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-backend.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { claudeContextRewriteBackend } from "../src/context-rewrite/backend.js";
+
+const SCHEMA = 1;
+
+function sampleRequest() {
+  return {
+    sessionId: "s1",
+    revision: "rev-1",
+    messages: [
+      { role: "user", content: "read config.json" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "reading" },
+          { type: "tool_use", id: "call-1", name: "Read", input: { path: "config.json" } },
+        ],
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: "body" }] },
+    ],
+  } as any;
+}
+
+async function snapshotFor() {
+  return claudeContextRewriteBackend.readSnapshot({
+    sessionId: "s1",
+    request: sampleRequest(),
+  });
+}
+
+function planWith(targetItemIds: string[], fingerprints?: Record<string, string>) {
+  return {
+    schemaVersion: SCHEMA,
+    planId: "plan-1",
+    hostId: "claude-code",
+    sessionId: "s1",
+    baseRevision: "rev-1",
+    sourceModuleId: "test",
+    operations: [
+      {
+        id: "op-1",
+        type: "remove",
+        targetItemIds,
+        targetItemFingerprints: fingerprints,
+        rationale: "test",
+        estimatedSavedChars: 10,
+      },
+    ],
+    createdAt: new Date(0).toISOString(),
+  } as any;
+}
+
+test("backend declares request_overlay mode and claude-code host", () => {
+  assert.equal(claudeContextRewriteBackend.hostId, "claude-code");
+  assert.equal(claudeContextRewriteBackend.mode, "request_overlay");
+});
+
+test("readSnapshot returns a snapshot over the current messages", async () => {
+  const snap = await snapshotFor();
+  assert.equal(snap.hostId, "claude-code");
+  assert.equal(snap.sessionId, "s1");
+  assert.ok(snap.items.length > 0);
+});
+
+test("validate defers the plan when baseRevision does not match", async () => {
+  const snap = await snapshotFor();
+  const plan = planWith([snap.items[0].stableId]);
+  plan.baseRevision = "different-rev";
+  const result = await claudeContextRewriteBackend.validate({ snapshot: snap, plan });
+  assert.equal(result.valid, false);
+  assert.deepEqual(result.applicableOperationIds, []);
+  assert.ok(result.deferredOperationIds.includes("op-1"));
+});
+
+test("validate marks an operation applicable when targets exist", async () => {
+  const snap = await snapshotFor();
+  const target = snap.items[0].stableId;
+  const result = await claudeContextRewriteBackend.validate({
+    snapshot: snap,
+    plan: planWith([target]),
+  });
+  assert.equal(result.valid, true);
+  assert.ok(result.applicableOperationIds.includes("op-1"));
+});
+
+test("validate defers when a target item id is missing", async () => {
+  const snap = await snapshotFor();
+  const result = await claudeContextRewriteBackend.validate({
+    snapshot: snap,
+    plan: planWith(["s1:99:0"]),
+  });
+  assert.ok(result.deferredOperationIds.includes("op-1"));
+  assert.ok(!result.applicableOperationIds.includes("op-1"));
+});
+
+test("validate defers when a target fingerprint has drifted", async () => {
+  const snap = await snapshotFor();
+  const target = snap.items[0].stableId;
+  const result = await claudeContextRewriteBackend.validate({
+    snapshot: snap,
+    plan: planWith([target], { [target]: "wrong-fingerprint" }),
+  });
+  assert.ok(result.deferredOperationIds.includes("op-1"));
+});
+
+test("apply skeleton returns the request unchanged and reports not applied", async () => {
+  const snap = await snapshotFor();
+  const target = snap.items[0].stableId;
+  const request = sampleRequest();
+  const { request: out, result } = await claudeContextRewriteBackend.apply({
+    snapshot: snap,
+    plan: planWith([target]),
+    request,
+  });
+  assert.equal(out, request);
+  assert.equal(result.applied, false);
+  assert.equal(result.changed, false);
+});

--- a/components/adapters/claude-code/tests/context-rewrite-replay.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-replay.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { claudeContextRewriteBackend } from "../src/context-rewrite/backend.js";
+
+const SCHEMA = 1;
+
+function historyWith(toolBody: string) {
+  return {
+    sessionId: "s1",
+    revision: "rev-1",
+    messages: [
+      { role: "assistant", content: [{ type: "tool_use", id: "call-1", name: "Read", input: { path: "a.txt" } }] },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "call-1", content: toolBody }] },
+      { role: "user", content: "current question kept" },
+    ],
+  } as any;
+}
+
+const BIG = "file body ".repeat(80);
+
+async function snapFor(req: any) {
+  return claudeContextRewriteBackend.readSnapshot({ sessionId: "s1", request: req });
+}
+
+function planFor(itemId: string, fingerprint?: string) {
+  return {
+    schemaVersion: SCHEMA,
+    planId: "plan-1",
+    hostId: "claude-code",
+    sessionId: "s1",
+    baseRevision: "rev-1",
+    sourceModuleId: "test",
+    operations: [
+      {
+        id: "op-1",
+        type: "replace",
+        targetItemIds: [itemId],
+        targetItemFingerprints: fingerprint ? { [itemId]: fingerprint } : undefined,
+        rationale: "t",
+        estimatedSavedChars: 10,
+      },
+    ],
+    createdAt: new Date(0).toISOString(),
+  } as any;
+}
+
+test("replaying the same plan on resent history removes the same item", async () => {
+  const first = historyWith(BIG);
+  const snap = await snapFor(first);
+  const tr = snap.items.find((i) => i.kind === "tool_result")!;
+  const plan = planFor(tr.stableId, tr.fingerprint);
+
+  const r1 = await claudeContextRewriteBackend.apply({ snapshot: snap, plan, request: first });
+
+  // Second request: Claude resends the identical history. Same plan, fresh snapshot.
+  const second = historyWith(BIG);
+  const snap2 = await snapFor(second);
+  const r2 = await claudeContextRewriteBackend.apply({ snapshot: snap2, plan, request: second });
+
+  assert.deepEqual(r1.result.removedItemIds, r2.result.removedItemIds);
+  assert.equal(r1.result.savedChars, r2.result.savedChars);
+  assert.equal(r2.result.applied, true);
+});
+
+test("saved chars are not double counted across replays", async () => {
+  const req = historyWith(BIG);
+  const snap = await snapFor(req);
+  const tr = snap.items.find((i) => i.kind === "tool_result")!;
+  const plan = planFor(tr.stableId, tr.fingerprint);
+
+  const once = (await claudeContextRewriteBackend.apply({ snapshot: snap, plan, request: req })).result.savedChars;
+  const twice = (await claudeContextRewriteBackend.apply({ snapshot: snap, plan, request: req })).result.savedChars;
+
+  // Each apply reports the saving for that request only; it does not accumulate.
+  assert.equal(once, twice);
+});
+
+test("plan defers when the target content changed (fingerprint drift), never fuzzy-deletes", async () => {
+  const original = historyWith(BIG);
+  const snap = await snapFor(original);
+  const tr = snap.items.find((i) => i.kind === "tool_result")!;
+  const plan = planFor(tr.stableId, tr.fingerprint);
+
+  // The tool_result content is different now; same position, different fingerprint.
+  const changed = historyWith("a completely different body " + BIG);
+  const snap2 = await snapFor(changed);
+  const r = await claudeContextRewriteBackend.apply({ snapshot: snap2, plan, request: changed });
+
+  assert.equal(r.result.changed, false);
+  assert.ok(r.result.deferredOperationIds.includes("op-1"));
+});

--- a/components/adapters/claude-code/tests/context-rewrite-snapshot.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-snapshot.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildClaudeContextSnapshot } from "../src/context-rewrite/snapshot.js";
+
+function sampleMessages() {
+  return [
+    { role: "user", content: "read config.json" },
+    {
+      role: "assistant",
+      content: [
+        { type: "text", text: "reading it now" },
+        { type: "tool_use", id: "call-1", name: "Read", input: { path: "config.json" } },
+      ],
+    },
+    {
+      role: "user",
+      content: [
+        { type: "tool_result", tool_use_id: "call-1", content: "file body here" },
+      ],
+    },
+  ] as any;
+}
+
+test("snapshot carries host id, session, revision and schema version", () => {
+  const snap = buildClaudeContextSnapshot({
+    sessionId: "s1",
+    revision: "rev-1",
+    messages: sampleMessages(),
+  });
+  assert.equal(snap.hostId, "claude-code");
+  assert.equal(snap.sessionId, "s1");
+  assert.equal(snap.revision, "rev-1");
+  assert.ok(snap.schemaVersion);
+});
+
+test("each content block becomes one item ref with a stable id and fingerprint", () => {
+  const snap = buildClaudeContextSnapshot({
+    sessionId: "s1",
+    revision: "rev-1",
+    messages: sampleMessages(),
+  });
+  // user string (1) + assistant text + tool_use (2) + tool_result (1) = 4 items
+  assert.equal(snap.items.length, 4);
+  for (const item of snap.items) {
+    assert.ok(item.stableId, "item needs a stable id");
+    assert.ok(item.fingerprint, "item needs a fingerprint");
+    assert.ok(item.chars >= 0);
+  }
+});
+
+test("kinds are mapped from role and block type", () => {
+  const snap = buildClaudeContextSnapshot({
+    sessionId: "s1",
+    revision: "rev-1",
+    messages: sampleMessages(),
+  });
+  const kinds = snap.items.map((i) => i.kind);
+  assert.ok(kinds.includes("user"));
+  assert.ok(kinds.includes("assistant"));
+  assert.ok(kinds.includes("tool_call"));
+  assert.ok(kinds.includes("tool_result"));
+});
+
+test("tool_call and tool_result carry their call id", () => {
+  const snap = buildClaudeContextSnapshot({
+    sessionId: "s1",
+    revision: "rev-1",
+    messages: sampleMessages(),
+  });
+  const toolCall = snap.items.find((i) => i.kind === "tool_call");
+  const toolResult = snap.items.find((i) => i.kind === "tool_result");
+  assert.equal(toolCall?.callId, "call-1");
+  assert.equal(toolResult?.callId, "call-1");
+});
+
+test("stable ids are identical across resends of the same history", () => {
+  const first = buildClaudeContextSnapshot({ sessionId: "s1", revision: "r", messages: sampleMessages() });
+  const second = buildClaudeContextSnapshot({ sessionId: "s1", revision: "r", messages: sampleMessages() });
+  assert.deepEqual(
+    first.items.map((i) => i.stableId),
+    second.items.map((i) => i.stableId),
+  );
+  assert.deepEqual(
+    first.items.map((i) => i.fingerprint),
+    second.items.map((i) => i.fingerprint),
+  );
+});

--- a/components/adapters/claude-code/tests/doctor.test.ts
+++ b/components/adapters/claude-code/tests/doctor.test.ts
@@ -331,6 +331,9 @@ test("formatClaudeCodeDoctorReport shows degraded mode when core runtime is heal
     coreRuntimeHealthy: true,
     recoveryMcpHealthy: false,
     degradedMode: true,
+    overlayBackendMode: "request_overlay",
+    overlayEvictionEnabled: false,
+    overlayEvictionFailureMode: "bypass",
   });
 
   assert.match(text, /core runtime healthy: yes/);
@@ -372,6 +375,9 @@ test("formatClaudeCodeDoctorReport explains first-run SessionStart remediation w
     coreRuntimeHealthy: false,
     recoveryMcpHealthy: true,
     degradedMode: false,
+    overlayBackendMode: "request_overlay",
+    overlayEvictionEnabled: false,
+    overlayEvictionFailureMode: "bypass",
   });
   assert.match(text, /start a new Claude Code session so SessionStart can boot the local TokenPilot gateway/);
   assert.match(text, /tokenpilot-claude-code start/);

--- a/components/packages/features/eviction/package.json
+++ b/components/packages/features/eviction/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@lightmem2/artifact-store": "workspace:*",
     "@lightmem2/history": "workspace:*",
+    "@lightmem2/host-adapter": "workspace:*",
     "@lightmem2/kernel": "workspace:*"
   }
 }

--- a/components/packages/features/eviction/src/context-mutation-plan.ts
+++ b/components/packages/features/eviction/src/context-mutation-plan.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextMutationOperation,
+  type ContextMutationPlan,
+  type ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+
+// One evicted block, described independently of any host adapter. The caller
+// (a host adapter) resolves each segment to a concrete message/block location
+// and passes it in, so this module stays in the features layer and never
+// depends on an adapter package.
+export type EvictionPlanSelection = {
+  segmentIds: string[];
+  chars: number;
+  rationale?: string;
+};
+
+export type SegmentLocation = {
+  messageIndex: number;
+  blockIndex: number;
+};
+
+function overlayStableId(sessionId: string, loc: SegmentLocation): string {
+  return `${sessionId}:${loc.messageIndex}:${loc.blockIndex}`;
+}
+
+function planId(sessionId: string, revision: string, selections: EvictionPlanSelection[]): string {
+  return createHash("sha256")
+    .update(JSON.stringify({ sessionId, revision, selections }))
+    .digest("hex")
+    .slice(0, 24);
+}
+
+// Turn signal-driven eviction selections into a shared ContextMutationPlan the
+// overlay backend can validate and apply. Each selection becomes one replace
+// operation whose targets are the overlay stable ids, carrying the snapshot
+// fingerprints so the backend can prove the targets survived revision drift.
+export function buildContextMutationPlan(params: {
+  hostId: string;
+  sessionId: string;
+  snapshot: ModelContextSnapshot;
+  selections: EvictionPlanSelection[];
+  segmentLocations: Map<string, SegmentLocation>;
+  sourceModuleId?: string;
+  createdAt?: string;
+}): ContextMutationPlan {
+  const fingerprintById = new Map(
+    params.snapshot.items.map((item) => [item.stableId, item.fingerprint]),
+  );
+
+  const operations: ContextMutationOperation[] = [];
+  params.selections.forEach((selection, index) => {
+    const targetItemIds: string[] = [];
+    const targetItemFingerprints: Record<string, string> = {};
+
+    for (const segmentId of selection.segmentIds) {
+      const loc = params.segmentLocations.get(segmentId);
+      if (!loc) continue;
+      const stableId = overlayStableId(params.sessionId, loc);
+      const fingerprint = fingerprintById.get(stableId);
+      // Only target items that actually exist in the snapshot.
+      if (fingerprint === undefined) continue;
+      targetItemIds.push(stableId);
+      targetItemFingerprints[stableId] = fingerprint;
+    }
+
+    if (targetItemIds.length === 0) return;
+
+    operations.push({
+      id: `op-${index}`,
+      type: "replace",
+      targetItemIds,
+      targetItemFingerprints,
+      rationale: selection.rationale ?? "signal-driven eviction",
+      estimatedSavedChars: selection.chars,
+    });
+  });
+
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: planId(params.sessionId, params.snapshot.revision, params.selections),
+    hostId: params.hostId,
+    sessionId: params.sessionId,
+    baseRevision: params.snapshot.revision,
+    sourceModuleId: params.sourceModuleId ?? "eviction",
+    operations,
+    createdAt: params.createdAt ?? new Date(0).toISOString(),
+  };
+}

--- a/components/packages/features/eviction/src/index.ts
+++ b/components/packages/features/eviction/src/index.ts
@@ -4,3 +4,4 @@ export * from "./planning/index.js";
 export * from "./task-state-estimator.js";
 export * from "./history-apply.js";
 export * from "./lifecycle-policy-context.js";
+export * from "./context-mutation-plan.js";

--- a/components/packages/features/eviction/tests/context-mutation-plan.test.ts
+++ b/components/packages/features/eviction/tests/context-mutation-plan.test.ts
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildContextMutationPlan } from "../src/context-mutation-plan.js";
+
+const SCHEMA = 1;
+
+function snapshot() {
+  return {
+    schemaVersion: SCHEMA,
+    hostId: "claude-code",
+    sessionId: "s1",
+    revision: "rev-1",
+    items: [
+      { stableId: "s1:0:0", kind: "user", fingerprint: "fp-a", chars: 5 },
+      { stableId: "s1:1:0", kind: "tool_result", fingerprint: "fp-b", chars: 800 },
+    ],
+  } as any;
+}
+
+test("builds a replace operation targeting the overlay stable id with its fingerprint", () => {
+  const plan = buildContextMutationPlan({
+    hostId: "claude-code",
+    sessionId: "s1",
+    snapshot: snapshot(),
+    selections: [{ segmentIds: ["seg-1"], chars: 800 }],
+    segmentLocations: new Map([["seg-1", { messageIndex: 1, blockIndex: 0 }]]),
+  });
+
+  assert.equal(plan.hostId, "claude-code");
+  assert.equal(plan.sessionId, "s1");
+  assert.equal(plan.baseRevision, "rev-1");
+  assert.equal(plan.operations.length, 1);
+  const op = plan.operations[0];
+  assert.equal(op.type, "replace");
+  assert.deepEqual(op.targetItemIds, ["s1:1:0"]);
+  assert.equal(op.targetItemFingerprints?.["s1:1:0"], "fp-b");
+  assert.equal(op.estimatedSavedChars, 800);
+});
+
+test("skips segments that do not resolve to a snapshot item", () => {
+  const plan = buildContextMutationPlan({
+    hostId: "claude-code",
+    sessionId: "s1",
+    snapshot: snapshot(),
+    // location points at message 9 which is not in the snapshot
+    selections: [{ segmentIds: ["seg-x"], chars: 100 }],
+    segmentLocations: new Map([["seg-x", { messageIndex: 9, blockIndex: 0 }]]),
+  });
+  // no valid targets → no operation emitted
+  assert.equal(plan.operations.length, 0);
+});
+
+test("skips a segment with no known location but keeps others", () => {
+  const plan = buildContextMutationPlan({
+    hostId: "claude-code",
+    sessionId: "s1",
+    snapshot: snapshot(),
+    selections: [{ segmentIds: ["seg-1", "seg-missing"], chars: 800 }],
+    segmentLocations: new Map([["seg-1", { messageIndex: 1, blockIndex: 0 }]]),
+  });
+  assert.equal(plan.operations.length, 1);
+  assert.deepEqual(plan.operations[0].targetItemIds, ["s1:1:0"]);
+});
+
+test("plan id is deterministic for the same inputs", () => {
+  const args = {
+    hostId: "claude-code",
+    sessionId: "s1",
+    snapshot: snapshot(),
+    selections: [{ segmentIds: ["seg-1"], chars: 800 }],
+    segmentLocations: new Map([["seg-1", { messageIndex: 1, blockIndex: 0 }]]),
+  };
+  const a = buildContextMutationPlan(args);
+  const b = buildContextMutationPlan(args);
+  assert.equal(a.planId, b.planId);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@lightmem2/artifact-store':
         specifier: workspace:*
         version: link:../../packages/foundation/artifact-store
+      '@lightmem2/eviction':
+        specifier: workspace:*
+        version: link:../../packages/features/eviction
       '@lightmem2/host-adapter':
         specifier: workspace:*
         version: link:../../packages/foundation/host-adapter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
       '@lightmem2/history':
         specifier: workspace:*
         version: link:../../foundation/history
+      '@lightmem2/host-adapter':
+        specifier: workspace:*
+        version: link:../../foundation/host-adapter
       '@lightmem2/kernel':
         specifier: workspace:*
         version: link:../../foundation/kernel


### PR DESCRIPTION
## 概述
Claude Code 的模型上下文请求覆盖(request overlay),完成 CLA-01~06。
eviction 决策 → ContextMutationPlan → overlay backend validate+apply,
真实改写发给上游的请求,支持持久重放和失败降级。

## 工作项
- CLA-01 snapshot:稳定 ID(sid:msgIdx:blockIdx)+ 内容 fingerprint;
  session 绑定通过 resolveObservedClaudeSessionId 解析真实 hook session id
- CLA-02 backend:validate(schema/host/session/revision 前置校验 +
  fingerprint 校验 targets)+ apply(在 clone 上改、保护当前用户轮、
  tool_result 保留 tool_use_id 只换 content 保闭包、异常降级)
- CLA-03 幂等重放:同一 plan 重放删同样内容、savedChars 不重复累加、
  fingerprint 漂移则 defer 不误删
- CLA-04 gateway 接线:before-call 接入 overlay,替换直接删除路径;
  eviction-off 行为不变
- CLA-05 config/preset(已有)+ doctor 显示 overlay 状态 +
  report 显示本轮/累计 saved chars
- CLA-06 失败隔离:任何失败 bypass 转发原请求(不 500),
  trace 只记错误类别不记原文
- plan producer:features/eviction/context-mutation-plan.ts,
  features 层零 adapter 依赖(segmentLocations 参数注入)

## 涉及的共享/他人文件
- gateway-runtime.ts(集成接线,导师已批准)
- eviction.ts(导出 buildToolResultSegments/analyzeClaudeEviction)
- features/eviction/(新增 context-mutation-plan.ts + 一条 host-adapter 依赖,
  未改现有代码)
- doctor.ts/session-report.ts/session-state.ts(加显示字段)

## 测试
全套 85 pass 0 fail,typecheck 干净,含团队 GUA-06 两个验收
(五请求+进程重启持久重放、失败 bypass)。

## 待确认
CLA-01 session 绑定用的是实时解析(synth→real 每次请求推断),
非持久映射表。若需显式映射表可再补。