### PR TITLE
fix(codex): harden context journals and add offline rebase smoke

### DIFF
--- a/components/adapters/codex/README.md
+++ b/components/adapters/codex/README.md
@@ -137,6 +137,35 @@ Once installed, Codex can use the real internal recovery tool named
 `memory_fault_recover` through the registered MCP server. Recovery hints in
 trimmed payloads are no longer just protocol text.
 
+### Offline context-rebase smoke
+
+The response-chain rebase path has a credential-free smoke command for local
+development and CI:
+
+```bash
+npm --prefix components/adapters/codex run smoke:context-rebase:codex -- \
+  --mode=mock \
+  --output-dir=/path/to/sanitized-evidence
+```
+
+It starts a temporary loopback Responses upstream and verifies encrypted
+reasoning replay, function call/output closure, sentinel eviction and
+retention, five turns on the new response chain, proxy restart, one-attempt
+fallback with cooldown, all eight stabilizer/reduction/rewrite combinations,
+and estimated rebase accounting including the break-even turn.
+
+The command never reads an API key. Its evidence is explicitly marked
+`mode: mock` and omits raw prompts, headers, response IDs, and encrypted
+reasoning payloads. It does not replace real-provider validation or
+provider-observed usage and break-even evidence.
+
+Context-history journal writers use a session-scoped cross-process lock. A
+successful append is one complete JSONL record followed by `sync`; concurrent
+request and response writers cannot interleave their records. If an external
+crash leaves a malformed tail, later reads and writes fail closed so the proxy
+bypasses rewriting instead of guessing history. This does not claim
+power-loss-level transactional append semantics.
+
 If install finishes in degraded MCP mode, Codex stable-prefix and reduction remain usable; only the real `memory_fault_recover` tool path is unavailable until MCP startup succeeds.
 
 If doctor still reports `proxy healthy: no` after hooks are trusted and a new session has started, use the daemon fallback:
@@ -263,6 +292,7 @@ Primary package scripts:
 npm --prefix components/adapters/codex run build
 npm --prefix components/adapters/codex run typecheck
 npm --prefix components/adapters/codex test
+npm --prefix components/adapters/codex run smoke:context-rebase:codex -- --mode=mock
 npm --prefix components/adapters/codex run install:codex
 npm --prefix components/adapters/codex run doctor:codex
 ```

--- a/components/adapters/codex/package.json
+++ b/components/adapters/codex/package.json
@@ -34,6 +34,7 @@
     "start": "node dist/cli.js serve",
     "doctor:codex": "node --import tsx scripts/doctor-codex.ts",
     "report-cache-audit:codex": "node --import tsx scripts/report-cache-audit-codex.ts",
+    "smoke:context-rebase:codex": "node --import tsx scripts/context-rebase-smoke.ts",
     "install:codex": "node --import tsx scripts/install-codex.ts",
     "pack:release": "bash ./scripts/pack_release.sh",
     "test": "node --import tsx --test tests/*.test.ts",

--- a/components/adapters/codex/scripts/context-rebase-smoke.ts
+++ b/components/adapters/codex/scripts/context-rebase-smoke.ts
@@ -1,0 +1,52 @@
+import { runCodexRebaseMockSmoke } from "../src/context-rebase-smoke.js";
+
+function optionValue(name: string): string | undefined {
+  const prefix = `--${name}=`;
+  const argument = process.argv.slice(2).find((value) => value.startsWith(prefix));
+  return argument?.slice(prefix.length);
+}
+
+function printHelp(): void {
+  console.log([
+    "Usage: npm run smoke:context-rebase:codex -- [options]",
+    "",
+    "Options:",
+    "  --mode=mock          Run the offline scripted Responses smoke (default).",
+    "  --model=<name>       Non-sensitive model label recorded in evidence.",
+    "  --output-dir=<path>  Directory for the sanitized evidence JSON.",
+    "  --help               Show this help.",
+    "",
+    "This offline command never reads an API key and never persists raw prompts,",
+    "headers, response ids, or encrypted reasoning payloads in its evidence file.",
+  ].join("\n"));
+}
+
+async function main(): Promise<void> {
+  if (process.argv.includes("--help")) {
+    printHelp();
+    return;
+  }
+  const mode = optionValue("mode") ?? "mock";
+  if (mode !== "mock") {
+    throw new Error("Only --mode=mock is available in the offline smoke command");
+  }
+  const result = await runCodexRebaseMockSmoke({
+    model: optionValue("model"),
+    outputDir: optionValue("output-dir"),
+  });
+  console.log(JSON.stringify({
+    ok: true,
+    mode: result.evidence.mode,
+    artifactPath: result.artifactPath,
+    artifactSha256: result.artifactSha256,
+    sentinel: result.evidence.happyPath.sentinel,
+    continuationTurns: result.evidence.happyPath.responseChain.continuationTurns,
+    fallbackSucceeded: result.evidence.fallback.fallbackSucceeded,
+    moduleMatrixPassed: result.evidence.moduleMatrix.every((entry) => entry.isolationPassed),
+  }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/components/adapters/codex/src/context-history/index.ts
+++ b/components/adapters/codex/src/context-history/index.ts
@@ -5,6 +5,11 @@ export {
   readCodexContextHistoryJournal,
 } from "./journal-store.js";
 export type { CodexContextHistoryJournalReadResult } from "./journal-store.js";
+export {
+  acquireCodexContextHistoryJournalLock,
+  codexContextHistoryJournalLockPath,
+} from "./journal-append.js";
+export type { CodexContextHistoryJournalLock } from "./journal-append.js";
 export { appendCodexRequestJournalEntry } from "./request-journal.js";
 export { appendCodexResponseJournalEntry } from "./response-journal.js";
 export { collectCodexResponseItemsFromStream } from "./sse-item-collector.js";

--- a/components/adapters/codex/src/context-history/journal-append.ts
+++ b/components/adapters/codex/src/context-history/journal-append.ts
@@ -1,0 +1,265 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
+import { hostname } from "node:os";
+import { dirname } from "node:path";
+
+import {
+  codexContextHistoryJournalPath,
+  readCodexContextHistoryJournal,
+} from "./journal-store.js";
+
+type CodexContextHistoryJournalLockOwner = {
+  token: string;
+  pid: number;
+  hostname: string;
+  createdAt: string;
+};
+
+export type CodexContextHistoryJournalLock = {
+  lockPath: string;
+  release(): Promise<void>;
+};
+
+const DEFAULT_LOCK_STALE_MS = 30 * 60 * 1000;
+const DEFAULT_LOCK_TIMEOUT_MS = 30_000;
+const DEFAULT_LOCK_RETRY_MS = 10;
+const LOCK_REMOVE_MAX_RETRIES = 5;
+const LOCK_REMOVE_RETRY_MS = 20;
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function isTransientWindowsLockError(error: unknown): boolean {
+  if (process.platform !== "win32") return false;
+  const code = errorCode(error);
+  return code === "EPERM" || code === "EBUSY" || code === "EACCES";
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function removeLockPath(path: string): Promise<void> {
+  await rm(path, {
+    recursive: true,
+    force: true,
+    maxRetries: LOCK_REMOVE_MAX_RETRIES,
+    retryDelay: LOCK_REMOVE_RETRY_MS,
+  });
+}
+
+function timestampMs(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  if (pid === process.pid) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return errorCode(error) === "EPERM";
+  }
+}
+
+function asLockOwner(value: unknown): CodexContextHistoryJournalLockOwner | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const owner = value as Record<string, unknown>;
+  return typeof owner.token === "string" && owner.token.length > 0
+    && typeof owner.pid === "number" && Number.isInteger(owner.pid) && owner.pid > 0
+    && typeof owner.hostname === "string" && owner.hostname.length > 0
+    && timestampMs(owner.createdAt) !== undefined
+    ? owner as CodexContextHistoryJournalLockOwner
+    : undefined;
+}
+
+async function readLockOwner(lockPath: string): Promise<CodexContextHistoryJournalLockOwner | undefined> {
+  for (let attempt = 0; attempt <= LOCK_REMOVE_MAX_RETRIES; attempt += 1) {
+    try {
+      return asLockOwner(JSON.parse(await readFile(lockPath, "utf8")) as unknown);
+    } catch (error) {
+      if (isTransientWindowsLockError(error) && attempt < LOCK_REMOVE_MAX_RETRIES) {
+        await wait(LOCK_REMOVE_RETRY_MS);
+        continue;
+      }
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+async function lockIsStale(params: {
+  lockPath: string;
+  staleAfterMs: number;
+  nowMs: number;
+}): Promise<boolean> {
+  const owner = await readLockOwner(params.lockPath);
+  if (owner) {
+    if (owner.hostname === hostname()) return !isProcessAlive(owner.pid);
+    return params.nowMs - (timestampMs(owner.createdAt) ?? params.nowMs) > params.staleAfterMs;
+  }
+  try {
+    const lockStat = await stat(params.lockPath);
+    return params.nowMs - lockStat.mtimeMs > params.staleAfterMs;
+  } catch (error) {
+    // The owner may have released the lock between our failed exclusive open
+    // and this stat. Treat a missing path as contention and retry creation;
+    // claiming it as stale could rename a replacement lock created meanwhile.
+    if (errorCode(error) === "ENOENT") return false;
+    if (isTransientWindowsLockError(error)) return false;
+    throw error;
+  }
+}
+
+export function codexContextHistoryJournalLockPath(stateDir: string, sessionId: string): string {
+  return `${codexContextHistoryJournalPath(stateDir, sessionId)}.lock`;
+}
+
+async function tryAcquireJournalLock(params: {
+  stateDir: string;
+  sessionId: string;
+  staleAfterMs: number;
+}): Promise<CodexContextHistoryJournalLock | undefined> {
+  const lockPath = codexContextHistoryJournalLockPath(params.stateDir, params.sessionId);
+  await mkdir(dirname(lockPath), { recursive: true });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let lockHandle: Awaited<ReturnType<typeof open>>;
+    try {
+      lockHandle = await open(lockPath, "wx");
+    } catch (error) {
+      if (isTransientWindowsLockError(error)) return undefined;
+      if (errorCode(error) !== "EEXIST") throw error;
+      if (!await lockIsStale({
+        lockPath,
+        staleAfterMs: params.staleAfterMs,
+        nowMs: Date.now(),
+      })) return undefined;
+
+      const claimedStaleLockPath = `${lockPath}.stale-${randomUUID()}`;
+      try {
+        await rename(lockPath, claimedStaleLockPath);
+      } catch (claimError) {
+        if (isTransientWindowsLockError(claimError)) return undefined;
+        const claimErrorCode = errorCode(claimError);
+        if (claimErrorCode === "ENOENT" || claimErrorCode === "EEXIST") return undefined;
+        throw claimError;
+      }
+      await removeLockPath(claimedStaleLockPath);
+      continue;
+    }
+
+    const owner: CodexContextHistoryJournalLockOwner = {
+      token: randomUUID(),
+      pid: process.pid,
+      hostname: hostname(),
+      createdAt: new Date().toISOString(),
+    };
+    try {
+      await lockHandle.writeFile(JSON.stringify(owner), "utf8");
+      await lockHandle.sync();
+    } catch (error) {
+      const failedLockPath = `${lockPath}.failed-${owner.token}`;
+      try {
+        await rename(lockPath, failedLockPath);
+        await removeLockPath(failedLockPath);
+      } catch {
+        // A missing or replaced path is no longer this failed acquisition's lock.
+      }
+      throw error;
+    } finally {
+      await lockHandle.close();
+    }
+
+    return {
+      lockPath,
+      async release() {
+        try {
+          const current = await readLockOwner(lockPath);
+          if (current?.token === owner.token) {
+            const releasedLockPath = `${lockPath}.released-${owner.token}`;
+            await rename(lockPath, releasedLockPath);
+            await removeLockPath(releasedLockPath);
+          }
+        } catch {
+          // Leaving a stale lock is safer than deleting a lock whose owner may have changed.
+        }
+      },
+    };
+  }
+  return undefined;
+}
+
+export async function acquireCodexContextHistoryJournalLock(params: {
+  stateDir: string;
+  sessionId: string;
+  staleAfterMs?: number;
+  timeoutMs?: number;
+  retryMs?: number;
+}): Promise<CodexContextHistoryJournalLock> {
+  const staleAfterMs = Math.max(1_000, params.staleAfterMs ?? DEFAULT_LOCK_STALE_MS);
+  const timeoutMs = Math.max(0, params.timeoutMs ?? DEFAULT_LOCK_TIMEOUT_MS);
+  const retryMs = Math.max(1, params.retryMs ?? DEFAULT_LOCK_RETRY_MS);
+  const deadline = Date.now() + timeoutMs;
+
+  do {
+    const lock = await tryAcquireJournalLock({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      staleAfterMs,
+    });
+    if (lock) return lock;
+    if (Date.now() >= deadline) break;
+    await wait(Math.min(retryMs, Math.max(1, deadline - Date.now())));
+  } while (true);
+
+  throw new Error(`Timed out acquiring Codex context-history journal lock for session ${params.sessionId}`);
+}
+
+export async function withCodexContextHistoryJournalLock<T>(params: {
+  stateDir: string;
+  sessionId: string;
+}, action: () => Promise<T>): Promise<T> {
+  const lock = await acquireCodexContextHistoryJournalLock(params);
+  try {
+    return await action();
+  } finally {
+    await lock.release();
+  }
+}
+
+export async function appendCodexContextHistoryJournalEntryLocked(
+  stateDir: string,
+  sessionId: string,
+  payload: unknown,
+): Promise<void> {
+  const path = codexContextHistoryJournalPath(stateDir, sessionId);
+  await mkdir(dirname(path), { recursive: true });
+  const current = await readCodexContextHistoryJournal(stateDir, sessionId);
+  if (current.readError || current.malformedLineCount > 0) {
+    throw new Error(`Refusing to append to invalid Codex context-history journal for session ${sessionId}`);
+  }
+  const handle = await open(path, "a");
+  try {
+    await handle.appendFile(`${JSON.stringify(payload)}\n`, "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function appendCodexContextHistoryJournalEntry(
+  stateDir: string,
+  sessionId: string,
+  payload: unknown,
+): Promise<void> {
+  await withCodexContextHistoryJournalLock({ stateDir, sessionId }, async () => {
+    await appendCodexContextHistoryJournalEntryLocked(stateDir, sessionId, payload);
+  });
+}

--- a/components/adapters/codex/src/context-history/replayability.ts
+++ b/components/adapters/codex/src/context-history/replayability.ts
@@ -37,7 +37,7 @@ export function codexReplayabilityForItem(item: JsonObject): CodexItemReplayabil
       : { mode: "deferred", reason: "tool_call_id_missing" };
   }
   if (type === "reasoning" || type === "compaction") {
-    return typeof item.encrypted_content === "string" && item.encrypted_content.length > 0
+    return typeof item.encrypted_content === "string" && item.encrypted_content.trim().length > 0
       ? { mode: "replayable", reason: "exact_payload_required" }
       : { mode: "deferred", reason: "exact_payload_missing" };
   }

--- a/components/adapters/codex/src/context-history/request-journal.ts
+++ b/components/adapters/codex/src/context-history/request-journal.ts
@@ -1,5 +1,8 @@
-import { appendJsonl } from "@lightmem2/host-adapter";
-import { codexContextHistoryJournalPath, readCodexContextHistoryJournalEntries } from "./journal-store.js";
+import { readCodexContextHistoryJournal } from "./journal-store.js";
+import {
+  appendCodexContextHistoryJournalEntryLocked,
+  withCodexContextHistoryJournalLock,
+} from "./journal-append.js";
 import { cloneJson, hashJson, normalizeStatus, sanitizeValue } from "./shared.js";
 import {
   CODEX_CONTEXT_HISTORY_REQUEST_SCHEMA,
@@ -29,7 +32,7 @@ function requestIdFromPayload(params: {
 }
 
 function latestRequestEntry(
-  entries: Awaited<ReturnType<typeof readCodexContextHistoryJournalEntries>>,
+  entries: Awaited<ReturnType<typeof readCodexContextHistoryJournal>>["entries"],
   requestId: string,
 ): CodexRequestJournalEntry | undefined {
   for (let index = entries.length - 1; index >= 0; index -= 1) {
@@ -45,7 +48,7 @@ function canAdvanceStatus(current: CodexJournalStatus, next: CodexJournalStatus)
   return next !== "pending";
 }
 
-export async function appendCodexRequestJournalEntry(params: {
+async function appendCodexRequestJournalEntryLocked(params: {
   stateDir: string;
   sessionId: string;
   payload: JsonObject;
@@ -57,7 +60,11 @@ export async function appendCodexRequestJournalEntry(params: {
   observedAt?: string;
 }): Promise<CodexRequestJournalEntry> {
   const requestId = params.requestId ?? requestIdFromPayload(params);
-  const current = await readCodexContextHistoryJournalEntries(params.stateDir, params.sessionId);
+  const journal = await readCodexContextHistoryJournal(params.stateDir, params.sessionId);
+  if (journal.readError || journal.malformedLineCount > 0) {
+    throw new Error(`Refusing to update invalid Codex context-history journal for session ${params.sessionId}`);
+  }
+  const current = journal.entries;
   const existing = latestRequestEntry(current, requestId);
   const nextStatus = normalizeStatus(params.status, existing?.status ?? "pending");
   if (existing && !canAdvanceStatus(existing.status, nextStatus)) return existing;
@@ -89,6 +96,23 @@ export async function appendCodexRequestJournalEntry(params: {
     error: params.error,
     observedAt: params.observedAt ?? new Date().toISOString(),
   };
-  await appendJsonl(codexContextHistoryJournalPath(params.stateDir, params.sessionId), entry);
+  await appendCodexContextHistoryJournalEntryLocked(params.stateDir, params.sessionId, entry);
   return entry;
+}
+
+export async function appendCodexRequestJournalEntry(params: {
+  stateDir: string;
+  sessionId: string;
+  payload: JsonObject;
+  committedInputItems?: JsonObject[];
+  requestId?: string;
+  turnOrdinal?: number;
+  status?: CodexJournalStatus;
+  error?: string;
+  observedAt?: string;
+}): Promise<CodexRequestJournalEntry> {
+  return withCodexContextHistoryJournalLock(
+    { stateDir: params.stateDir, sessionId: params.sessionId },
+    () => appendCodexRequestJournalEntryLocked(params),
+  );
 }

--- a/components/adapters/codex/src/context-history/response-journal.ts
+++ b/components/adapters/codex/src/context-history/response-journal.ts
@@ -1,5 +1,4 @@
-import { appendJsonl } from "@lightmem2/host-adapter";
-import { codexContextHistoryJournalPath } from "./journal-store.js";
+import { appendCodexContextHistoryJournalEntry } from "./journal-append.js";
 import { collectCodexResponseItemsFromStream } from "./sse-item-collector.js";
 import { cloneJson, normalizeStatus, sanitizeValue } from "./shared.js";
 import {
@@ -88,6 +87,6 @@ export async function appendCodexResponseJournalEntry(params: {
     error: params.error,
     observedAt: params.observedAt ?? new Date().toISOString(),
   };
-  await appendJsonl(codexContextHistoryJournalPath(params.stateDir, params.sessionId), entry);
+  await appendCodexContextHistoryJournalEntry(params.stateDir, params.sessionId, entry);
   return entry;
 }

--- a/components/adapters/codex/src/context-rebase-smoke.ts
+++ b/components/adapters/codex/src/context-rebase-smoke.ts
@@ -1,0 +1,751 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage } from "node:http";
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { reserveUnusedPort } from "@lightmem2/host-adapter";
+
+import { normalizeTokenPilotCodexConfig } from "./config.js";
+import {
+  buildCodexEffectiveHistory,
+  loadCodexContextHistoryJournal,
+  type JsonObject,
+} from "./context-history/index.js";
+import type { TokenPilotCodexLogger } from "./logger.js";
+import { startCodexResponsesProxy, type CodexProxyRuntime } from "./proxy-runtime.js";
+import {
+  readCodexRebaseCooldownJournal,
+  readLatestCodexRebaseEpoch,
+} from "./context-rewrite/index.js";
+import type { CodexRebaseAccounting } from "./context-rewrite/types.js";
+import { resolveCodexSessionIdByResponseId } from "./session-state.js";
+
+export const CODEX_REBASE_SMOKE_EVIDENCE_SCHEMA =
+  "lightmem2.codex.context-rebase-smoke-evidence/v1";
+
+export type CodexRebaseSmokeAccountingEvidence = {
+  plannedSavedChars: number;
+  plannedSavedTokens: number;
+  actuallyRemovedChars: number;
+  actuallyRemovedTokens: number;
+  rebaseReplayCostChars: number;
+  rebaseReplayCostTokens: number;
+  subsequentSavedCharsPerTurn: number;
+  subsequentSavedTokensPerTurn: number;
+  estimatorCostChars: number;
+  estimatorCostTokens: number;
+  fallbackExtraRequestCount: number;
+  cacheColdMissCount: number;
+  breakEvenTurn?: number;
+};
+
+export type CodexRebaseSmokeEvidence = {
+  schema: typeof CODEX_REBASE_SMOKE_EVIDENCE_SCHEMA;
+  mode: "mock";
+  provider: "local-scripted-responses";
+  model: string;
+  endpoint: "loopback-temporary";
+  runtime: {
+    node: string;
+    codexCli: string;
+  };
+  startedAt: string;
+  finishedAt: string;
+  happyPath: {
+    upstreamRequestCount: number;
+    rebaseRequestFound: boolean;
+    oldPreviousResponseIdRemoved: boolean;
+    sentinel: {
+      evictedAbsent: boolean;
+      retainedPresent: boolean;
+    };
+    replayItemTypes: string[];
+    reasoning: {
+      present: boolean;
+      encryptedPayloadChars: number;
+      encryptedPayloadSha256: string;
+      encryptedPayloadDigestMatches: boolean;
+    };
+    toolClosure: {
+      callCount: number;
+      outputCount: number;
+      complete: boolean;
+    };
+    responseChain: {
+      newRootResponseIdPresent: boolean;
+      terminalResponseIdPresent: boolean;
+      terminalSessionMappingMatches: boolean;
+      epochCommitted: boolean;
+      journalCommittedBeforeEpoch: boolean;
+      continuationTurns: number;
+      linksValid: boolean;
+      restartPreserved: boolean;
+      finalHistoryComplete: boolean;
+    };
+    accounting?: CodexRebaseSmokeAccountingEvidence;
+  };
+  fallback: {
+    rebaseAttempts: number;
+    originalRequestRetries: number;
+    fallbackSucceeded: boolean;
+    originalPreviousResponseIdRestored: boolean;
+    epochRolledBack: boolean;
+    cooldownRecorded: boolean;
+    accounting?: CodexRebaseSmokeAccountingEvidence;
+  };
+  moduleMatrix: Array<{
+    stabilizer: boolean;
+    reduction: boolean;
+    rewrite: boolean;
+    stablePrefixApplied: boolean;
+    reductionApplied: boolean;
+    rewriteApplied: boolean;
+    isolationPassed: boolean;
+  }>;
+  privacy: {
+    credentialSource: "not-required";
+    rawPromptPersisted: false;
+    rawEncryptedPayloadPersisted: false;
+    rawHeadersPersisted: false;
+    ephemeralStateRemoved: true;
+  };
+};
+
+export type RunCodexRebaseMockSmokeOptions = {
+  model?: string;
+  outputDir?: string;
+};
+
+export type CodexRebaseSmokeRunResult = {
+  artifactPath: string;
+  artifactSha256: string;
+  evidence: CodexRebaseSmokeEvidence;
+};
+
+type MockUpstream = {
+  baseUrl: string;
+  requests: JsonObject[];
+  close(): Promise<void>;
+};
+
+const FETCH_FORBIDDEN_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77,
+  79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123,
+  135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530,
+  531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719,
+  1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666,
+  6667, 6668, 6669, 6697, 10080,
+]);
+
+const silentLogger: TokenPilotCodexLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function jsonItems(value: unknown): JsonObject[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is JsonObject => Boolean(item && typeof item === "object" && !Array.isArray(item)))
+    : [];
+}
+
+function serializedInput(payload: JsonObject | undefined): string {
+  return JSON.stringify(jsonItems(payload?.input));
+}
+
+function accountingEvidence(
+  accounting: CodexRebaseAccounting | undefined,
+): CodexRebaseSmokeAccountingEvidence | undefined {
+  if (!accounting) return undefined;
+  return { ...accounting };
+}
+
+async function reserveFetchPort(): Promise<number> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const port = await reserveUnusedPort();
+    if (!FETCH_FORBIDDEN_PORTS.has(port)) return port;
+  }
+  throw new Error("Unable to reserve a fetch-safe smoke port");
+}
+
+async function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise<string>((resolveBody, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))));
+    req.on("error", reject);
+    req.on("end", () => resolveBody(Buffer.concat(chunks).toString("utf8")));
+  });
+}
+
+async function startMockUpstream(params: {
+  prefix: string;
+  encryptedPayload?: string;
+  rejectRebase?: boolean;
+}): Promise<MockUpstream> {
+  const port = await reserveFetchPort();
+  const requests: JsonObject[] = [];
+  const server = createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/responses") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    const payload = JSON.parse(await readRequestBody(req)) as JsonObject;
+    requests.push(payload);
+    const requestOrdinal = requests.length;
+    const isRebase = requestOrdinal > 1 && !("previous_response_id" in payload);
+    if (params.rejectRebase && isRebase) {
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        error: { code: "invalid_request_error", message: "scripted replay schema rejection" },
+      }));
+      return;
+    }
+
+    const responseId = `${params.prefix}-${requestOrdinal}`;
+    const output = requestOrdinal === 1 && params.encryptedPayload
+      ? [
+        {
+          id: `${params.prefix}-reasoning-1`,
+          type: "reasoning",
+          encrypted_content: params.encryptedPayload,
+          summary: [],
+        },
+        {
+          id: `${params.prefix}-call-item-1`,
+          type: "function_call",
+          call_id: `${params.prefix}-call-1`,
+          name: "lookup_smoke_fixture",
+          arguments: JSON.stringify({ record: "retained" }),
+        },
+      ]
+      : [
+        {
+          id: `${params.prefix}-message-${requestOrdinal}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: `scripted response ${requestOrdinal}` }],
+        },
+      ];
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      id: responseId,
+      object: "response",
+      status: "completed",
+      previous_response_id:
+        typeof payload.previous_response_id === "string" ? payload.previous_response_id : undefined,
+      output,
+    }));
+  });
+  await new Promise<void>((resolveListen, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolveListen();
+    });
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close() {
+      return new Promise<void>((resolveClose, reject) => {
+        server.close((error) => error ? reject(error) : resolveClose());
+      });
+    },
+  };
+}
+
+function buildSmokeConfig(params: {
+  stateDir: string;
+  proxyPort: number;
+  upstreamBaseUrl: string;
+  modelPlan?: { stableItemId: string };
+  modules?: { stabilizer: boolean; reduction: boolean };
+  rewriteEnabled?: boolean;
+}) {
+  return normalizeTokenPilotCodexConfig({
+    stateDir: params.stateDir,
+    proxyPort: params.proxyPort,
+    upstreamProvider: "OpenAI",
+    upstream: {
+      name: "local-scripted-responses",
+      baseUrl: params.upstreamBaseUrl,
+      wireApi: "responses",
+      requiresOpenAIAuth: false,
+    },
+    modules: {
+      stabilizer: params.modules?.stabilizer ?? false,
+      reduction: params.modules?.reduction ?? false,
+    },
+    contextRewrite: {
+      enabled: params.rewriteEnabled ?? true,
+      mode: "response_chain_rebase",
+      failureMode: "bypass",
+      retryOriginalRequest: true,
+      cooldownMs: 300_000,
+      mutationPlan: params.modelPlan
+        ? { operations: [{ type: "evict", stableItemId: params.modelPlan.stableItemId }] }
+        : { operations: [] },
+    },
+    reduction: {
+      triggerMinChars: 256,
+      maxToolChars: 400,
+      passes: {
+        readStateCompaction: false,
+        toolPayloadTrim: true,
+        htmlSlimming: false,
+        execOutputTruncation: true,
+        agentsStartupOptimization: false,
+      },
+      passOptions: {
+        execOutputTruncation: {
+          toolThresholds: { bash: 400 },
+        },
+      },
+    },
+  });
+}
+
+async function postResponse(
+  runtime: CodexProxyRuntime,
+  payload: JsonObject,
+): Promise<JsonObject> {
+  const response = await fetch(`${runtime.baseUrl}/responses`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Codex rebase smoke request failed with status ${response.status}`);
+  }
+  const parsed = JSON.parse(text) as JsonObject;
+  if (typeof parsed.id !== "string" || !parsed.id) {
+    throw new Error("Codex rebase smoke response did not include a response id");
+  }
+  return parsed;
+}
+
+function toolClosureEvidence(input: JsonObject[]): {
+  callCount: number;
+  outputCount: number;
+  complete: boolean;
+} {
+  const calls = input.filter((item) => item.type === "function_call");
+  const outputs = input.filter((item) => item.type === "function_call_output");
+  const callIds = calls.map((item) => item.call_id).filter((value): value is string => typeof value === "string");
+  const outputIds = outputs
+    .map((item) => item.call_id)
+    .filter((value): value is string => typeof value === "string");
+  const complete = callIds.length === calls.length
+    && outputIds.length === outputs.length
+    && new Set(callIds).size === callIds.length
+    && new Set(outputIds).size === outputIds.length
+    && callIds.length === outputIds.length
+    && callIds.every((callId) => outputIds.includes(callId));
+  return { callCount: calls.length, outputCount: outputs.length, complete };
+}
+
+async function runHappyPath(model: string): Promise<CodexRebaseSmokeEvidence["happyPath"]> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-smoke-state-"));
+  const marker = randomUUID();
+  const evictSentinel = `EVICT_ME_${marker}`;
+  const keepSentinel = `KEEP_ME_${marker}`;
+  const encryptedPayload = `synthetic-encrypted-reasoning-${randomUUID()}`;
+  const sessionId = `codex-rebase-smoke-${randomUUID()}`;
+  const upstream = await startMockUpstream({
+    prefix: "resp-smoke",
+    encryptedPayload,
+  });
+  let runtime: CodexProxyRuntime | undefined;
+  try {
+    const config = buildSmokeConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamBaseUrl: upstream.baseUrl,
+    });
+    runtime = await startCodexResponsesProxy({ config, logger: silentLogger });
+
+    const first = await postResponse(runtime, {
+      model,
+      stream: false,
+      include: ["reasoning.encrypted_content"],
+      metadata: { tokenpilotSessionId: sessionId },
+      input: [
+        { role: "user", content: evictSentinel },
+        { role: "user", content: keepSentinel },
+      ],
+    });
+    const firstResponseId = String(first.id);
+    const second = await postResponse(runtime, {
+      model,
+      stream: false,
+      include: ["reasoning.encrypted_content"],
+      previous_response_id: firstResponseId,
+      input: [{
+        type: "function_call_output",
+        call_id: "resp-smoke-call-1",
+        output: "retained tool result",
+      }],
+    });
+    let previousResponseId = String(second.id);
+
+    const beforeRebase = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: previousResponseId,
+    });
+    const evictedItem = beforeRebase.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes(evictSentinel)
+    ));
+    if (!evictedItem) throw new Error("Smoke setup could not resolve the eviction target");
+    config.contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: evictedItem.stableItemId }],
+    };
+
+    const rebaseResponse = await postResponse(runtime, {
+      model,
+      stream: false,
+      include: ["reasoning.encrypted_content"],
+      previous_response_id: previousResponseId,
+      input: [{ role: "user", content: "new chain turn 1" }],
+    });
+    previousResponseId = String(rebaseResponse.id);
+    const newRootResponseIdPresent = previousResponseId.length > 0;
+    config.contextRewrite.mutationPlan = { operations: [] };
+
+    let restartPreserved = false;
+    const continuationLinks: boolean[] = [];
+    for (let turn = 2; turn <= 5; turn += 1) {
+      if (turn === 3) {
+        const headBeforeRestart = previousResponseId;
+        await runtime.close();
+        runtime = undefined;
+        const restartedConfig = buildSmokeConfig({
+          stateDir,
+          proxyPort: await reserveFetchPort(),
+          upstreamBaseUrl: upstream.baseUrl,
+        });
+        runtime = await startCodexResponsesProxy({ config: restartedConfig, logger: silentLogger });
+        restartPreserved = await resolveCodexSessionIdByResponseId(stateDir, headBeforeRestart) === sessionId;
+      }
+      const expectedPreviousResponseId = previousResponseId;
+      const requestIndex = upstream.requests.length;
+      const response = await postResponse(runtime, {
+        model,
+        stream: false,
+        include: ["reasoning.encrypted_content"],
+        previous_response_id: expectedPreviousResponseId,
+        input: [{ role: "user", content: `new chain turn ${turn}` }],
+      });
+      previousResponseId = String(response.id);
+      continuationLinks.push(
+        upstream.requests[requestIndex]?.previous_response_id === expectedPreviousResponseId,
+      );
+    }
+
+    const rebasePayload = upstream.requests[2];
+    const replayInput = jsonItems(rebasePayload?.input);
+    const replayText = serializedInput(rebasePayload);
+    const reasoning = replayInput.find((item) => item.type === "reasoning");
+    const replayedEncryptedPayload = typeof reasoning?.encrypted_content === "string"
+      ? reasoning.encrypted_content
+      : "";
+    const closure = toolClosureEvidence(replayInput);
+    const epoch = await readLatestCodexRebaseEpoch({ stateDir, sessionId });
+    const journal = await loadCodexContextHistoryJournal(stateDir, sessionId);
+    const committedRootResponse = journal.find((entry) => (
+      entry.kind === "response"
+      && entry.responseId === String(rebaseResponse.id)
+      && entry.status === "completed"
+      && entry.previousResponseId === null
+    ));
+    const committedRootRequest = committedRootResponse?.requestId
+      ? journal.find((entry) => (
+        entry.kind === "request"
+        && entry.requestId === committedRootResponse.requestId
+        && entry.status === "completed"
+        && Array.isArray(entry.committedInputItems)
+      ))
+      : undefined;
+    const finalHistory = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: previousResponseId,
+    });
+    const finalHistoryText = JSON.stringify(finalHistory.replayableItems);
+    const terminalSessionMappingMatches =
+      await resolveCodexSessionIdByResponseId(stateDir, previousResponseId) === sessionId;
+
+    return {
+      upstreamRequestCount: upstream.requests.length,
+      rebaseRequestFound: Boolean(rebasePayload),
+      oldPreviousResponseIdRemoved: Boolean(rebasePayload) && !("previous_response_id" in rebasePayload),
+      sentinel: {
+        evictedAbsent: !replayText.includes(evictSentinel) && !finalHistoryText.includes(evictSentinel),
+        retainedPresent: replayText.includes(keepSentinel) && finalHistoryText.includes(keepSentinel),
+      },
+      replayItemTypes: replayInput.map((item) => (
+        typeof item.type === "string"
+          ? item.type
+          : typeof item.role === "string" ? `message:${item.role}` : "unknown"
+      )),
+      reasoning: {
+        present: Boolean(reasoning),
+        encryptedPayloadChars: replayedEncryptedPayload.length,
+        encryptedPayloadSha256: sha256(replayedEncryptedPayload),
+        encryptedPayloadDigestMatches: sha256(replayedEncryptedPayload) === sha256(encryptedPayload),
+      },
+      toolClosure: closure,
+      responseChain: {
+        newRootResponseIdPresent,
+        terminalResponseIdPresent: previousResponseId.length > 0,
+        terminalSessionMappingMatches,
+        epochCommitted: epoch?.status === "committed",
+        journalCommittedBeforeEpoch:
+          epoch?.status === "committed"
+          && epoch.newResponseId === String(rebaseResponse.id)
+          && Boolean(committedRootResponse)
+          && Boolean(committedRootRequest)
+          && Date.parse(committedRootResponse?.observedAt ?? "") <= Date.parse(epoch.updatedAt),
+        continuationTurns: 5,
+        linksValid: continuationLinks.every(Boolean),
+        restartPreserved,
+        finalHistoryComplete: !finalHistory.incomplete,
+      },
+      accounting: accountingEvidence(epoch?.accounting),
+    };
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+}
+
+async function runFallbackPath(model: string): Promise<CodexRebaseSmokeEvidence["fallback"]> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-fallback-smoke-state-"));
+  const evictSentinel = `EVICT_ME_${randomUUID()}`;
+  const sessionId = `codex-rebase-fallback-smoke-${randomUUID()}`;
+  const upstream = await startMockUpstream({ prefix: "resp-fallback", rejectRebase: true });
+  let runtime: CodexProxyRuntime | undefined;
+  try {
+    const config = buildSmokeConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamBaseUrl: upstream.baseUrl,
+    });
+    runtime = await startCodexResponsesProxy({ config, logger: silentLogger });
+    const first = await postResponse(runtime, {
+      model,
+      stream: false,
+      metadata: { tokenpilotSessionId: sessionId },
+      input: [{ role: "user", content: evictSentinel }],
+    });
+    const oldPreviousResponseId = String(first.id);
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: oldPreviousResponseId,
+    });
+    const evictedItem = history.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes(evictSentinel)
+    ));
+    if (!evictedItem) throw new Error("Fallback smoke setup could not resolve the eviction target");
+    config.contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: evictedItem.stableItemId }],
+    };
+
+    const result = await postResponse(runtime, {
+      model,
+      stream: false,
+      previous_response_id: oldPreviousResponseId,
+      input: [{ role: "user", content: "fallback current turn" }],
+    });
+    const rebasePayload = upstream.requests[1];
+    const fallbackPayload = upstream.requests[2];
+    const epoch = await readLatestCodexRebaseEpoch({ stateDir, sessionId });
+    const cooldownJournal = await readCodexRebaseCooldownJournal(stateDir, sessionId);
+
+    return {
+      rebaseAttempts: rebasePayload && !("previous_response_id" in rebasePayload) ? 1 : 0,
+      originalRequestRetries:
+        fallbackPayload?.previous_response_id === oldPreviousResponseId ? 1 : 0,
+      fallbackSucceeded: typeof result.id === "string" && result.id.length > 0,
+      originalPreviousResponseIdRestored:
+        fallbackPayload?.previous_response_id === oldPreviousResponseId,
+      epochRolledBack: epoch?.status === "rolled_back",
+      cooldownRecorded: cooldownJournal.cooldowns.length === 1,
+      accounting: accountingEvidence(epoch?.accounting),
+    };
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+}
+
+async function runModuleCombination(params: {
+  model: string;
+  stabilizer: boolean;
+  reduction: boolean;
+  rewrite: boolean;
+}): Promise<CodexRebaseSmokeEvidence["moduleMatrix"][number]> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-module-matrix-state-"));
+  const sessionId = `codex-module-matrix-${randomUUID()}`;
+  const evictSentinel = `EVICT_ME_${randomUUID()}`;
+  const longToolOutput = `HEAD\n${"line\n".repeat(600)}`;
+  const upstream = await startMockUpstream({ prefix: "resp-matrix" });
+  let runtime: CodexProxyRuntime | undefined;
+  try {
+    const config = buildSmokeConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamBaseUrl: upstream.baseUrl,
+      modules: {
+        stabilizer: params.stabilizer,
+        reduction: params.reduction,
+      },
+      rewriteEnabled: params.rewrite,
+    });
+    runtime = await startCodexResponsesProxy({ config, logger: silentLogger });
+    const callId = `matrix-call-${randomUUID()}`;
+    const first = await postResponse(runtime, {
+      model: params.model,
+      stream: false,
+      instructions: [
+        "You are a coding agent.",
+        "Your working directory is: /workspace/smoke",
+        "Runtime: agent=matrix-agent | mode=offline",
+      ].join("\n"),
+      metadata: { tokenpilotSessionId: sessionId },
+      input: [
+        {
+          role: "developer",
+          content: [
+            "You are a coding agent.",
+            "Your working directory is: /workspace/smoke",
+            "Runtime: agent=matrix-agent | mode=offline",
+          ].join("\n"),
+        },
+        { role: "user", content: evictSentinel },
+        { type: "function_call", call_id: callId, name: "bash", arguments: "{}" },
+        { type: "function_call_output", call_id: callId, name: "bash", output: longToolOutput },
+      ],
+    });
+    const firstResponseId = String(first.id);
+    const firstUpstreamPayload = upstream.requests[0];
+    const firstInput = jsonItems(firstUpstreamPayload?.input);
+    const forwardedToolOutput = firstInput.find((item) => item.type === "function_call_output")?.output;
+    const stablePrefixApplied = typeof firstUpstreamPayload?.prompt_cache_key === "string";
+    const reductionApplied =
+      typeof forwardedToolOutput === "string" && forwardedToolOutput.length < longToolOutput.length;
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: firstResponseId,
+    });
+    const evictedItem = history.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes(evictSentinel)
+    ));
+    if (!evictedItem) throw new Error("Module matrix could not resolve the eviction target");
+    config.contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: evictedItem.stableItemId }],
+    };
+    await postResponse(runtime, {
+      model: params.model,
+      stream: false,
+      previous_response_id: firstResponseId,
+      input: [{ role: "user", content: "module matrix current turn" }],
+    });
+    const rewriteApplied = !("previous_response_id" in (upstream.requests[1] ?? {}));
+    const isolationPassed = stablePrefixApplied === params.stabilizer
+      && reductionApplied === params.reduction
+      && rewriteApplied === params.rewrite;
+    return {
+      stabilizer: params.stabilizer,
+      reduction: params.reduction,
+      rewrite: params.rewrite,
+      stablePrefixApplied,
+      reductionApplied,
+      rewriteApplied,
+      isolationPassed,
+    };
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+}
+
+async function runModuleMatrix(model: string): Promise<CodexRebaseSmokeEvidence["moduleMatrix"]> {
+  const evidence: CodexRebaseSmokeEvidence["moduleMatrix"] = [];
+  for (const stabilizer of [false, true]) {
+    for (const reduction of [false, true]) {
+      for (const rewrite of [false, true]) {
+        evidence.push(await runModuleCombination({ model, stabilizer, reduction, rewrite }));
+      }
+    }
+  }
+  return evidence;
+}
+
+async function writeEvidence(
+  outputDir: string,
+  evidence: CodexRebaseSmokeEvidence,
+): Promise<{ artifactPath: string; artifactSha256: string }> {
+  await mkdir(outputDir, { recursive: true });
+  const artifactPath = join(outputDir, "codex-context-rebase-mock-smoke.json");
+  const tempPath = `${artifactPath}.${process.pid}.${randomUUID()}.tmp`;
+  const text = `${JSON.stringify(evidence, null, 2)}\n`;
+  await writeFile(tempPath, text, { encoding: "utf8", mode: 0o600 });
+  await rename(tempPath, artifactPath);
+  return { artifactPath, artifactSha256: sha256(text) };
+}
+
+export async function runCodexRebaseMockSmoke(
+  options: RunCodexRebaseMockSmokeOptions = {},
+): Promise<CodexRebaseSmokeRunResult> {
+  const model = options.model?.trim() || "gpt-5.4-mini";
+  const startedAt = new Date().toISOString();
+  // Proxy startup configures a process-global state resolver, so smoke
+  // scenarios intentionally run serially even though their state dirs differ.
+  const happyPath = await runHappyPath(model);
+  const fallback = await runFallbackPath(model);
+  const moduleMatrix = await runModuleMatrix(model);
+  const evidence: CodexRebaseSmokeEvidence = {
+    schema: CODEX_REBASE_SMOKE_EVIDENCE_SCHEMA,
+    mode: "mock",
+    provider: "local-scripted-responses",
+    model,
+    endpoint: "loopback-temporary",
+    runtime: {
+      node: process.version,
+      codexCli: process.env.CODEX_CLI_VERSION?.trim() || "not-observed",
+    },
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    happyPath,
+    fallback,
+    moduleMatrix,
+    privacy: {
+      credentialSource: "not-required",
+      rawPromptPersisted: false,
+      rawEncryptedPayloadPersisted: false,
+      rawHeadersPersisted: false,
+      ephemeralStateRemoved: true,
+    },
+  };
+  const outputDir = options.outputDir
+    ? resolve(options.outputDir)
+    : await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-smoke-evidence-"));
+  const artifact = await writeEvidence(outputDir, evidence);
+  return { ...artifact, evidence };
+}

--- a/components/adapters/codex/tests/context-history-journal.test.ts
+++ b/components/adapters/codex/tests/context-history-journal.test.ts
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
-import { appendFile, mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { spawn } from "node:child_process";
+import { appendFile, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 import {
   appendCodexRequestJournalEntry,
   appendCodexResponseJournalEntry,
   codexContextHistoryJournalPath,
+  codexContextHistoryJournalLockPath,
   loadCodexContextHistoryJournal,
   readCodexContextHistoryJournal,
 } from "../src/context-history/index.js";
@@ -19,8 +22,63 @@ async function withTempState(
   try {
     await fn(stateDir);
   } finally {
-    await rm(stateDir, { recursive: true, force: true });
+    await rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
+}
+
+async function runJournalWriterProcess(params: {
+  stateDir: string;
+  sessionId: string;
+  prefix: string;
+  count: number;
+}): Promise<void> {
+  const moduleUrl = pathToFileURL(resolve(__dirname, "../src/context-history/index.ts")).href;
+  const script = `
+    const contextHistoryModule = await import(${JSON.stringify(moduleUrl)});
+    const appendCodexRequestJournalEntry = contextHistoryModule.appendCodexRequestJournalEntry
+      ?? contextHistoryModule.default?.appendCodexRequestJournalEntry;
+    if (typeof appendCodexRequestJournalEntry !== "function") {
+      throw new Error("appendCodexRequestJournalEntry export is unavailable");
+    }
+    const [stateDir, sessionId, prefix, countText] = process.argv.slice(1);
+    const count = Number(countText);
+    for (let index = 0; index < count; index += 1) {
+      await appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: prefix + "-" + index,
+        payload: { input: [{ role: "user", content: prefix + "-" + index }] },
+        status: "completed",
+      });
+    }
+  `;
+
+  await new Promise<void>((resolveChild, rejectChild) => {
+    const child = spawn(process.execPath, [
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "-e",
+      script,
+      params.stateDir,
+      params.sessionId,
+      params.prefix,
+      String(params.count),
+    ], {
+      cwd: resolve(__dirname, ".."),
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once("error", rejectChild);
+    child.once("close", (code) => {
+      if (code === 0) resolveChild();
+      else rejectChild(new Error(`journal writer exited ${code}: ${stderr}`));
+    });
+  });
 }
 
 test("CDH-01 request journal stores sanitized input metadata and deduplicates request retries", async () => {
@@ -163,6 +221,175 @@ test("CDH-01 isolates malformed JSONL records without discarding valid history",
     assert.equal(journal.entries.length, 1);
     assert.equal(journal.malformedLineCount, 2);
     assert.equal(journal.readError, undefined);
+  });
+});
+
+test("CDH-01 serializes concurrent retries inside one request read-modify-append boundary", async () => {
+  await withTempState(async (stateDir) => {
+    const writes = Array.from({ length: 24 }, (_, index) => appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: "codex-session-concurrent-retry",
+      requestId: "request-same",
+      payload: { input: [{ role: "user", content: "same request" }] },
+      status: "completed",
+      observedAt: `2026-08-04T10:00:${String(index).padStart(2, "0")}.000Z`,
+    }));
+
+    const entries = await Promise.all(writes);
+    const journal = await readCodexContextHistoryJournal(stateDir, "codex-session-concurrent-retry");
+
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(journal.entries.length, 1);
+    assert.equal(new Set(entries.map((entry) => entry.requestId)).size, 1);
+    assert.equal(journal.entries[0]?.kind, "request");
+  });
+});
+
+test("CDH-01 serializes concurrent request and response journal records", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-concurrent-mixed";
+    const count = 16;
+    await Promise.all([
+      ...Array.from({ length: count }, (_, index) => appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-${index}`,
+        payload: { input: [{ role: "user", content: `request ${index}` }] },
+        status: "completed",
+      })),
+      ...Array.from({ length: count }, (_, index) => appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-${index}`,
+        response: {
+          id: `response-${index}`,
+          output: [{ id: `message-${index}`, type: "message", role: "assistant", content: [] }],
+        },
+        status: "completed",
+      })),
+    ]);
+
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    const rawLines = (await readFile(path, "utf8")).split(/\r?\n/).filter(Boolean);
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    const requests = journal.entries.filter((entry) => entry.kind === "request");
+
+    assert.equal(rawLines.length, count * 2);
+    assert.doesNotThrow(() => rawLines.forEach((line) => JSON.parse(line)));
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(journal.entries.length, count * 2);
+    assert.equal(new Set(requests.map((entry) => entry.requestId)).size, count);
+    assert.equal(
+      new Set(requests.map((entry) => entry.turnOrdinal)).size,
+      count,
+      JSON.stringify(requests.map((entry) => ({ requestId: entry.requestId, turnOrdinal: entry.turnOrdinal }))),
+    );
+  });
+});
+
+test("CDH-01 serializes context-history appends across writer processes", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-cross-process";
+    const processCount = 3;
+    const recordsPerProcess = 6;
+    await Promise.all(Array.from({ length: processCount }, (_, index) => runJournalWriterProcess({
+      stateDir,
+      sessionId,
+      prefix: `writer-${index}`,
+      count: recordsPerProcess,
+    })));
+
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    const requests = journal.entries.filter((entry) => entry.kind === "request");
+
+    assert.equal(journal.readError, undefined);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(requests.length, processCount * recordsPerProcess);
+    assert.equal(new Set(requests.map((entry) => entry.requestId)).size, requests.length);
+    assert.equal(new Set(requests.map((entry) => entry.turnOrdinal)).size, requests.length);
+  });
+});
+
+test("CDH-01 stale journal lock recovery uses a claim before concurrent appends", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-stale-journal-lock";
+    const lockPath = codexContextHistoryJournalLockPath(stateDir, sessionId);
+    await mkdir(dirname(lockPath), { recursive: true });
+    await writeFile(lockPath, JSON.stringify({
+      token: "dead-owner",
+      pid: 2_147_483_647,
+      hostname: hostname(),
+      createdAt: "2026-08-04T00:00:00.000Z",
+    }), "utf8");
+
+    await Promise.all(Array.from({ length: 8 }, (_, index) => appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: `request-${index}`,
+      payload: { input: [{ role: "user", content: `request ${index}` }] },
+      status: "completed",
+    })));
+
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(journal.entries.length, 8);
+    await assert.rejects(stat(lockPath), { code: "ENOENT" });
+  });
+});
+
+test("CDH-01 refuses to append after a malformed tail and preserves prior bytes", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-malformed-tail";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "valid" }] },
+      status: "completed",
+    });
+    await appendFile(path, "{\"truncated\":", "utf8");
+    const before = await readFile(path, "utf8");
+
+    await assert.rejects(
+      appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: "request-2",
+        response: { id: "response-2", output: [] },
+        status: "completed",
+      }),
+      /Refusing to append to invalid Codex context-history journal/,
+    );
+
+    assert.equal(await readFile(path, "utf8"), before);
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.entries.length, 1);
+    assert.equal(journal.malformedLineCount, 1);
+  });
+});
+
+test("CDH-01 fails closed when the context-history journal cannot be read", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-read-error";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await mkdir(path, { recursive: true });
+
+    await assert.rejects(
+      appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: "request-1",
+        payload: { input: [{ role: "user", content: "must bypass" }] },
+        status: "completed",
+      }),
+      /Refusing to update invalid Codex context-history journal/,
+    );
+
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.entries.length, 0);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.ok(journal.readError);
   });
 });
 

--- a/components/adapters/codex/tests/context-reasoning-replay.test.ts
+++ b/components/adapters/codex/tests/context-reasoning-replay.test.ts
@@ -1,0 +1,306 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendCodexRequestJournalEntry,
+  appendCodexResponseJournalEntry,
+  buildCodexEffectiveHistory,
+  type JsonObject,
+} from "../src/context-history/index.js";
+import {
+  appendCodexRebaseCapability,
+  buildCodexRebaseRequest,
+  executeCodexRebaseWithFallback,
+} from "../src/context-rewrite/index.js";
+
+type ReasoningReplayTurnFixture = {
+  requestId: string;
+  request: JsonObject;
+  response: JsonObject;
+};
+
+type ReasoningReplayFixture = {
+  fixtureKind: string;
+  sessionId: string;
+  model: string;
+  encryptedContent: string;
+  complete: {
+    turns: ReasoningReplayTurnFixture[];
+    currentInput: JsonObject[];
+  };
+  missingReasoning: JsonObject;
+  malformedReasoning: JsonObject;
+  truncatedResponse: JsonObject;
+};
+
+async function withTempState(fn: (stateDir: string) => Promise<void>): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-reasoning-replay-"));
+  try {
+    await fn(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+}
+
+async function loadFixture(): Promise<ReasoningReplayFixture> {
+  const path = join(__dirname, "fixtures", "context-history", "encrypted-reasoning-replay.json");
+  return JSON.parse(await readFile(path, "utf8")) as ReasoningReplayFixture;
+}
+
+function outputItems(response: JsonObject): JsonObject[] {
+  return Array.isArray(response.output)
+    ? response.output.filter((item): item is JsonObject => Boolean(item && typeof item === "object" && !Array.isArray(item)))
+    : [];
+}
+
+function replayInputShape(item: JsonObject): JsonObject {
+  const replayed = structuredClone(item);
+  delete replayed.id;
+  delete replayed.status;
+  delete replayed.created_at;
+  return replayed;
+}
+
+function itemLabel(item: JsonObject): string {
+  if (typeof item.type === "string") return item.type;
+  return typeof item.role === "string" ? `message:${item.role}` : "item";
+}
+
+function countOccurrences(value: unknown, needle: string): number {
+  return JSON.stringify(value).split(needle).length - 1;
+}
+
+async function persistCompleteFixture(stateDir: string, fixture: ReasoningReplayFixture): Promise<void> {
+  for (const turn of fixture.complete.turns) {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId: fixture.sessionId,
+      requestId: turn.requestId,
+      payload: turn.request,
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId: fixture.sessionId,
+      requestId: turn.requestId,
+      response: turn.response,
+      status: "completed",
+    });
+  }
+}
+
+test("CDH-05 encrypted reasoning fixture remains replayable with ordered tool closure", async () => {
+  await withTempState(async (stateDir) => {
+    const fixture = await loadFixture();
+    assert.equal(fixture.fixtureKind, "synthetic-sanitized-encrypted-reasoning-replay");
+    await persistCompleteFixture(stateDir, fixture);
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: fixture.sessionId,
+      headResponseId: "resp-reasoning-2",
+    });
+    const fixtureReasoning = outputItems(fixture.complete.turns[0]?.response ?? {})[0];
+    const replayedReasoning = history.replayableItems.find((entry) => entry.item.type === "reasoning");
+
+    assert.equal(history.incomplete, false);
+    assert.deepEqual(history.deferredItems, []);
+    assert.deepEqual(history.unresolvedCallIds, []);
+    assert.ok(fixtureReasoning);
+    assert.deepEqual(replayedReasoning?.item, fixtureReasoning);
+    assert.equal(replayedReasoning?.item.encrypted_content, fixture.encryptedContent);
+    assert.deepEqual(
+      history.replayableItems.map((entry) => itemLabel(entry.item)),
+      ["message:user", "reasoning", "function_call", "function_call_output", "message"],
+    );
+  });
+});
+
+test("CDR-02 replays encrypted reasoning exactly for stream and non-stream rebases", async () => {
+  await withTempState(async (stateDir) => {
+    const fixture = await loadFixture();
+    await persistCompleteFixture(stateDir, fixture);
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId: fixture.sessionId,
+      headResponseId: "resp-reasoning-2",
+    });
+    const evicted = history.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes("EVICT_ME_REASONING_FIXTURE")
+    ));
+    const fixtureReasoning = outputItems(fixture.complete.turns[0]?.response ?? {})[0];
+    assert.ok(evicted);
+    assert.ok(fixtureReasoning);
+
+    for (const stream of [false, true]) {
+      const originalPayload: JsonObject = {
+        model: fixture.model,
+        stream,
+        previous_response_id: "resp-reasoning-2",
+        include: ["reasoning.encrypted_content"],
+        input: fixture.complete.currentInput,
+      };
+      const originalBefore = structuredClone(originalPayload);
+      const result = buildCodexRebaseRequest({
+        sessionId: fixture.sessionId,
+        planId: `plan-reasoning-replay-${stream ? "stream" : "non-stream"}`,
+        baseRevision: history.revision,
+        originalPayload,
+        effectiveHistory: history,
+        currentInput: fixture.complete.currentInput,
+        mutationPlan: { operations: [{ type: "evict", stableItemId: evicted.stableItemId }] },
+      });
+      const replayInput = Array.isArray(result.payload.input)
+        ? result.payload.input as JsonObject[]
+        : [];
+      const reasoning = replayInput.find((item) => item.type === "reasoning");
+
+      assert.equal("previous_response_id" in result.payload, false);
+      assert.equal(result.payload.stream, stream);
+      assert.deepEqual(result.payload.include, ["reasoning.encrypted_content"]);
+      assert.deepEqual(reasoning, replayInputShape(fixtureReasoning));
+      assert.equal(reasoning?.encrypted_content, fixture.encryptedContent);
+      assert.deepEqual(
+        replayInput.map(itemLabel),
+        ["reasoning", "function_call", "function_call_output", "message", "message:user"],
+      );
+      assert.equal(countOccurrences(replayInput, "CURRENT_INPUT_REASONING_FIXTURE"), 1);
+      assert.equal(countOccurrences(replayInput, "EVICT_ME_REASONING_FIXTURE"), 0);
+      assert.equal(countOccurrences(replayInput, "KEEP_ME_TOOL_OUTPUT"), 1);
+      assert.equal(countOccurrences(replayInput, "KEEP_ME_ASSISTANT"), 1);
+      assert.deepEqual(originalPayload, originalBefore);
+    }
+  });
+});
+
+test("CDR-01 missing and malformed encrypted reasoning block rebase without mutating input", async () => {
+  const fixture = await loadFixture();
+  for (const [caseName, reasoning] of [
+    ["missing", fixture.missingReasoning],
+    ["malformed", fixture.malformedReasoning],
+  ] as const) {
+    await withTempState(async (stateDir) => {
+      const sessionId = `${fixture.sessionId}-${caseName}`;
+      const responseId = `resp-reasoning-${caseName}`;
+      await appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-reasoning-${caseName}`,
+        payload: { model: fixture.model, input: [{ role: "user", content: caseName }] },
+        status: "completed",
+      });
+      await appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-reasoning-${caseName}`,
+        response: { id: responseId, status: "completed", output: [reasoning] },
+        status: "completed",
+      });
+      const history = await buildCodexEffectiveHistory({ stateDir, sessionId, headResponseId: responseId });
+      const originalPayload: JsonObject = {
+        model: fixture.model,
+        previous_response_id: responseId,
+        input: fixture.complete.currentInput,
+      };
+      const originalBefore = structuredClone(originalPayload);
+
+      assert.equal(history.incomplete, true);
+      assert.equal(history.deferredItems.length, 1);
+      assert.equal(history.deferredItems[0]?.item.type, "reasoning");
+      assert.throws(() => buildCodexRebaseRequest({
+        sessionId,
+        planId: `plan-reasoning-${caseName}`,
+        baseRevision: history.revision,
+        originalPayload,
+        effectiveHistory: history,
+        currentInput: fixture.complete.currentInput,
+        mutationPlan: { operations: [] },
+      }), /effective_history_incomplete/);
+      assert.deepEqual(originalPayload, originalBefore);
+    });
+  }
+});
+
+test("CDR-01 truncated reasoning response blocks rebase without guessing encrypted content", async () => {
+  await withTempState(async (stateDir) => {
+    const fixture = await loadFixture();
+    const sessionId = `${fixture.sessionId}-truncated`;
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-reasoning-truncated",
+      payload: { model: fixture.model, input: [{ role: "user", content: "truncated" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-reasoning-truncated",
+      response: fixture.truncatedResponse,
+    });
+    const responseId = String(fixture.truncatedResponse.id);
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId, headResponseId: responseId });
+    const originalPayload: JsonObject = {
+      model: fixture.model,
+      previous_response_id: responseId,
+      input: fixture.complete.currentInput,
+    };
+    const originalBefore = structuredClone(originalPayload);
+
+    assert.equal(history.incomplete, true);
+    assert.deepEqual(history.replayableItems, []);
+    assert.throws(() => buildCodexRebaseRequest({
+      sessionId,
+      planId: "plan-reasoning-truncated",
+      baseRevision: history.revision,
+      originalPayload,
+      effectiveHistory: history,
+      currentInput: fixture.complete.currentInput,
+      mutationPlan: { operations: [] },
+    }), /effective_history_incomplete/);
+    assert.deepEqual(originalPayload, originalBefore);
+  });
+});
+
+test("CDR-05 known unsupported reasoning replay bypasses before opening a rebase request", async () => {
+  await withTempState(async (stateDir) => {
+    const fixture = await loadFixture();
+    await appendCodexRebaseCapability({
+      stateDir,
+      provider: "OpenAI",
+      model: fixture.model,
+      itemType: "reasoning",
+      status: "unsupported",
+      reason: "schema_error",
+    });
+    const originalPayload: JsonObject = {
+      model: fixture.model,
+      previous_response_id: "resp-reasoning-2",
+      input: fixture.complete.currentInput,
+    };
+    const rebasedPayload: JsonObject = {
+      model: fixture.model,
+      input: [{ type: "reasoning", encrypted_content: fixture.encryptedContent }, ...fixture.complete.currentInput],
+    };
+    const sentPayloads: JsonObject[] = [];
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: fixture.sessionId,
+      planId: "plan-reasoning-known-unsupported",
+      epochId: "epoch-reasoning-known-unsupported",
+      originalPayload,
+      rebasedPayload,
+      capabilityStore: { stateDir, provider: "OpenAI", model: fixture.model },
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+
+    assert.equal(result.outcome, "bypassed");
+    assert.deepEqual(result.capability?.skippedItemTypes, ["reasoning"]);
+    assert.deepEqual(sentPayloads, [originalPayload]);
+  });
+});

--- a/components/adapters/codex/tests/context-rebase-pipeline.test.ts
+++ b/components/adapters/codex/tests/context-rebase-pipeline.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createServer as createHttpServer } from "node:http";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -9,6 +9,7 @@ import { reserveUnusedPort } from "@lightmem2/host-adapter";
 import { normalizeTokenPilotCodexConfig } from "../src/config.js";
 import {
   buildCodexEffectiveHistory,
+  codexContextHistoryJournalPath,
   loadCodexContextHistoryJournal,
   parseCodexRollout,
 } from "../src/context-history/index.js";
@@ -584,6 +585,59 @@ test("CDH-02 proxy journal respects failed non-stream response bodies", async ()
     const journal = await loadCodexContextHistoryJournal(stateDir, sessionId);
     assert.equal(journal.filter((entry) => entry.kind === "request").at(-1)?.status, "failed");
     assert.equal(journal.find((entry) => entry.kind === "response")?.status, "failed");
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDH-01 proxy bypasses context-history journaling when the journal cannot be read", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-journal-bypass-"));
+  const upstream = await startSequencedResponsesUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-journal-bypass";
+    await mkdir(codexContextHistoryJournalPath(stateDir, sessionId), { recursive: true });
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: {
+        stabilizer: false,
+        reduction: false,
+      },
+      contextRewrite: {
+        enabled: true,
+        mode: "response_chain_rebase",
+        failureMode: "bypass",
+        retryOriginalRequest: true,
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const response = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "JOURNAL_FAILURE_BYPASS_SENTINEL" }],
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(upstream.requests.length, 1);
+    assert.match(JSON.stringify(upstream.requests[0]), /JOURNAL_FAILURE_BYPASS_SENTINEL/);
   } finally {
     await runtime?.close();
     await upstream.close();

--- a/components/adapters/codex/tests/context-rebase-smoke.test.ts
+++ b/components/adapters/codex/tests/context-rebase-smoke.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CODEX_REBASE_SMOKE_EVIDENCE_SCHEMA,
+  runCodexRebaseMockSmoke,
+} from "../src/context-rebase-smoke.js";
+
+test("CDR-06 offline smoke emits sanitized five-turn, restart, and fallback evidence", async () => {
+  const outputDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-smoke-test-"));
+  try {
+    const result = await runCodexRebaseMockSmoke({ outputDir, model: "offline-smoke-model" });
+    const evidence = result.evidence;
+    const artifactText = await readFile(result.artifactPath, "utf8");
+
+    assert.equal(evidence.schema, CODEX_REBASE_SMOKE_EVIDENCE_SCHEMA);
+    assert.equal(evidence.mode, "mock");
+    assert.equal(evidence.happyPath.rebaseRequestFound, true);
+    assert.equal(evidence.happyPath.oldPreviousResponseIdRemoved, true);
+    assert.deepEqual(evidence.happyPath.sentinel, {
+      evictedAbsent: true,
+      retainedPresent: true,
+    });
+    assert.deepEqual(evidence.happyPath.replayItemTypes, [
+      "message:user",
+      "reasoning",
+      "function_call",
+      "function_call_output",
+      "message",
+      "message:user",
+    ]);
+    assert.equal(evidence.happyPath.reasoning.present, true);
+    assert.ok(evidence.happyPath.reasoning.encryptedPayloadChars > 0);
+    assert.equal(evidence.happyPath.reasoning.encryptedPayloadDigestMatches, true);
+    assert.deepEqual(evidence.happyPath.toolClosure, {
+      callCount: 1,
+      outputCount: 1,
+      complete: true,
+    });
+    assert.deepEqual(evidence.happyPath.responseChain, {
+      newRootResponseIdPresent: true,
+      terminalResponseIdPresent: true,
+      terminalSessionMappingMatches: true,
+      epochCommitted: true,
+      journalCommittedBeforeEpoch: true,
+      continuationTurns: 5,
+      linksValid: true,
+      restartPreserved: true,
+      finalHistoryComplete: true,
+    });
+    assert.equal(evidence.happyPath.accounting?.fallbackExtraRequestCount, 0);
+    assert.equal(evidence.happyPath.accounting?.cacheColdMissCount, 1);
+    assert.ok((evidence.happyPath.accounting?.plannedSavedChars ?? 0) > 0);
+    assert.ok((evidence.happyPath.accounting?.actuallyRemovedChars ?? 0) > 0);
+    assert.ok((evidence.happyPath.accounting?.rebaseReplayCostChars ?? 0) > 0);
+    assert.ok((evidence.happyPath.accounting?.subsequentSavedCharsPerTurn ?? 0) > 0);
+    assert.equal(
+      evidence.happyPath.accounting?.breakEvenTurn,
+      Math.ceil(
+        (evidence.happyPath.accounting?.rebaseReplayCostChars ?? 0)
+          / (evidence.happyPath.accounting?.subsequentSavedCharsPerTurn ?? 1),
+      ),
+    );
+    assert.deepEqual(evidence.fallback, {
+      rebaseAttempts: 1,
+      originalRequestRetries: 1,
+      fallbackSucceeded: true,
+      originalPreviousResponseIdRestored: true,
+      epochRolledBack: true,
+      cooldownRecorded: true,
+      accounting: evidence.fallback.accounting,
+    });
+    assert.equal(evidence.fallback.accounting?.fallbackExtraRequestCount, 1);
+    assert.equal(evidence.moduleMatrix.length, 8);
+    assert.equal(evidence.moduleMatrix.every((entry) => entry.isolationPassed), true);
+    assert.equal(
+      new Set(evidence.moduleMatrix.map((entry) => (
+        `${Number(entry.stabilizer)}${Number(entry.reduction)}${Number(entry.rewrite)}`
+      ))).size,
+      8,
+    );
+    assert.equal(evidence.privacy.ephemeralStateRemoved, true);
+    assert.match(result.artifactSha256, /^[a-f0-9]{64}$/);
+    assert.equal(JSON.parse(artifactText).schema, CODEX_REBASE_SMOKE_EVIDENCE_SCHEMA);
+    assert.doesNotMatch(artifactText, /EVICT_ME_|KEEP_ME_|synthetic-encrypted-reasoning-/);
+    assert.doesNotMatch(artifactText, /previous_response_id|authorization|bearer/i);
+  } finally {
+    await rm(outputDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+});

--- a/components/adapters/codex/tests/fixtures/context-history/encrypted-reasoning-replay.json
+++ b/components/adapters/codex/tests/fixtures/context-history/encrypted-reasoning-replay.json
@@ -1,0 +1,130 @@
+{
+  "fixtureKind": "synthetic-sanitized-encrypted-reasoning-replay",
+  "sessionId": "codex-session-reasoning-replay",
+  "model": "gpt-5.4-mini",
+  "encryptedContent": "enc_fixture_v1_AAECAwQFBgcICQoLDA0ODw",
+  "complete": {
+    "turns": [
+      {
+        "requestId": "request-reasoning-1",
+        "request": {
+          "model": "gpt-5.4-mini",
+          "stream": false,
+          "input": [
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "EVICT_ME_REASONING_FIXTURE inspect the synthetic record"
+                }
+              ]
+            }
+          ]
+        },
+        "response": {
+          "id": "resp-reasoning-1",
+          "status": "completed",
+          "output": [
+            {
+              "id": "rs-reasoning-fixture",
+              "type": "reasoning",
+              "encrypted_content": "enc_fixture_v1_AAECAwQFBgcICQoLDA0ODw",
+              "summary": [
+                {
+                  "type": "summary_text",
+                  "text": "Synthetic reasoning summary."
+                }
+              ],
+              "status": "completed"
+            },
+            {
+              "id": "fc-reasoning-fixture",
+              "type": "function_call",
+              "call_id": "call-reasoning-fixture",
+              "name": "lookup_fixture",
+              "arguments": "{\"key\":\"alpha\"}",
+              "status": "completed"
+            }
+          ]
+        }
+      },
+      {
+        "requestId": "request-reasoning-2",
+        "request": {
+          "model": "gpt-5.4-mini",
+          "stream": false,
+          "previous_response_id": "resp-reasoning-1",
+          "input": [
+            {
+              "type": "function_call_output",
+              "call_id": "call-reasoning-fixture",
+              "output": "{\"value\":\"KEEP_ME_TOOL_OUTPUT\"}"
+            }
+          ]
+        },
+        "response": {
+          "id": "resp-reasoning-2",
+          "previous_response_id": "resp-reasoning-1",
+          "status": "completed",
+          "output": [
+            {
+              "id": "msg-reasoning-fixture",
+              "type": "message",
+              "role": "assistant",
+              "content": [
+                {
+                  "type": "output_text",
+                  "text": "KEEP_ME_ASSISTANT completed the synthetic lookup"
+                }
+              ],
+              "status": "completed"
+            }
+          ]
+        }
+      }
+    ],
+    "currentInput": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "input_text",
+            "text": "CURRENT_INPUT_REASONING_FIXTURE continue once"
+          }
+        ]
+      }
+    ]
+  },
+  "missingReasoning": {
+    "id": "rs-reasoning-missing",
+    "type": "reasoning",
+    "summary": [
+      {
+        "type": "summary_text",
+        "text": "Summary is not a substitute for encrypted content."
+      }
+    ],
+    "status": "completed"
+  },
+  "malformedReasoning": {
+    "id": "rs-reasoning-malformed",
+    "type": "reasoning",
+    "encrypted_content": "   ",
+    "summary": [],
+    "status": "completed"
+  },
+  "truncatedResponse": {
+    "id": "resp-reasoning-truncated",
+    "status": "incomplete",
+    "output": [
+      {
+        "id": "rs-reasoning-truncated",
+        "type": "reasoning",
+        "encrypted_content": "enc_fixture_v1_truncated_transport_record",
+        "summary": [],
+        "status": "incomplete"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Serialize Codex context-history journal writes with a session-scoped cross-process lock.
- Add stale-lock recovery, synced JSONL appends, and fail-closed handling for malformed or unreadable journals.
- Add sanitized encrypted-reasoning replay fixtures and positive/negative tests.
- Add a credential-free offline response-chain rebase smoke covering:
  - sentinel eviction and retention
  - five turns on the new response chain
  - proxy restart
  - fallback and cooldown
  - all eight module combinations
  - estimated accounting and break-even
- Document the offline smoke command and its limitations.

## Validation

- Focused tests: 37/37 passed
- Codex typecheck: passed
- Codex build: passed
- Package boundaries: passed
- Offline mock smoke: passed
- Full Codex suite: 216/217 passed
  - The remaining Windows hook-path assertion is an existing baseline failure; this PR does not modify that test.

## Remaining work

- Real-provider encrypted reasoning smoke
- Provider-observed usage and real break-even evidence
- This PR intentionally does not read or require an API key