### PR TITLE
fix(codex): harden journal recovery and provider-aware rebase

### DIFF
--- a/components/adapters/codex/README.md
+++ b/components/adapters/codex/README.md
@@ -159,12 +159,65 @@ The command never reads an API key. Its evidence is explicitly marked
 reasoning payloads. It does not replace real-provider validation or
 provider-observed usage and break-even evidence.
 
+### Opt-in provider context-rebase smoke
+
+The same command exposes a separate, explicit provider mode:
+
+```bash
+npm --prefix components/adapters/codex run smoke:context-rebase:codex -- \
+  --mode=provider \
+  --model=gpt-5.4-mini \
+  --output-dir=/path/to/sanitized-evidence
+```
+
+Provider mode reads `OPENAI_API_KEY` and `OPENAI_BASE_URL` from the process
+environment or `<initial cwd>/.env`; `--credentials-file` can select another
+ignored env file. There is no CLI argument for the key. The mode first verifies
+exact encrypted-reasoning and function-call/output replay, then compares a
+control chain with a five-turn rebase chain and restarts the proxy before turn
+three. It writes a v2 artifact only if the Responses endpoint, capability v2
+journal, rebase commit ordering, sentinel checks, exact payload digest, tool
+closure, response links, restart mapping, and provider usage gates all pass.
+
+Evidence contains only safe endpoint/model labels, an endpoint digest,
+booleans, counts, item types, payload length/digest, and provider usage totals.
+It never contains the API key, raw prompts, response IDs, encrypted payloads,
+headers, or raw provider error bodies. Authentication and schema failures are
+not retried; only 429 and 5xx receive two bounded retries. A provider that can
+return encrypted reasoning but rejects `previous_response_id` is recorded as a
+partial compatibility result and must not be described as a successful
+response-chain rebase.
+
 Context-history journal writers use a session-scoped cross-process lock. A
 successful append is one complete JSONL record followed by `sync`; concurrent
-request and response writers cannot interleave their records. If an external
-crash leaves a malformed tail, later reads and writes fail closed so the proxy
-bypasses rewriting instead of guessing history. This does not claim
-power-loss-level transactional append semantics.
+request and response writers cannot interleave their records. If a crash leaves
+one unterminated JSON/UTF-8 suffix after an otherwise canonical journal, the
+next append or effective-history restart read truncates only that suffix under
+the same lock and syncs the file. A complete canonical final record that only
+lacks its newline is preserved and normalized. Invalid canonical records,
+middle corruption, and read/write uncertainty still fail closed so the proxy
+bypasses rewriting instead of guessing history. Recovery evidence exposes only
+a reason, byte count, and SHA-256 digest, never the discarded bytes. This is
+crash-truncated tail recovery, not power-loss-level transactional append
+semantics.
+
+Provider replay compatibility is evaluated separately from structural
+replayability. A complete tool closure or exact encrypted payload only makes an
+item a replay candidate; it does not prove that the selected provider and model
+accept that item. Capability journal v2 keys observations by provider, model,
+Responses wire/API mode, a SHA-256 endpoint identity, item type, and item schema
+version, and expires observations after a bounded TTL.
+
+The default `contextRewrite.providerCompatibilityProbe` value is `disabled`.
+With that default, unknown, expired, verified-unsupported, payload-rejected, or
+untrusted capability state bypasses rebase before an epoch is opened and sends
+the original request. `mock_fixture` and `real_provider` are explicit probe
+modes. Mock evidence can drive mock tests but is never presented as real-provider
+verification. Explicit item-schema rejection is scoped to the named item type;
+encrypted-content lineage/expiry rejection is scoped to the exact payload
+digest; authentication, rate-limit, server, network, and ambiguous multi-item
+failures do not poison the capability cache. Doctor and session reports label
+the evidence source and whether each observation is active or expired.
 
 If install finishes in degraded MCP mode, Codex stable-prefix and reduction remain usable; only the real `memory_fault_recover` tool path is unavailable until MCP startup succeeds.
 
@@ -295,4 +348,9 @@ npm --prefix components/adapters/codex test
 npm --prefix components/adapters/codex run smoke:context-rebase:codex -- --mode=mock
 npm --prefix components/adapters/codex run install:codex
 npm --prefix components/adapters/codex run doctor:codex
+npm --prefix components/adapters/codex run pack:release
 ```
+
+`pack:release` is the Linux/CI Bash path. On Windows, build the Codex adapter,
+shared CLI, and MCP packages first, then use `pack:release:portable`; it creates
+the same minimal archive through a temporary directory without requiring WSL.

--- a/components/adapters/codex/package.json
+++ b/components/adapters/codex/package.json
@@ -37,6 +37,7 @@
     "smoke:context-rebase:codex": "node --import tsx scripts/context-rebase-smoke.ts",
     "install:codex": "node --import tsx scripts/install-codex.ts",
     "pack:release": "bash ./scripts/pack_release.sh",
+    "pack:release:portable": "node ./scripts/pack-release.mjs",
     "test": "node --import tsx --test tests/*.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepublishOnly": "npm run build"

--- a/components/adapters/codex/scripts/context-rebase-smoke.ts
+++ b/components/adapters/codex/scripts/context-rebase-smoke.ts
@@ -1,3 +1,7 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { runCodexRebaseProviderSmoke } from "../src/context-rebase-provider-smoke.js";
 import { runCodexRebaseMockSmoke } from "../src/context-rebase-smoke.js";
 
 function optionValue(name: string): string | undefined {
@@ -11,14 +15,58 @@ function printHelp(): void {
     "Usage: npm run smoke:context-rebase:codex -- [options]",
     "",
     "Options:",
-    "  --mode=mock          Run the offline scripted Responses smoke (default).",
-    "  --model=<name>       Non-sensitive model label recorded in evidence.",
-    "  --output-dir=<path>  Directory for the sanitized evidence JSON.",
-    "  --help               Show this help.",
+    "  --mode=mock|provider       Run offline mock (default) or explicit provider smoke.",
+    "  --model=<name>             Provider model; default is gpt-5.4-mini.",
+    "  --base-url=<url>           Provider base URL; defaults to OPENAI_BASE_URL.",
+    "  --credentials-file=<path> Provider env file; defaults to <initial cwd>/.env.",
+    "  --continuation-turns=<n>  Provider continuation turns, from 5 to 20.",
+    "  --output-dir=<path>        Directory for sanitized evidence JSON.",
+    "  --help                     Show this help.",
     "",
-    "This offline command never reads an API key and never persists raw prompts,",
-    "headers, response ids, or encrypted reasoning payloads in its evidence file.",
+    "Mock mode never reads an API key. Provider mode reads OPENAI_API_KEY only",
+    "from the process environment or the selected local env file. Neither mode",
+    "persists raw prompts, headers, response ids, provider error bodies, or",
+    "encrypted reasoning payloads in its evidence file.",
   ].join("\n"));
+}
+
+function envValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length >= 2 && (
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  )) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+async function loadProviderEnvFile(path: string): Promise<void> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  for (const rawLine of text.replace(/^\uFEFF/u, "").split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const separator = line.indexOf("=");
+    if (separator <= 0) continue;
+    const name = line.slice(0, separator).trim();
+    if (name !== "OPENAI_API_KEY" && name !== "OPENAI_BASE_URL") continue;
+    if (process.env[name]?.trim()) continue;
+    process.env[name] = envValue(line.slice(separator + 1));
+  }
+}
+
+function integerOption(name: string): number | undefined {
+  const value = optionValue(name);
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) throw new Error(`--${name} must be an integer`);
+  return parsed;
 }
 
 async function main(): Promise<void> {
@@ -27,8 +75,40 @@ async function main(): Promise<void> {
     return;
   }
   const mode = optionValue("mode") ?? "mock";
+  if (mode === "provider") {
+    const initialCwd = process.env.INIT_CWD?.trim() || process.cwd();
+    const envFile = resolve(optionValue("credentials-file") ?? resolve(initialCwd, ".env"));
+    await loadProviderEnvFile(envFile);
+    const baseUrl = optionValue("base-url")?.trim() || process.env.OPENAI_BASE_URL?.trim();
+    if (!baseUrl) throw new Error("Provider smoke requires OPENAI_BASE_URL or --base-url");
+    const result = await runCodexRebaseProviderSmoke({
+      baseUrl,
+      model: optionValue("model"),
+      outputDir: optionValue("output-dir"),
+      continuationTurns: integerOption("continuation-turns"),
+    });
+    console.log(JSON.stringify({
+      ok: true,
+      mode: result.evidence.mode,
+      provider: result.evidence.provider,
+      endpointHost: result.evidence.endpoint.host,
+      model: result.evidence.model,
+      artifactPath: result.artifactPath,
+      artifactSha256: result.artifactSha256,
+      encryptedReasoningPresent: result.evidence.capability.encryptedReasoningPresent,
+      verifiedItemTypes: result.evidence.capability.realProviderVerifiedItemTypes,
+      rebaseCommitted: result.evidence.rebase.committed,
+      sentinel: result.evidence.rebase.sentinel,
+      continuationTurns: result.evidence.rebase.responseChain.continuationTurns,
+      restartPreserved: result.evidence.rebase.responseChain.restartPreserved,
+      observedBreakEvenTurn: result.evidence.usage.observedBreakEvenTurn ?? null,
+      projectedBreakEvenTurn: result.evidence.usage.projectedBreakEvenTurn ?? null,
+      observedSavedInputTokens: result.evidence.usage.observedSavedInputTokens,
+    }, null, 2));
+    return;
+  }
   if (mode !== "mock") {
-    throw new Error("Only --mode=mock is available in the offline smoke command");
+    throw new Error("Smoke mode must be --mode=mock or --mode=provider");
   }
   const result = await runCodexRebaseMockSmoke({
     model: optionValue("model"),

--- a/components/adapters/codex/scripts/pack-release.mjs
+++ b/components/adapters/codex/scripts/pack-release.mjs
@@ -1,0 +1,102 @@
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const adapterDir = resolve(scriptDir, "..");
+const repoRoot = resolve(adapterDir, "../../..");
+const npmExecPath = process.env.npm_execpath;
+
+function npmInvocation(args) {
+  return npmExecPath
+    ? { command: process.execPath, args: [npmExecPath, ...args] }
+    : { command: process.platform === "win32" ? "npm.cmd" : "npm", args };
+}
+
+function childEnv(workdir, extra = {}) {
+  const env = { ...process.env, ...extra, INIT_CWD: workdir };
+  for (const name of [
+    "npm_config_local_prefix",
+    "npm_config_workspace",
+    "npm_config_workspaces",
+    "npm_config_include_workspace_root",
+    "npm_lifecycle_event",
+    "npm_lifecycle_script",
+    "npm_package_json",
+  ]) {
+    delete env[name];
+  }
+  return env;
+}
+
+function runPack(packageDir, cacheDir) {
+  const invocation = npmInvocation(["pack", "--silent"]);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: packageDir,
+    env: childEnv(packageDir, { npm_config_cache: cacheDir }),
+    encoding: "utf8",
+    shell: false,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const category = result.stderr?.trim() ? "npm-pack-error" : "unknown";
+    throw new Error(`Release npm pack failed (${category}; exit ${result.status ?? "unknown"})`);
+  }
+  const archiveName = result.stdout
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .at(-1);
+  if (!archiveName || basename(archiveName) !== archiveName || !archiveName.endsWith(".tgz")) {
+    throw new Error("Release npm pack did not return a safe archive name");
+  }
+  return archiveName;
+}
+
+async function main() {
+  const packDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-pack-"));
+  try {
+    const packageDir = join(packDir, "package");
+    const distDir = join(packageDir, "dist");
+    await mkdir(distDir, { recursive: true });
+    for (const file of ["index.js", "cli.js", "hooks-handler.js", "install-codex.js"]) {
+      await copyFile(join(adapterDir, "dist", file), join(distDir, file));
+    }
+    await copyFile(
+      resolve(repoRoot, "components/products/cli/dist/cli.js"),
+      join(distDir, "lightmem2.js"),
+    );
+    await copyFile(
+      resolve(repoRoot, "components/products/mcp/dist/server.js"),
+      join(distDir, "mcp-server.js"),
+    );
+    await copyFile(join(adapterDir, "README.md"), join(packageDir, "README.md"));
+
+    const manifest = JSON.parse(await readFile(join(adapterDir, "package.json"), "utf8"));
+    delete manifest.dependencies;
+    delete manifest.devDependencies;
+    delete manifest.scripts;
+    manifest.files = ["dist", "README.md"];
+    await writeFile(
+      join(packageDir, "package.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      "utf8",
+    );
+
+    const cacheDir = join(packDir, "npm-cache");
+    await mkdir(cacheDir, { recursive: true });
+    const archiveName = runPack(packageDir, cacheDir);
+    const archivePath = join(adapterDir, archiveName);
+    await copyFile(join(packageDir, archiveName), archivePath);
+    process.stdout.write(`${archivePath}\n`);
+  } finally {
+    await rm(packDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/components/adapters/codex/src/config.ts
+++ b/components/adapters/codex/src/config.ts
@@ -197,6 +197,10 @@ export function normalizeTokenPilotCodexConfig(
       failureMode: "bypass",
       retryOriginalRequest: boolValue(contextRewrite.retryOriginalRequest, true),
       cooldownMs: numberValue(contextRewrite.cooldownMs, 300_000, 0, 86_400_000),
+      providerCompatibilityProbe: contextRewrite.providerCompatibilityProbe === "mock_fixture"
+        || contextRewrite.providerCompatibilityProbe === "real_provider"
+        ? contextRewrite.providerCompatibilityProbe
+        : "disabled",
       mutationPlan: sanitizeCodexMutationPlan(contextRewrite.mutationPlan),
     },
     reduction: {

--- a/components/adapters/codex/src/context-history/effective-history.ts
+++ b/components/adapters/codex/src/context-history/effective-history.ts
@@ -1,4 +1,4 @@
-import { readCodexContextHistoryJournal } from "./journal-store.js";
+import { readCodexContextHistoryJournalRecoveringTail } from "./journal-append.js";
 import { codexReplayabilityForItem } from "./replayability.js";
 import { cloneJson, hashJson } from "./shared.js";
 import type {
@@ -343,7 +343,7 @@ export async function buildCodexEffectiveHistory(params: {
   currentRequestId?: string;
   rolloutParserBootstrap?: () => Promise<CodexEffectiveHistory | null>;
 }): Promise<CodexEffectiveHistory> {
-  const journalRead = await readCodexContextHistoryJournal(params.stateDir, params.sessionId);
+  const journalRead = await readCodexContextHistoryJournalRecoveringTail(params.stateDir, params.sessionId);
   const requests = latestRequests(journalRead.entries);
   const responses = latestResponsesById(journalRead.entries);
   const committedChain = buildCommittedChain({

--- a/components/adapters/codex/src/context-history/index.ts
+++ b/components/adapters/codex/src/context-history/index.ts
@@ -8,8 +8,12 @@ export type { CodexContextHistoryJournalReadResult } from "./journal-store.js";
 export {
   acquireCodexContextHistoryJournalLock,
   codexContextHistoryJournalLockPath,
+  recoverCodexContextHistoryJournalTail,
 } from "./journal-append.js";
-export type { CodexContextHistoryJournalLock } from "./journal-append.js";
+export type {
+  CodexContextHistoryJournalLock,
+  CodexContextHistoryJournalTailRecoveryResult,
+} from "./journal-append.js";
 export { appendCodexRequestJournalEntry } from "./request-journal.js";
 export { appendCodexResponseJournalEntry } from "./response-journal.js";
 export { collectCodexResponseItemsFromStream } from "./sse-item-collector.js";

--- a/components/adapters/codex/src/context-history/journal-append.ts
+++ b/components/adapters/codex/src/context-history/journal-append.ts
@@ -1,12 +1,16 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises";
 import { hostname } from "node:os";
 import { dirname } from "node:path";
+import { TextDecoder } from "node:util";
 
 import {
   codexContextHistoryJournalPath,
+  parseCodexContextHistoryJournalLine,
+  parseCodexContextHistoryJournalText,
   readCodexContextHistoryJournal,
 } from "./journal-store.js";
+import type { CodexContextHistoryJournalReadResult } from "./journal-store.js";
 
 type CodexContextHistoryJournalLockOwner = {
   token: string;
@@ -20,11 +24,24 @@ export type CodexContextHistoryJournalLock = {
   release(): Promise<void>;
 };
 
+export type CodexContextHistoryJournalTailRecoveryResult = {
+  status: "not_needed" | "truncated" | "newline_appended" | "blocked";
+  reason?:
+    | "malformed_trailing_record"
+    | "complete_record_missing_newline"
+    | "invalid_trailing_record"
+    | "invalid_prefix"
+    | "read_error";
+  recoveredByteCount: number;
+  tailSha256?: string;
+};
+
 const DEFAULT_LOCK_STALE_MS = 30 * 60 * 1000;
 const DEFAULT_LOCK_TIMEOUT_MS = 30_000;
 const DEFAULT_LOCK_RETRY_MS = 10;
 const LOCK_REMOVE_MAX_RETRIES = 5;
 const LOCK_REMOVE_RETRY_MS = 20;
+const FATAL_UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 function errorCode(error: unknown): string | undefined {
   return error && typeof error === "object" && "code" in error && typeof error.code === "string"
@@ -274,6 +291,155 @@ export async function withCodexContextHistoryJournalLock<T>(params: {
   }
 }
 
+function sha256Bytes(value: Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function decodeUtf8(value: Uint8Array): string | undefined {
+  try {
+    return FATAL_UTF8_DECODER.decode(value);
+  } catch {
+    return undefined;
+  }
+}
+
+async function syncTruncate(path: string, size: number): Promise<void> {
+  const handle = await open(path, "r+");
+  try {
+    await handle.truncate(size);
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function syncAppendNewline(path: string): Promise<void> {
+  const handle = await open(path, "a");
+  try {
+    await handle.appendFile("\n", "utf8");
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function journalTailState(
+  path: string,
+): Promise<"missing" | "terminated" | "unterminated" | "read_error"> {
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    handle = await open(path, "r");
+  } catch (error) {
+    return errorCode(error) === "ENOENT" ? "missing" : "read_error";
+  }
+  try {
+    const fileStat = await handle.stat();
+    if (!fileStat.isFile()) return "read_error";
+    if (fileStat.size === 0) return "terminated";
+    const lastByte = Buffer.allocUnsafe(1);
+    const read = await handle.read(lastByte, 0, 1, fileStat.size - 1);
+    if (read.bytesRead !== 1) return "read_error";
+    return lastByte[0] === 0x0a ? "terminated" : "unterminated";
+  } catch {
+    return "read_error";
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function recoverCodexContextHistoryJournalTailLocked(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexContextHistoryJournalTailRecoveryResult> {
+  // Writers always terminate canonical JSONL records with LF. Under the same
+  // session lock, an unterminated suffix is recoverable only when every prior
+  // line is canonical and the suffix is either an incomplete JSON/UTF-8 value
+  // or one complete canonical record that only lost its final LF.
+  const path = codexContextHistoryJournalPath(stateDir, sessionId);
+  const tailState = await journalTailState(path);
+  if (tailState === "missing" || tailState === "terminated") {
+    return { status: "not_needed", recoveredByteCount: 0 };
+  }
+  if (tailState === "read_error") {
+    return { status: "blocked", reason: "read_error", recoveredByteCount: 0 };
+  }
+  let raw: Buffer;
+  try {
+    raw = await readFile(path);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { status: "not_needed", recoveredByteCount: 0 };
+    return { status: "blocked", reason: "read_error", recoveredByteCount: 0 };
+  }
+  if (raw.length === 0 || raw.at(-1) === 0x0a) {
+    return { status: "not_needed", recoveredByteCount: 0 };
+  }
+
+  const lastNewline = raw.lastIndexOf(0x0a);
+  const prefixLength = lastNewline + 1;
+  const prefix = raw.subarray(0, prefixLength);
+  const tail = raw.subarray(prefixLength);
+  const tailSha256 = sha256Bytes(tail);
+  const prefixText = decodeUtf8(prefix);
+  if (prefixText === undefined
+    || parseCodexContextHistoryJournalText(prefixText, sessionId).malformedLineCount > 0) {
+    return {
+      status: "blocked",
+      reason: "invalid_prefix",
+      recoveredByteCount: 0,
+      tailSha256,
+    };
+  }
+
+  const tailText = decodeUtf8(tail);
+  if (tailText !== undefined) {
+    const parsedTail = parseCodexContextHistoryJournalLine(tailText, sessionId);
+    if (parsedTail.status === "valid") {
+      await syncAppendNewline(path);
+      return {
+        status: "newline_appended",
+        reason: "complete_record_missing_newline",
+        recoveredByteCount: 0,
+        tailSha256,
+      };
+    }
+    if (parsedTail.status === "invalid_record") {
+      return {
+        status: "blocked",
+        reason: "invalid_trailing_record",
+        recoveredByteCount: 0,
+        tailSha256,
+      };
+    }
+  }
+
+  await syncTruncate(path, prefixLength);
+  return {
+    status: "truncated",
+    reason: "malformed_trailing_record",
+    recoveredByteCount: tail.length,
+    tailSha256,
+  };
+}
+
+export async function recoverCodexContextHistoryJournalTail(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexContextHistoryJournalTailRecoveryResult> {
+  return withCodexContextHistoryJournalLock({ stateDir, sessionId }, () => (
+    recoverCodexContextHistoryJournalTailLocked(stateDir, sessionId)
+  ));
+}
+
+export async function readCodexContextHistoryJournalRecoveringTail(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexContextHistoryJournalReadResult> {
+  return withCodexContextHistoryJournalLock({ stateDir, sessionId }, async () => {
+    await recoverCodexContextHistoryJournalTailLocked(stateDir, sessionId);
+    return readCodexContextHistoryJournal(stateDir, sessionId);
+  });
+}
+
 export async function appendCodexContextHistoryJournalEntryLocked(
   stateDir: string,
   sessionId: string,
@@ -281,6 +447,7 @@ export async function appendCodexContextHistoryJournalEntryLocked(
 ): Promise<void> {
   const path = codexContextHistoryJournalPath(stateDir, sessionId);
   await mkdir(dirname(path), { recursive: true });
+  await recoverCodexContextHistoryJournalTailLocked(stateDir, sessionId);
   const current = await readCodexContextHistoryJournal(stateDir, sessionId);
   if (current.readError || current.malformedLineCount > 0) {
     throw new Error(`Refusing to append to invalid Codex context-history journal for session ${sessionId}`);

--- a/components/adapters/codex/src/context-history/journal-store.ts
+++ b/components/adapters/codex/src/context-history/journal-store.ts
@@ -17,6 +17,11 @@ export type CodexContextHistoryJournalReadResult = {
   readError?: string;
 };
 
+export type CodexContextHistoryJournalLineParseResult =
+  | { status: "valid"; entry: CodexContextHistoryJournalEntry }
+  | { status: "invalid_json" }
+  | { status: "invalid_record" };
+
 function encodedSessionId(sessionId: string): string {
   return encodeURIComponent(sessionId.trim() || "unknown-session");
 }
@@ -213,6 +218,36 @@ function canonicalContextHistoryJournalEntry(
   return undefined;
 }
 
+export function parseCodexContextHistoryJournalLine(
+  line: string,
+  expectedSessionId: string,
+): CodexContextHistoryJournalLineParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line) as unknown;
+  } catch {
+    return { status: "invalid_json" };
+  }
+  const entry = canonicalContextHistoryJournalEntry(parsed, expectedSessionId);
+  return entry
+    ? { status: "valid", entry }
+    : { status: "invalid_record" };
+}
+
+export function parseCodexContextHistoryJournalText(
+  raw: string,
+  sessionId: string,
+): CodexContextHistoryJournalReadResult {
+  const entries: CodexContextHistoryJournalEntry[] = [];
+  let malformedLineCount = 0;
+  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
+    const parsed = parseCodexContextHistoryJournalLine(line, sessionId);
+    if (parsed.status === "valid") entries.push(parsed.entry);
+    else malformedLineCount += 1;
+  }
+  return { entries, malformedLineCount };
+}
+
 function errorCode(error: unknown): string | undefined {
   return error && typeof error === "object" && "code" in error && typeof error.code === "string"
     ? error.code
@@ -237,19 +272,7 @@ export async function readCodexContextHistoryJournal(
     };
   }
 
-  const entries: CodexContextHistoryJournalEntry[] = [];
-  let malformedLineCount = 0;
-  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
-    try {
-      const parsed = JSON.parse(line) as unknown;
-      const entry = canonicalContextHistoryJournalEntry(parsed, sessionId);
-      if (entry) entries.push(entry);
-      else malformedLineCount += 1;
-    } catch {
-      malformedLineCount += 1;
-    }
-  }
-  return { entries, malformedLineCount };
+  return parseCodexContextHistoryJournalText(raw, sessionId);
 }
 
 export async function readCodexContextHistoryJournalEntries(

--- a/components/adapters/codex/src/context-history/request-journal.ts
+++ b/components/adapters/codex/src/context-history/request-journal.ts
@@ -1,6 +1,7 @@
 import { readCodexContextHistoryJournal } from "./journal-store.js";
 import {
   appendCodexContextHistoryJournalEntryLocked,
+  recoverCodexContextHistoryJournalTailLocked,
   withCodexContextHistoryJournalLock,
 } from "./journal-append.js";
 import {
@@ -94,6 +95,7 @@ async function appendCodexRequestJournalEntryLocked(params: {
     throw new TypeError("Codex request journal turnOrdinal must be a positive integer");
   }
   const observedAt = normalizeObservedAt(params.observedAt);
+  await recoverCodexContextHistoryJournalTailLocked(params.stateDir, params.sessionId);
   const journal = await readCodexContextHistoryJournal(params.stateDir, params.sessionId);
   if (journal.readError || journal.malformedLineCount > 0) {
     throw new Error(`Refusing to update invalid Codex context-history journal for session ${params.sessionId}`);

--- a/components/adapters/codex/src/context-rebase-provider-smoke.ts
+++ b/components/adapters/codex/src/context-rebase-provider-smoke.ts
@@ -1,0 +1,969 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, mkdtemp, rename, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { reserveUnusedPort } from "@lightmem2/host-adapter";
+
+import { normalizeTokenPilotCodexConfig } from "./config.js";
+import {
+  buildCodexEffectiveHistory,
+  loadCodexContextHistoryJournal,
+  type JsonObject,
+} from "./context-history/index.js";
+import type { TokenPilotCodexLogger } from "./logger.js";
+import { startCodexResponsesProxy, type CodexProxyRuntime } from "./proxy-runtime.js";
+import {
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
+  readCodexRebaseCapabilityJournal,
+  readLatestCodexRebaseEpoch,
+} from "./context-rewrite/index.js";
+import type { CodexRebaseAccounting } from "./context-rewrite/types.js";
+import { resolveCodexSessionIdByResponseId } from "./session-state.js";
+
+export const CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA =
+  "lightmem2.codex.context-rebase-provider-smoke-evidence/v2";
+
+export type ProviderUsageObservation = {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+};
+
+export type ProviderUsageTurnComparison = {
+  turn: number;
+  baselineInputTokens: number;
+  rebaseInputTokens: number;
+  savedInputTokens: number;
+  cumulativeSavedInputTokens: number;
+  baselineCachedInputTokens: number;
+  rebaseCachedInputTokens: number;
+};
+
+export type ProviderUsageEvidence = {
+  source: "provider-response-usage";
+  comparableSetup: boolean;
+  setup: {
+    baseline: ProviderUsageObservation[];
+    rebase: ProviderUsageObservation[];
+  };
+  continuationTurns: ProviderUsageTurnComparison[];
+  observedBreakEvenTurn?: number;
+  projectedBreakEvenTurn?: number;
+  rebaseTurnOverheadTokens: number;
+  observedSavedInputTokens: number;
+  subsequentSavedInputTokensPerTurn: number;
+};
+
+export type ProviderCompatibilityMatrixEntry = {
+  itemType: string;
+  structuralPolicy: "replay-candidate" | "closure-required" | "exact-payload" | "observation-only" | "deferred";
+  providerDecision: "real-pass" | "real-reject" | "mock" | "not-observed";
+  evidence: "real-provider" | "mock-fixture" | "none";
+  reason: string;
+};
+
+export type CodexRebaseProviderSmokeEvidence = {
+  schema: typeof CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA;
+  mode: "provider";
+  provider: "openai-compatible";
+  endpoint: {
+    host: string;
+    sha256: string;
+  };
+  model: string;
+  protocol: {
+    wireMode: typeof CODEX_REBASE_WIRE_MODE;
+    apiVersion: typeof CODEX_REBASE_API_VERSION;
+    itemSchemaVersion: typeof CODEX_REBASE_ITEM_SCHEMA_VERSION;
+  };
+  runtime: {
+    node: string;
+    codexCli: string;
+  };
+  startedAt: string;
+  finishedAt: string;
+  capability: {
+    responsesEndpointAccepted: boolean;
+    reasoningItemPresent: boolean;
+    encryptedReasoningPresent: boolean;
+    encryptedPayloadChars: number;
+    encryptedPayloadSha256: string;
+    toolCallPresent: boolean;
+    journalTrusted: boolean;
+    realProviderVerifiedItemTypes: string[];
+  };
+  compatibilityMatrix: ProviderCompatibilityMatrixEntry[];
+  rebase: {
+    committed: boolean;
+    oldChainReferenceRemoved: boolean;
+    currentInputOccurrences: number;
+    sentinel: {
+      evictedAbsent: boolean;
+      retainedPresent: boolean;
+    };
+    replayItemTypes: string[];
+    encryptedPayloadDigestMatches: boolean;
+    toolClosure: {
+      callCount: number;
+      outputCount: number;
+      complete: boolean;
+    };
+    responseChain: {
+      newRootPresent: boolean;
+      terminalPresent: boolean;
+      terminalSessionMappingMatches: boolean;
+      journalCommittedBeforeEpoch: boolean;
+      continuationTurns: number;
+      linksValid: boolean;
+      restartPreserved: boolean;
+      finalHistoryComplete: boolean;
+    };
+    estimatorAccounting?: CodexRebaseAccounting;
+  };
+  controlledFailureCoverage: {
+    source: "mock-automation";
+    fallbackAtMostOnce: true;
+    transientDoesNotPoisonCapability: true;
+    payloadRejectionScopedByDigest: true;
+    cooldownPreventsImmediateRetry: true;
+  };
+  usage: ProviderUsageEvidence;
+  privacy: {
+    credentialSource: "OPENAI_API_KEY";
+    baseUrlSource: "OPENAI_BASE_URL-or-cli";
+    rawPromptPersisted: false;
+    rawEncryptedPayloadPersisted: false;
+    rawResponseIdPersisted: false;
+    rawHeadersPersisted: false;
+    rawProviderErrorPersisted: false;
+    ephemeralStateRemoved: true;
+  };
+};
+
+export type RunCodexRebaseProviderSmokeOptions = {
+  baseUrl: string;
+  model?: string;
+  outputDir?: string;
+  continuationTurns?: number;
+};
+
+export type CodexRebaseProviderSmokeRunResult = {
+  artifactPath: string;
+  artifactSha256: string;
+  evidence: CodexRebaseProviderSmokeEvidence;
+};
+
+type ProviderConversationResult = {
+  setupUsage: ProviderUsageObservation[];
+  continuationUsage: ProviderUsageObservation[];
+};
+
+type ProviderRebaseResult = ProviderConversationResult & {
+  capability: CodexRebaseProviderSmokeEvidence["capability"];
+  compatibilityMatrix: ProviderCompatibilityMatrixEntry[];
+  rebase: CodexRebaseProviderSmokeEvidence["rebase"];
+};
+
+const FETCH_FORBIDDEN_PORTS = new Set([
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 69, 77,
+  79, 87, 95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123,
+  135, 137, 139, 143, 161, 179, 389, 427, 465, 512, 513, 514, 515, 526, 530,
+  531, 532, 540, 548, 554, 556, 563, 587, 601, 636, 989, 990, 993, 995, 1719,
+  1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666,
+  6667, 6668, 6669, 6697, 10080,
+]);
+
+const silentLogger: TokenPilotCodexLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function credentialShaped(value: string): boolean {
+  return /(?:\b(?:bearer|api[_-]?key|access[_-]?token|secret)\b|sk-[a-z0-9_-]{12,}|[?&](?:key|token|signature)=)/iu.test(value);
+}
+
+export function sanitizedEvidenceLabel(value: string | undefined): string {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length <= 160 && !credentialShaped(trimmed)
+    ? trimmed
+    : "not-observed";
+}
+
+function jsonItems(value: unknown): JsonObject[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is JsonObject => Boolean(item && typeof item === "object" && !Array.isArray(item)))
+    : [];
+}
+
+function numericField(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.trunc(value)
+    : 0;
+}
+
+function usageObservation(response: JsonObject): ProviderUsageObservation {
+  const usage = response.usage && typeof response.usage === "object" && !Array.isArray(response.usage)
+    ? response.usage as JsonObject
+    : {};
+  const details = usage.input_tokens_details
+    && typeof usage.input_tokens_details === "object"
+    && !Array.isArray(usage.input_tokens_details)
+    ? usage.input_tokens_details as JsonObject
+    : {};
+  return {
+    inputTokens: numericField(usage.input_tokens),
+    cachedInputTokens: numericField(details.cached_tokens),
+    outputTokens: numericField(usage.output_tokens),
+    totalTokens: numericField(usage.total_tokens),
+  };
+}
+
+function responseId(response: JsonObject, phase: string): string {
+  if (typeof response.id !== "string" || !response.id) {
+    throw new Error(`Provider smoke ${phase} did not return a response id`);
+  }
+  if (response.status && response.status !== "completed") {
+    throw new Error(`Provider smoke ${phase} returned a non-completed response`);
+  }
+  return response.id;
+}
+
+function toolClosureEvidence(input: JsonObject[]): {
+  callCount: number;
+  outputCount: number;
+  complete: boolean;
+} {
+  const calls = input.filter((item) => item.type === "function_call");
+  const outputs = input.filter((item) => item.type === "function_call_output");
+  const callIds = calls.map((item) => item.call_id).filter((value): value is string => typeof value === "string");
+  const outputIds = outputs.map((item) => item.call_id).filter((value): value is string => typeof value === "string");
+  return {
+    callCount: calls.length,
+    outputCount: outputs.length,
+    complete: callIds.length === calls.length
+      && outputIds.length === outputs.length
+      && new Set(callIds).size === callIds.length
+      && new Set(outputIds).size === outputIds.length
+      && callIds.length === outputIds.length
+      && callIds.every((callId) => outputIds.includes(callId)),
+  };
+}
+
+async function reserveFetchPort(): Promise<number> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const port = await reserveUnusedPort();
+    if (!FETCH_FORBIDDEN_PORTS.has(port)) return port;
+  }
+  throw new Error("Unable to reserve a fetch-safe provider smoke port");
+}
+
+function buildProviderSmokeConfig(params: {
+  stateDir: string;
+  proxyPort: number;
+  upstreamBaseUrl: string;
+  rewriteEnabled: boolean;
+}) {
+  return normalizeTokenPilotCodexConfig({
+    stateDir: params.stateDir,
+    proxyPort: params.proxyPort,
+    upstreamProvider: "provider-smoke",
+    upstream: {
+      name: "openai-compatible",
+      baseUrl: params.upstreamBaseUrl,
+      wireApi: "responses",
+      requiresOpenAIAuth: true,
+    },
+    modules: { stabilizer: false, reduction: false },
+    contextRewrite: {
+      enabled: params.rewriteEnabled,
+      providerCompatibilityProbe: "real_provider",
+      mode: "response_chain_rebase",
+      failureMode: "bypass",
+      retryOriginalRequest: true,
+      cooldownMs: 300_000,
+      mutationPlan: { operations: [] },
+    },
+  });
+}
+
+function sanitizedProviderFailure(response: Response, text: string, phase: string): Error {
+  let code = "unknown";
+  let category = "unclassified";
+  try {
+    const parsed = JSON.parse(text) as { error?: { code?: unknown; type?: unknown; message?: unknown } };
+    const rawCode = parsed.error?.code ?? parsed.error?.type;
+    if (typeof rawCode === "string" && /^[a-zA-Z0-9_.-]{1,80}$/u.test(rawCode)) code = rawCode;
+    const message = typeof parsed.error?.message === "string" ? parsed.error.message : "";
+    if (/previous_response_id/iu.test(message)) category = "chain-reference";
+    else if (/tool_choice/iu.test(message)) category = "tool-choice";
+    else if (/\btools?\b/iu.test(message)) category = "tools";
+    else if (/\bstore\b/iu.test(message)) category = "storage";
+    else if (/encrypted_content/iu.test(message)) category = "encrypted-replay";
+    else if (/reasoning/iu.test(message)) category = "reasoning";
+    else if (/\binput\b/iu.test(message)) category = "input-schema";
+  } catch {
+    // Raw provider bodies are intentionally discarded.
+  }
+  return new Error(`Provider smoke ${phase} failed with HTTP ${response.status} (${code}; ${category})`);
+}
+
+async function postProviderResponse(
+  runtime: CodexProxyRuntime,
+  payload: JsonObject,
+  phase: string,
+): Promise<JsonObject> {
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    let response: Response;
+    try {
+      response = await fetch(`${runtime.baseUrl}/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      const kind = error instanceof Error ? error.name : "unknown";
+      throw new Error(`Provider smoke ${phase} failed before receiving HTTP response (${kind})`);
+    }
+    const text = await response.text();
+    if (!response.ok) {
+      if ((response.status === 429 || response.status >= 500) && attempt < 3) {
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, attempt * 500));
+        continue;
+      }
+      throw sanitizedProviderFailure(response, text, phase);
+    }
+    try {
+      const parsed = JSON.parse(text) as JsonObject;
+      responseId(parsed, phase);
+      return parsed;
+    } catch (error) {
+      if (error instanceof SyntaxError) throw new Error(`Provider smoke ${phase} returned malformed JSON`);
+      throw error;
+    }
+  }
+  throw new Error(`Provider smoke ${phase} exhausted its transient retry budget`);
+}
+
+function toolDefinition(): JsonObject {
+  return {
+    type: "function",
+    name: "lookup_smoke_fixture",
+    description: "Return one fixed synthetic smoke-test record.",
+    strict: true,
+    parameters: {
+      type: "object",
+      properties: { record: { type: "string" } },
+      required: ["record"],
+      additionalProperties: false,
+    },
+  };
+}
+
+function firstTurnPayload(params: {
+  model: string;
+  sessionId: string;
+  evictText: string;
+  keepText: string;
+}): JsonObject {
+  return {
+    model: params.model,
+    stream: false,
+    store: false,
+    include: ["reasoning.encrypted_content"],
+    reasoning: { effort: "medium", summary: "auto" },
+    max_output_tokens: 512,
+    metadata: { tokenpilotSessionId: params.sessionId },
+    instructions: "Reason about the two synthetic records, then reply with the single word READY.",
+    input: [
+      { role: "user", content: params.evictText },
+      { role: "user", content: params.keepText },
+    ],
+  };
+}
+
+function continuationPayload(params: {
+  model: string;
+  previousResponseId: string;
+  input: JsonObject[];
+}): JsonObject {
+  return {
+    model: params.model,
+    stream: false,
+    store: true,
+    include: ["reasoning.encrypted_content"],
+    reasoning: { effort: "medium", summary: "auto" },
+    max_output_tokens: 512,
+    tools: [toolDefinition()],
+    tool_choice: "none",
+    previous_response_id: params.previousResponseId,
+    input: params.input,
+  };
+}
+
+function toolRequestItem(): JsonObject {
+  return { role: "user", content: "Use lookup_smoke_fixture for the retained synthetic record." };
+}
+
+function requiredToolCallPayload(params: {
+  model: string;
+  sessionId: string;
+  historyInput: JsonObject[];
+}): JsonObject {
+  return {
+    model: params.model,
+    stream: false,
+    store: false,
+    include: ["reasoning.encrypted_content"],
+    reasoning: { effort: "medium", summary: "auto" },
+    max_output_tokens: 512,
+    metadata: { tokenpilotSessionId: params.sessionId },
+    tools: [toolDefinition()],
+    tool_choice: { type: "function", name: "lookup_smoke_fixture" },
+    input: [...params.historyInput, toolRequestItem()],
+  };
+}
+
+function storedRootPayload(params: {
+  model: string;
+  sessionId: string;
+  historyInput: JsonObject[];
+}): JsonObject {
+  return {
+    model: params.model,
+    stream: false,
+    store: true,
+    include: ["reasoning.encrypted_content"],
+    reasoning: { effort: "medium", summary: "auto" },
+    max_output_tokens: 512,
+    metadata: { tokenpilotSessionId: params.sessionId },
+    tools: [toolDefinition()],
+    tool_choice: "none",
+    input: params.historyInput,
+  };
+}
+
+function firstReasoning(response: JsonObject): {
+  reasoning: JsonObject;
+  encryptedPayload: string;
+} {
+  const output = jsonItems(response.output);
+  const reasoning = output.find((item) => item.type === "reasoning");
+  const encryptedPayload = typeof reasoning?.encrypted_content === "string"
+    ? reasoning.encrypted_content
+    : "";
+  if (!reasoning) {
+    const outputTypes = output.map((item) => typeof item.type === "string" ? item.type : "unknown").join(",") || "none";
+    throw new Error(`Provider response did not include a reasoning item (output types: ${outputTypes})`);
+  }
+  if (!encryptedPayload) throw new Error("Provider response did not include encrypted reasoning content");
+  return { reasoning, encryptedPayload };
+}
+
+function requiredToolCall(response: JsonObject): { call: JsonObject; callId: string } {
+  const call = jsonItems(response.output).find((item) => (
+    item.type === "function_call" && item.name === "lookup_smoke_fixture"
+  ));
+  const callId = typeof call?.call_id === "string" ? call.call_id : "";
+  if (!call || !callId) throw new Error("Provider response did not include the required function call");
+  return { call, callId };
+}
+
+function syntheticConversationValues(marker: string): { evictText: string; keepText: string } {
+  return {
+    evictText: `EVICT_ME_${marker}\n${"discardable provider smoke context. ".repeat(180)}`,
+    keepText: `KEEP_ME_${marker}`,
+  };
+}
+
+async function setupStoredRoot(params: {
+  runtime: CodexProxyRuntime;
+  model: string;
+  sessionId: string;
+  evictText: string;
+  keepText: string;
+  phase: string;
+}): Promise<{
+  first: JsonObject;
+  firstEncryptedPayload: string;
+  toolResponse: JsonObject;
+  toolOutputResponse: JsonObject;
+  previousResponseId: string;
+}> {
+  const first = await postProviderResponse(params.runtime, firstTurnPayload({
+    model: params.model,
+    sessionId: params.sessionId,
+    evictText: params.evictText,
+    keepText: params.keepText,
+  }), `${params.phase} setup turn 1`);
+  const firstOutput = firstReasoning(first);
+  const initialHistory = [
+    { role: "user", content: params.evictText },
+    { role: "user", content: params.keepText },
+    ...jsonItems(first.output),
+  ];
+  const toolResponse = await postProviderResponse(params.runtime, requiredToolCallPayload({
+    model: params.model,
+    sessionId: params.sessionId,
+    historyInput: initialHistory,
+  }), `${params.phase} setup turn 2`);
+  const toolCall = requiredToolCall(toolResponse);
+  const toolOutputResponse = await postProviderResponse(params.runtime, storedRootPayload({
+    model: params.model,
+    sessionId: params.sessionId,
+    historyInput: [
+      ...initialHistory,
+      toolRequestItem(),
+      ...jsonItems(toolResponse.output),
+      {
+        type: "function_call_output",
+        call_id: toolCall.callId,
+        output: "retained synthetic tool result",
+      },
+    ],
+  }), `${params.phase} setup turn 3`);
+  return {
+    first,
+    firstEncryptedPayload: firstOutput.encryptedPayload,
+    toolResponse,
+    toolOutputResponse,
+    previousResponseId: responseId(toolOutputResponse, `${params.phase} setup turn 3`),
+  };
+}
+
+async function runControlConversation(params: {
+  baseUrl: string;
+  model: string;
+  continuationTurns: number;
+  marker: string;
+}): Promise<ProviderConversationResult> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-provider-control-state-"));
+  let runtime: CodexProxyRuntime | undefined;
+  try {
+    const config = buildProviderSmokeConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamBaseUrl: params.baseUrl,
+      rewriteEnabled: false,
+    });
+    runtime = await startCodexResponsesProxy({ config, logger: silentLogger });
+    const sessionId = `codex-provider-control-${randomUUID()}`;
+    const values = syntheticConversationValues(params.marker);
+    const setup = await setupStoredRoot({
+      runtime,
+      model: params.model,
+      sessionId,
+      ...values,
+      phase: "control",
+    });
+    let previousResponseId = setup.previousResponseId;
+    const continuationUsage: ProviderUsageObservation[] = [];
+    for (let turn = 1; turn <= params.continuationTurns; turn += 1) {
+      const response = await postProviderResponse(runtime, continuationPayload({
+        model: params.model,
+        previousResponseId,
+        input: [{ role: "user", content: `Acknowledge continuation turn ${turn} with one word.` }],
+      }), `control continuation turn ${turn}`);
+      previousResponseId = responseId(response, `control continuation turn ${turn}`);
+      continuationUsage.push(usageObservation(response));
+    }
+    return {
+      setupUsage: [
+        usageObservation(setup.first),
+        usageObservation(setup.toolResponse),
+        usageObservation(setup.toolOutputResponse),
+      ],
+      continuationUsage,
+    };
+  } finally {
+    await runtime?.close();
+    await rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+}
+
+function compatibilityMatrix(realProviderVerifiedItemTypes: string[]): ProviderCompatibilityMatrixEntry[] {
+  const verified = new Set(realProviderVerifiedItemTypes);
+  const real = (itemType: string, policy: ProviderCompatibilityMatrixEntry["structuralPolicy"]): ProviderCompatibilityMatrixEntry => ({
+    itemType,
+    structuralPolicy: policy,
+    providerDecision: verified.has(itemType) ? "real-pass" : "not-observed",
+    evidence: verified.has(itemType) ? "real-provider" : "none",
+    reason: verified.has(itemType) ? "provider_rebase_committed" : "not_observed_in_provider_smoke",
+  });
+  return [
+    real("message", "replay-candidate"),
+    real("function_call", "closure-required"),
+    real("function_call_output", "closure-required"),
+    { itemType: "custom_tool_call", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "custom_tool_call_output", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    real("reasoning", "exact-payload"),
+    { itemType: "compaction", structuralPolicy: "exact-payload", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "web_search_call", structuralPolicy: "observation-only", providerDecision: "not-observed", evidence: "none", reason: "server_owned_observation_not_replayed" },
+    { itemType: "unknown", structuralPolicy: "deferred", providerDecision: "not-observed", evidence: "none", reason: "unknown_items_require_explicit_adapter_support" },
+  ];
+}
+
+async function runRebaseConversation(params: {
+  baseUrl: string;
+  model: string;
+  continuationTurns: number;
+  marker: string;
+}): Promise<ProviderRebaseResult> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-provider-rebase-state-"));
+  const sessionId = `codex-provider-rebase-${randomUUID()}`;
+  const values = syntheticConversationValues(params.marker);
+  const currentInput = `CURRENT_INPUT_${params.marker}`;
+  let runtime: CodexProxyRuntime | undefined;
+  try {
+    const config = buildProviderSmokeConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamBaseUrl: params.baseUrl,
+      rewriteEnabled: true,
+    });
+    runtime = await startCodexResponsesProxy({ config, logger: silentLogger });
+    const setup = await setupStoredRoot({
+      runtime,
+      model: params.model,
+      sessionId,
+      ...values,
+      phase: "rebase",
+    });
+    let previousResponseId = setup.previousResponseId;
+    const beforeRebase = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: previousResponseId,
+    });
+    const evictedItem = beforeRebase.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes(`EVICT_ME_${params.marker}`)
+    ));
+    if (!evictedItem) throw new Error("Provider smoke could not resolve the eviction target");
+    config.contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: evictedItem.stableItemId }],
+    };
+
+    const continuationUsage: ProviderUsageObservation[] = [];
+    const rebaseResponse = await postProviderResponse(runtime, continuationPayload({
+      model: params.model,
+      previousResponseId,
+      input: [{ role: "user", content: currentInput }],
+    }), "rebase continuation turn 1");
+    const newRootResponseId = responseId(rebaseResponse, "rebase continuation turn 1");
+    previousResponseId = newRootResponseId;
+    continuationUsage.push(usageObservation(rebaseResponse));
+    config.contextRewrite.mutationPlan = { operations: [] };
+
+    let restartPreserved = false;
+    const expectedPreviousIds: string[] = [];
+    for (let turn = 2; turn <= params.continuationTurns; turn += 1) {
+      if (turn === 3) {
+        const headBeforeRestart = previousResponseId;
+        await runtime.close();
+        runtime = undefined;
+        const restartedConfig = buildProviderSmokeConfig({
+          stateDir,
+          proxyPort: await reserveFetchPort(),
+          upstreamBaseUrl: params.baseUrl,
+          rewriteEnabled: true,
+        });
+        runtime = await startCodexResponsesProxy({ config: restartedConfig, logger: silentLogger });
+        restartPreserved = await resolveCodexSessionIdByResponseId(stateDir, headBeforeRestart) === sessionId;
+      }
+      expectedPreviousIds.push(previousResponseId);
+      const response = await postProviderResponse(runtime, continuationPayload({
+        model: params.model,
+        previousResponseId,
+        input: [{ role: "user", content: `Acknowledge continuation turn ${turn} with one word.` }],
+      }), `rebase continuation turn ${turn}`);
+      previousResponseId = responseId(response, `rebase continuation turn ${turn}`);
+      continuationUsage.push(usageObservation(response));
+    }
+
+    const epoch = await readLatestCodexRebaseEpoch({ stateDir, sessionId });
+    const journal = await loadCodexContextHistoryJournal(stateDir, sessionId);
+    const committedRootResponse = journal.find((entry) => (
+      entry.kind === "response"
+      && entry.responseId === newRootResponseId
+      && entry.status === "completed"
+      && entry.previousResponseId === null
+    ));
+    const committedRootRequest = committedRootResponse?.requestId
+      ? journal.find((entry) => (
+        entry.kind === "request"
+        && entry.requestId === committedRootResponse.requestId
+        && entry.status === "completed"
+        && Array.isArray(entry.committedInputItems)
+      ))
+      : undefined;
+    const replayInput = committedRootRequest?.kind === "request"
+      ? jsonItems(committedRootRequest.committedInputItems)
+      : [];
+    const replayText = JSON.stringify(replayInput);
+    const replayReasoning = replayInput.filter((item) => item.type === "reasoning");
+    const digestMatches = replayReasoning.some((item) => (
+      typeof item.encrypted_content === "string"
+      && sha256(item.encrypted_content) === sha256(setup.firstEncryptedPayload)
+    ));
+    const finalHistory = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: previousResponseId,
+    });
+    const finalHistoryText = JSON.stringify(finalHistory.replayableItems);
+    const continuationRequestLinks = expectedPreviousIds.map((expected) => journal.some((entry) => (
+      entry.kind === "request"
+      && entry.status === "completed"
+      && entry.previousResponseId === expected
+    )));
+    const terminalSessionMappingMatches =
+      await resolveCodexSessionIdByResponseId(stateDir, previousResponseId) === sessionId;
+    const capabilityJournal = await readCodexRebaseCapabilityJournal(stateDir);
+    const realProviderVerifiedItemTypes = Array.from(new Set(
+      capabilityJournal.capabilities
+        .filter((entry) => entry.status === "verified_supported" && entry.evidence === "real_provider")
+        .map((entry) => entry.itemType),
+    )).sort();
+
+    return {
+      setupUsage: [
+        usageObservation(setup.first),
+        usageObservation(setup.toolResponse),
+        usageObservation(setup.toolOutputResponse),
+      ],
+      continuationUsage,
+      capability: {
+        responsesEndpointAccepted: true,
+        reasoningItemPresent: true,
+        encryptedReasoningPresent: true,
+        encryptedPayloadChars: setup.firstEncryptedPayload.length,
+        encryptedPayloadSha256: sha256(setup.firstEncryptedPayload),
+        toolCallPresent: true,
+        journalTrusted: !capabilityJournal.readError && capabilityJournal.malformedLineCount === 0,
+        realProviderVerifiedItemTypes,
+      },
+      compatibilityMatrix: compatibilityMatrix(realProviderVerifiedItemTypes),
+      rebase: {
+        committed: epoch?.status === "committed",
+        oldChainReferenceRemoved: Boolean(committedRootResponse),
+        currentInputOccurrences: replayText.split(currentInput).length - 1,
+        sentinel: {
+          evictedAbsent: !replayText.includes(`EVICT_ME_${params.marker}`)
+            && !finalHistoryText.includes(`EVICT_ME_${params.marker}`),
+          retainedPresent: replayText.includes(`KEEP_ME_${params.marker}`)
+            && finalHistoryText.includes(`KEEP_ME_${params.marker}`),
+        },
+        replayItemTypes: replayInput.map((item) => (
+          typeof item.type === "string"
+            ? item.type
+            : typeof item.role === "string" ? `message:${item.role}` : "unknown"
+        )),
+        encryptedPayloadDigestMatches: digestMatches,
+        toolClosure: toolClosureEvidence(replayInput),
+        responseChain: {
+          newRootPresent: newRootResponseId.length > 0,
+          terminalPresent: previousResponseId.length > 0,
+          terminalSessionMappingMatches,
+          journalCommittedBeforeEpoch:
+            epoch?.status === "committed"
+            && epoch.newResponseId === newRootResponseId
+            && Boolean(committedRootResponse)
+            && Boolean(committedRootRequest)
+            && Date.parse(committedRootResponse?.observedAt ?? "") <= Date.parse(epoch.updatedAt),
+          continuationTurns: params.continuationTurns,
+          linksValid: continuationRequestLinks.every(Boolean),
+          restartPreserved,
+          finalHistoryComplete: !finalHistory.incomplete,
+        },
+        estimatorAccounting: epoch?.accounting ? { ...epoch.accounting } : undefined,
+      },
+    };
+  } finally {
+    await runtime?.close();
+    await rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+}
+
+export function compareProviderUsage(
+  baseline: ProviderUsageObservation[],
+  rebase: ProviderUsageObservation[],
+  setup: { baseline: ProviderUsageObservation[]; rebase: ProviderUsageObservation[] },
+): ProviderUsageEvidence {
+  if (baseline.length !== rebase.length || baseline.length === 0) {
+    throw new Error("Provider smoke usage comparison requires equal non-empty turn sets");
+  }
+  let cumulativeSavedInputTokens = 0;
+  const continuationTurns = baseline.map((baselineUsage, index) => {
+    const rebaseUsage = rebase[index];
+    if (!rebaseUsage) throw new Error("Provider smoke usage comparison lost a rebase turn");
+    const savedInputTokens = baselineUsage.inputTokens - rebaseUsage.inputTokens;
+    cumulativeSavedInputTokens += savedInputTokens;
+    return {
+      turn: index + 1,
+      baselineInputTokens: baselineUsage.inputTokens,
+      rebaseInputTokens: rebaseUsage.inputTokens,
+      savedInputTokens,
+      cumulativeSavedInputTokens,
+      baselineCachedInputTokens: baselineUsage.cachedInputTokens,
+      rebaseCachedInputTokens: rebaseUsage.cachedInputTokens,
+    };
+  });
+  const observedBreakEvenTurn = continuationTurns
+    .find((turn) => turn.cumulativeSavedInputTokens >= 0)?.turn;
+  const rebaseTurnOverheadTokens = Math.max(0, rebase[0]!.inputTokens - baseline[0]!.inputTokens);
+  const subsequentSavings = continuationTurns.slice(1).map((turn) => turn.savedInputTokens);
+  const subsequentSavedInputTokensPerTurn = subsequentSavings.length > 0
+    ? Math.round(subsequentSavings.reduce((sum, value) => sum + value, 0) / subsequentSavings.length)
+    : continuationTurns[0]!.savedInputTokens;
+  const projectedBreakEvenTurn = observedBreakEvenTurn
+    ?? (subsequentSavedInputTokensPerTurn > 0
+      ? 1 + Math.ceil(rebaseTurnOverheadTokens / subsequentSavedInputTokensPerTurn)
+      : undefined);
+  return {
+    source: "provider-response-usage",
+    comparableSetup: setup.baseline.length === setup.rebase.length && setup.baseline.length > 0,
+    setup,
+    continuationTurns,
+    observedBreakEvenTurn,
+    projectedBreakEvenTurn,
+    rebaseTurnOverheadTokens,
+    observedSavedInputTokens: cumulativeSavedInputTokens,
+    subsequentSavedInputTokensPerTurn,
+  };
+}
+
+function assertProviderEvidence(evidence: CodexRebaseProviderSmokeEvidence): void {
+  const requiredVerified = ["message", "reasoning", "function_call", "function_call_output"];
+  const missingVerified = requiredVerified.filter((itemType) => (
+    !evidence.capability.realProviderVerifiedItemTypes.includes(itemType)
+  ));
+  const checks: Array<[boolean, string]> = [
+    [evidence.capability.responsesEndpointAccepted, "Responses endpoint was not accepted"],
+    [evidence.capability.encryptedReasoningPresent, "Encrypted reasoning was not observed"],
+    [evidence.capability.journalTrusted, "Capability journal was not trusted"],
+    [missingVerified.length === 0, `Missing real-provider capability: ${missingVerified.join(",")}`],
+    [evidence.rebase.committed, "Rebase epoch was not committed"],
+    [evidence.rebase.oldChainReferenceRemoved, "Old chain reference remained on the new root"],
+    [evidence.rebase.currentInputOccurrences === 1, "Current input was not replayed exactly once"],
+    [evidence.rebase.sentinel.evictedAbsent, "Eviction sentinel remained after rebase"],
+    [evidence.rebase.sentinel.retainedPresent, "Retention sentinel was lost after rebase"],
+    [evidence.rebase.encryptedPayloadDigestMatches, "Encrypted reasoning digest changed during replay"],
+    [evidence.rebase.toolClosure.complete, "Tool call/output closure was not complete"],
+    [evidence.rebase.responseChain.journalCommittedBeforeEpoch, "Epoch committed before the response journal"],
+    [evidence.rebase.responseChain.continuationTurns >= 5, "Provider chain did not continue for five turns"],
+    [evidence.rebase.responseChain.linksValid, "Provider response-chain links were invalid"],
+    [evidence.rebase.responseChain.restartPreserved, "Proxy restart did not preserve the session mapping"],
+    [evidence.rebase.responseChain.finalHistoryComplete, "Final effective history was incomplete"],
+    [evidence.usage.comparableSetup, "Baseline and rebase setup were not comparable"],
+    [evidence.usage.continuationTurns.every((turn) => (
+      turn.baselineInputTokens > 0 && turn.rebaseInputTokens > 0
+    )), "Provider usage did not include positive input-token observations"],
+  ];
+  const failure = checks.find(([passed]) => !passed);
+  if (failure) throw new Error(`Provider smoke evidence gate failed: ${failure[1]}`);
+}
+
+async function writeEvidence(
+  outputDir: string,
+  evidence: CodexRebaseProviderSmokeEvidence,
+): Promise<{ artifactPath: string; artifactSha256: string }> {
+  await mkdir(outputDir, { recursive: true });
+  const artifactPath = join(outputDir, "codex-context-rebase-provider-smoke.json");
+  const tempPath = `${artifactPath}.${process.pid}.${randomUUID()}.tmp`;
+  const text = `${JSON.stringify(evidence, null, 2)}\n`;
+  await writeFile(tempPath, text, { encoding: "utf8", mode: 0o600 });
+  await rename(tempPath, artifactPath);
+  return { artifactPath, artifactSha256: sha256(text) };
+}
+
+export async function runCodexRebaseProviderSmoke(
+  options: RunCodexRebaseProviderSmokeOptions,
+): Promise<CodexRebaseProviderSmokeRunResult> {
+  if (!process.env.OPENAI_API_KEY?.trim()) {
+    throw new Error("Provider smoke requires OPENAI_API_KEY in the environment");
+  }
+  const baseUrl = options.baseUrl.trim().replace(/\/+$/u, "");
+  let parsedBaseUrl: URL;
+  try {
+    parsedBaseUrl = new URL(baseUrl);
+  } catch {
+    throw new Error("Provider smoke requires a valid base URL");
+  }
+  if (
+    parsedBaseUrl.protocol !== "https:"
+    && parsedBaseUrl.hostname !== "127.0.0.1"
+    && parsedBaseUrl.hostname !== "localhost"
+  ) {
+    throw new Error("Provider smoke requires HTTPS unless the provider is loopback-only");
+  }
+  const model = options.model?.trim() || "gpt-5.4-mini";
+  const continuationTurns = options.continuationTurns ?? 5;
+  if (!Number.isInteger(continuationTurns) || continuationTurns < 5 || continuationTurns > 20) {
+    throw new Error("Provider smoke continuationTurns must be an integer from 5 to 20");
+  }
+  const startedAt = new Date().toISOString();
+  const marker = randomUUID();
+  // Proxy startup configures a process-global resolver, so the scenarios run serially.
+  const baseline = await runControlConversation({ baseUrl, model, continuationTurns, marker });
+  const rebase = await runRebaseConversation({ baseUrl, model, continuationTurns, marker });
+  const usage = compareProviderUsage(
+    baseline.continuationUsage,
+    rebase.continuationUsage,
+    { baseline: baseline.setupUsage, rebase: rebase.setupUsage },
+  );
+  const evidence: CodexRebaseProviderSmokeEvidence = {
+    schema: CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA,
+    mode: "provider",
+    provider: "openai-compatible",
+    endpoint: {
+      host: sanitizedEvidenceLabel(parsedBaseUrl.hostname),
+      sha256: sha256(baseUrl),
+    },
+    model: sanitizedEvidenceLabel(model),
+    protocol: {
+      wireMode: CODEX_REBASE_WIRE_MODE,
+      apiVersion: CODEX_REBASE_API_VERSION,
+      itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+    },
+    runtime: {
+      node: process.version,
+      codexCli: sanitizedEvidenceLabel(process.env.CODEX_CLI_VERSION),
+    },
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    capability: rebase.capability,
+    compatibilityMatrix: rebase.compatibilityMatrix,
+    rebase: rebase.rebase,
+    controlledFailureCoverage: {
+      source: "mock-automation",
+      fallbackAtMostOnce: true,
+      transientDoesNotPoisonCapability: true,
+      payloadRejectionScopedByDigest: true,
+      cooldownPreventsImmediateRetry: true,
+    },
+    usage,
+    privacy: {
+      credentialSource: "OPENAI_API_KEY",
+      baseUrlSource: "OPENAI_BASE_URL-or-cli",
+      rawPromptPersisted: false,
+      rawEncryptedPayloadPersisted: false,
+      rawResponseIdPersisted: false,
+      rawHeadersPersisted: false,
+      rawProviderErrorPersisted: false,
+      ephemeralStateRemoved: true,
+    },
+  };
+  assertProviderEvidence(evidence);
+  const outputDir = options.outputDir
+    ? resolve(options.outputDir)
+    : await mkdtemp(join(tmpdir(), "lightmem2-codex-provider-smoke-evidence-"));
+  return { ...await writeEvidence(outputDir, evidence), evidence };
+}

--- a/components/adapters/codex/src/context-rebase-smoke.ts
+++ b/components/adapters/codex/src/context-rebase-smoke.ts
@@ -306,6 +306,7 @@ function buildSmokeConfig(params: {
     },
     contextRewrite: {
       enabled: params.rewriteEnabled ?? true,
+      providerCompatibilityProbe: "mock_fixture",
       mode: "response_chain_rebase",
       failureMode: "bypass",
       retryOriginalRequest: true,

--- a/components/adapters/codex/src/context-rewrite/fallback.ts
+++ b/components/adapters/codex/src/context-rewrite/fallback.ts
@@ -29,9 +29,9 @@ import {
 } from "./rebase-cooldown.js";
 import {
   appendCodexRebaseCapability,
-  codexRebasePayloadItemTypes,
-  readUnsupportedCodexRebaseItemTypes,
-  unsupportedCodexRebaseItemTypesFromResponse,
+  classifyCodexRebaseCapabilityRejection,
+  codexRebasePayloadItems,
+  resolveCodexProviderReplayCompatibility,
 } from "./rebase-capability.js";
 
 const activeRebaseSessions = new Set<string>();
@@ -137,9 +137,10 @@ export async function executeCodexRebaseWithFallback(params: {
   let cooldown: CodexRebaseCooldownNotice | undefined;
   let capability: CodexRebaseCapabilityNotice | undefined;
   let failureReason = "rebase_upstream_error";
-  const rebaseItemTypes = params.capabilityStore
-    ? codexRebasePayloadItemTypes(params.rebasedPayload)
+  const rebaseItems = params.capabilityStore
+    ? codexRebasePayloadItems(params.rebasedPayload)
     : [];
+  const rebaseItemTypes = rebaseItems.map((entry) => entry.itemType);
 
   async function sendOriginalBypass(
     notice?: CodexRebaseCapabilityNotice,
@@ -152,25 +153,53 @@ export async function executeCodexRebaseWithFallback(params: {
     };
   }
 
-  if (params.capabilityStore && rebaseItemTypes.length > 0) {
+  if (params.capabilityStore && rebaseItems.length > 0) {
     try {
-      const skippedItemTypes = await readUnsupportedCodexRebaseItemTypes({
-        stateDir: params.capabilityStore.stateDir,
-        provider: params.capabilityStore.provider,
-        model: params.capabilityStore.model,
-        itemTypes: rebaseItemTypes,
+      const probeMode = params.capabilityStore.probeMode ?? "disabled";
+      const compatibilityResult = await resolveCodexProviderReplayCompatibility({
+        ...params.capabilityStore,
+        items: rebaseItems,
+        acceptedEvidence: probeMode === "mock_fixture"
+          ? ["real_provider", "mock_fixture"]
+          : ["real_provider"],
       });
-      if (skippedItemTypes.length > 0) {
+      const rejected = compatibilityResult.decisions.filter((entry) => (
+        entry.status === "verified_unsupported" || entry.status === "payload_rejected"
+      ));
+      const unknown = compatibilityResult.decisions.filter((entry) => entry.status === "unknown_probe_required");
+      const probeEnabled = probeMode === "mock_fixture" || probeMode === "real_provider";
+      if (!compatibilityResult.journalTrusted || rejected.length > 0 || (unknown.length > 0 && !probeEnabled)) {
+        const skippedItemTypes = Array.from(new Set(
+          [...rejected, ...unknown].map((entry) => entry.itemType),
+        ));
+        const payloadRejectedItemTypes = rejected
+          .filter((entry) => entry.status === "payload_rejected")
+          .map((entry) => entry.itemType);
         return sendOriginalBypass({
           provider: params.capabilityStore.provider,
           model: params.capabilityStore.model,
           itemTypes: rebaseItemTypes,
           skippedItemTypes,
-          reason: "capability_unsupported",
+          unsupportedItemTypes: rejected
+            .filter((entry) => entry.status === "verified_unsupported")
+            .map((entry) => entry.itemType),
+          payloadRejectedItemTypes,
+          decisions: compatibilityResult.decisions,
+          reason: !compatibilityResult.journalTrusted
+            ? "capability_journal_untrusted"
+            : rejected.length > 0
+              ? "provider_replay_rejected"
+              : "provider_replay_probe_required",
         });
       }
     } catch {
-      // Capability cache is advisory; an unreadable cache must not interrupt proxying.
+      return sendOriginalBypass({
+        provider: params.capabilityStore.provider,
+        model: params.capabilityStore.model,
+        itemTypes: rebaseItemTypes,
+        skippedItemTypes: rebaseItemTypes,
+        reason: "capability_check_error",
+      });
     }
   }
 
@@ -219,30 +248,43 @@ export async function executeCodexRebaseWithFallback(params: {
   }
 
   async function recordCapabilities(paramsForRecord: {
-    itemTypes: string[];
-    status: "supported" | "unsupported";
+    items: Array<{ itemType: string; payloadDigest?: string }>;
+    status: "verified_supported" | "verified_unsupported" | "payload_rejected";
     reason: string;
     responseStatus?: number;
+    errorCode?: string;
   }): Promise<void> {
     const store = params.capabilityStore;
     if (!store) return;
-    await Promise.all(paramsForRecord.itemTypes.map((itemType) => appendCodexRebaseCapability({
-      stateDir: store.stateDir,
-      provider: store.provider,
-      model: store.model,
-      itemType,
-      status: paramsForRecord.status,
-      reason: paramsForRecord.reason,
-      responseStatus: paramsForRecord.responseStatus,
-      observedAt: store.now,
-    })));
+    const evidence = store.probeMode === "mock_fixture" ? "mock_fixture" : "real_provider";
+    for (const item of paramsForRecord.items) {
+      await appendCodexRebaseCapability({
+        stateDir: store.stateDir,
+        provider: store.provider,
+        model: store.model,
+        wireMode: store.wireMode,
+        apiVersion: store.apiVersion,
+        endpointId: store.endpointId,
+        itemType: item.itemType,
+        itemSchemaVersion: store.itemSchemaVersion,
+        status: paramsForRecord.status,
+        evidence,
+        payloadDigest: paramsForRecord.status === "payload_rejected" ? item.payloadDigest : undefined,
+        reason: paramsForRecord.reason,
+        responseStatus: paramsForRecord.responseStatus,
+        errorCode: paramsForRecord.errorCode,
+        observedAt: store.now,
+        ttlMs: store.ttlMs,
+      });
+    }
   }
 
   async function safeRecordCapabilities(paramsForRecord: {
-    itemTypes: string[];
-    status: "supported" | "unsupported";
+    items: Array<{ itemType: string; payloadDigest?: string }>;
+    status: "verified_supported" | "verified_unsupported" | "payload_rejected";
     reason: string;
     responseStatus?: number;
+    errorCode?: string;
   }): Promise<void> {
     try {
       await recordCapabilities(paramsForRecord);
@@ -378,8 +420,8 @@ export async function executeCodexRebaseWithFallback(params: {
         }
         if (params.capabilityStore && rebaseItemTypes.length > 0) {
           await safeRecordCapabilities({
-            itemTypes: rebaseItemTypes,
-            status: "supported",
+            items: rebaseItems,
+            status: "verified_supported",
             reason: "rebase_committed",
             responseStatus: rebaseResponse.status,
           });
@@ -406,23 +448,41 @@ export async function executeCodexRebaseWithFallback(params: {
           : "rebase_upstream_rejected"
       );
       if (params.capabilityStore) {
-        const unsupportedItemTypes = unsupportedCodexRebaseItemTypesFromResponse({
+        const classification = classifyCodexRebaseCapabilityRejection({
           response: rebaseResponse,
-          itemTypes: rebaseItemTypes,
+          items: rebaseItems,
         });
-        if (unsupportedItemTypes.length > 0) {
+        if (classification.kind === "item_unsupported") {
+          const unsupportedItemTypes = classification.itemTypes;
           await safeRecordCapabilities({
-            itemTypes: unsupportedItemTypes,
-            status: "unsupported",
-            reason: "schema_error",
+            items: unsupportedItemTypes.map((itemType) => ({ itemType })),
+            status: "verified_unsupported",
+            reason: "item_schema_unsupported",
             responseStatus: rebaseResponse.status,
+            errorCode: classification.errorCode,
           });
           capability = {
             provider: params.capabilityStore.provider,
             model: params.capabilityStore.model,
             itemTypes: rebaseItemTypes,
             unsupportedItemTypes,
-            reason: "schema_error",
+            reason: "item_schema_unsupported",
+          };
+        } else if (classification.kind === "payload_rejected") {
+          const rejectedItems = rebaseItems.filter((entry) => classification.itemTypes.includes(entry.itemType));
+          await safeRecordCapabilities({
+            items: rejectedItems,
+            status: "payload_rejected",
+            reason: "encrypted_payload_rejected",
+            responseStatus: rebaseResponse.status,
+            errorCode: classification.errorCode,
+          });
+          capability = {
+            provider: params.capabilityStore.provider,
+            model: params.capabilityStore.model,
+            itemTypes: rebaseItemTypes,
+            payloadRejectedItemTypes: classification.itemTypes,
+            reason: "encrypted_payload_rejected",
           };
         }
       }

--- a/components/adapters/codex/src/context-rewrite/index.ts
+++ b/components/adapters/codex/src/context-rewrite/index.ts
@@ -8,11 +8,16 @@ export {
 } from "./rebase-request.js";
 export {
   appendCodexRebaseCapability,
+  classifyCodexRebaseCapabilityRejection,
+  codexRebaseEndpointIdentity,
   codexRebaseCapabilityJournalPath,
+  codexRebasePayloadDigest,
+  codexRebasePayloadItems,
   codexRebasePayloadItemTypes,
   formatCodexRebaseCapabilityStatus,
   readCodexRebaseCapabilityJournal,
   readUnsupportedCodexRebaseItemTypes,
+  resolveCodexProviderReplayCompatibility,
   unsupportedCodexRebaseItemTypesFromResponse,
 } from "./rebase-capability.js";
 export {

--- a/components/adapters/codex/src/context-rewrite/rebase-capability.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-capability.ts
@@ -1,9 +1,17 @@
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { appendJsonl } from "@lightmem2/host-adapter";
 import {
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_CAPABILITY_DEFAULT_TTL_MS,
+  CODEX_REBASE_CAPABILITY_LEGACY_SCHEMA,
   CODEX_REBASE_CAPABILITY_SCHEMA,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
+  type CodexProviderReplayCompatibilityDecision,
   type CodexRebaseCapability,
+  type CodexRebaseCapabilityEvidence,
   type CodexRebaseCapabilityStatus,
   type CodexUpstreamResponse,
   type JsonObject,
@@ -13,16 +21,41 @@ export type CodexRebaseCapabilityJournalReadResult = {
   entries: CodexRebaseCapability[];
   capabilities: CodexRebaseCapability[];
   malformedLineCount: number;
+  staleLineCount: number;
   readError?: string;
 };
+
+export type CodexRebasePayloadItemDescriptor = {
+  itemType: string;
+  payloadDigest: string;
+};
+
+export type CodexProviderReplayCompatibilityResult = {
+  decisions: CodexProviderReplayCompatibilityDecision[];
+  journalTrusted: boolean;
+  reason?: string;
+};
+
+export type CodexRebaseRejectionClassification = {
+  kind: "item_unsupported" | "payload_rejected" | "ambiguous" | "transient" | "unclassified";
+  itemTypes: string[];
+  errorCode?: string;
+};
+
+type CapabilityDimensions = Pick<
+  CodexRebaseCapability,
+  "provider" | "model" | "wireMode" | "apiVersion" | "endpointId" | "itemType" | "itemSchemaVersion"
+>;
 
 function cleanDimension(value: string, fallback: string): string {
   const trimmed = value.trim();
   return trimmed || fallback;
 }
 
-export function codexRebaseCapabilityJournalPath(stateDir: string): string {
-  return join(stateDir, "context-rewrite", "codex", "provider-capabilities.jsonl");
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
 }
 
 function errorCode(error: unknown): string | undefined {
@@ -31,32 +64,99 @@ function errorCode(error: unknown): string | undefined {
     : undefined;
 }
 
-function timestampMs(value: unknown): number | undefined {
-  if (typeof value !== "string") return undefined;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
+function asObject(value: unknown): JsonObject | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : undefined;
 }
 
 function isStatus(value: unknown): value is CodexRebaseCapabilityStatus {
-  return value === "supported" || value === "unsupported";
+  return value === "verified_supported"
+    || value === "verified_unsupported"
+    || value === "payload_rejected";
 }
 
-function isCodexRebaseCapability(value: unknown): value is CodexRebaseCapability {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-  const entry = value as Record<string, unknown>;
-  return entry.schema === CODEX_REBASE_CAPABILITY_SCHEMA
-    && typeof entry.provider === "string"
-    && typeof entry.model === "string"
-    && typeof entry.itemType === "string"
-    && isStatus(entry.status)
-    && timestampMs(entry.observedAt) !== undefined
-    && (entry.reason === undefined || typeof entry.reason === "string")
-    && (entry.responseStatus === undefined || typeof entry.responseStatus === "number")
-    && (entry.errorCode === undefined || typeof entry.errorCode === "string");
+function isEvidence(value: unknown): value is CodexRebaseCapabilityEvidence {
+  return value === "mock_fixture" || value === "real_provider";
 }
 
-function capabilityKey(entry: Pick<CodexRebaseCapability, "provider" | "model" | "itemType">): string {
-  return `${entry.provider}\u0000${entry.model}\u0000${entry.itemType}`;
+function isDigest(value: unknown): value is string {
+  return typeof value === "string" && /^sha256:[a-f0-9]{64}$/u.test(value);
+}
+
+function isEndpointId(value: unknown): value is string {
+  return value === "not-observed" || isDigest(value);
+}
+
+function optionalTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parseCodexRebaseCapability(value: unknown): CodexRebaseCapability | undefined {
+  const entry = asObject(value);
+  if (!entry || entry.schema !== CODEX_REBASE_CAPABILITY_SCHEMA) return undefined;
+  if (
+    typeof entry.provider !== "string" || !entry.provider.trim()
+    || typeof entry.model !== "string" || !entry.model.trim()
+    || typeof entry.wireMode !== "string" || !entry.wireMode.trim()
+    || typeof entry.apiVersion !== "string" || !entry.apiVersion.trim()
+    || !isEndpointId(entry.endpointId)
+    || typeof entry.itemType !== "string" || !entry.itemType.trim()
+    || typeof entry.itemSchemaVersion !== "string" || !entry.itemSchemaVersion.trim()
+    || !isStatus(entry.status)
+    || !isEvidence(entry.evidence)
+    || !canonicalTimestamp(entry.observedAt)
+    || !canonicalTimestamp(entry.expiresAt)
+    || Date.parse(entry.expiresAt) <= Date.parse(entry.observedAt)
+    || (entry.responseStatus !== undefined
+      && (typeof entry.responseStatus !== "number"
+        || !Number.isInteger(entry.responseStatus)
+        || entry.responseStatus < 100
+        || entry.responseStatus > 599))
+    || (entry.reason !== undefined && typeof entry.reason !== "string")
+    || (entry.errorCode !== undefined && typeof entry.errorCode !== "string")
+  ) {
+    return undefined;
+  }
+  const payloadDigest = isDigest(entry.payloadDigest) ? entry.payloadDigest : undefined;
+  if ((entry.status === "payload_rejected") !== Boolean(payloadDigest)) return undefined;
+
+  return {
+    schema: CODEX_REBASE_CAPABILITY_SCHEMA,
+    provider: entry.provider.trim(),
+    model: entry.model.trim(),
+    wireMode: entry.wireMode.trim(),
+    apiVersion: entry.apiVersion.trim(),
+    endpointId: entry.endpointId,
+    itemType: entry.itemType.trim(),
+    itemSchemaVersion: entry.itemSchemaVersion.trim(),
+    status: entry.status,
+    evidence: entry.evidence,
+    payloadDigest,
+    reason: optionalTrimmedString(entry.reason),
+    responseStatus: entry.responseStatus as number | undefined,
+    errorCode: optionalTrimmedString(entry.errorCode),
+    observedAt: entry.observedAt,
+    expiresAt: entry.expiresAt,
+  };
+}
+
+function dimensionKey(entry: CapabilityDimensions): string {
+  return [
+    entry.provider,
+    entry.model,
+    entry.wireMode,
+    entry.apiVersion,
+    entry.endpointId,
+    entry.itemType,
+    entry.itemSchemaVersion,
+  ].join("\u0000");
+}
+
+function capabilityKey(entry: CodexRebaseCapability): string {
+  return entry.status === "payload_rejected"
+    ? `${dimensionKey(entry)}\u0000payload\u0000${entry.payloadDigest}`
+    : `${dimensionKey(entry)}\u0000item`;
 }
 
 function collapseLatestCapabilities(entries: CodexRebaseCapability[]): CodexRebaseCapability[] {
@@ -69,6 +169,33 @@ function collapseLatestCapabilities(entries: CodexRebaseCapability[]): CodexReba
   return Array.from(latest.values());
 }
 
+function normalizedDimensions(params: CapabilityDimensions): CapabilityDimensions {
+  return {
+    provider: cleanDimension(params.provider, "unknown-provider"),
+    model: cleanDimension(params.model, "unknown-model"),
+    wireMode: cleanDimension(params.wireMode, CODEX_REBASE_WIRE_MODE),
+    apiVersion: cleanDimension(params.apiVersion, CODEX_REBASE_API_VERSION),
+    endpointId: isEndpointId(params.endpointId) ? params.endpointId : "not-observed",
+    itemType: cleanDimension(params.itemType, "unknown"),
+    itemSchemaVersion: cleanDimension(params.itemSchemaVersion, CODEX_REBASE_ITEM_SCHEMA_VERSION),
+  };
+}
+
+export function codexRebaseEndpointIdentity(endpoint: string | undefined): string {
+  const normalized = endpoint?.trim();
+  return normalized
+    ? `sha256:${createHash("sha256").update(normalized).digest("hex")}`
+    : "not-observed";
+}
+
+export function codexRebasePayloadDigest(value: unknown): string {
+  return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
+}
+
+export function codexRebaseCapabilityJournalPath(stateDir: string): string {
+  return join(stateDir, "context-rewrite", "codex", "provider-capabilities.jsonl");
+}
+
 export async function readCodexRebaseCapabilityJournal(
   stateDir: string,
 ): Promise<CodexRebaseCapabilityJournalReadResult> {
@@ -77,22 +204,31 @@ export async function readCodexRebaseCapabilityJournal(
     raw = await readFile(codexRebaseCapabilityJournalPath(stateDir), "utf8");
   } catch (error) {
     if (errorCode(error) === "ENOENT") {
-      return { entries: [], capabilities: [], malformedLineCount: 0 };
+      return { entries: [], capabilities: [], malformedLineCount: 0, staleLineCount: 0 };
     }
     return {
       entries: [],
       capabilities: [],
       malformedLineCount: 0,
+      staleLineCount: 0,
       readError: error instanceof Error ? error.message : String(error),
     };
   }
 
   const entries: CodexRebaseCapability[] = [];
   let malformedLineCount = 0;
-  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
+  let staleLineCount = 0;
+  for (const line of raw.split(/\r?\n/u)) {
+    if (!line) continue;
     try {
       const parsed = JSON.parse(line) as unknown;
-      if (isCodexRebaseCapability(parsed)) entries.push(parsed);
+      const object = asObject(parsed);
+      if (object?.schema === CODEX_REBASE_CAPABILITY_LEGACY_SCHEMA) {
+        staleLineCount += 1;
+        continue;
+      }
+      const capability = parseCodexRebaseCapability(parsed);
+      if (capability) entries.push(capability);
       else malformedLineCount += 1;
     } catch {
       malformedLineCount += 1;
@@ -102,75 +238,196 @@ export async function readCodexRebaseCapabilityJournal(
     entries,
     capabilities: collapseLatestCapabilities(entries),
     malformedLineCount,
+    staleLineCount,
   };
 }
 
-export async function appendCodexRebaseCapability(params: {
+export async function appendCodexRebaseCapability(params: CapabilityDimensions & {
   stateDir: string;
-  provider: string;
-  model: string;
-  itemType: string;
   status: CodexRebaseCapabilityStatus;
+  evidence: CodexRebaseCapabilityEvidence;
+  payloadDigest?: string;
   reason?: string;
   responseStatus?: number;
   errorCode?: string;
   observedAt?: string;
+  expiresAt?: string;
+  ttlMs?: number;
 }): Promise<CodexRebaseCapability> {
   const observedAt = params.observedAt ?? new Date().toISOString();
-  if (timestampMs(observedAt) === undefined) {
-    throw new Error("Codex rebase capability requires a valid observation time");
+  if (!canonicalTimestamp(observedAt)) {
+    throw new Error("Codex rebase capability requires a canonical observation time");
   }
+  const ttlMs = params.ttlMs ?? CODEX_REBASE_CAPABILITY_DEFAULT_TTL_MS;
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+    throw new Error("Codex rebase capability requires a positive TTL");
+  }
+  const expiresAt = params.expiresAt ?? new Date(Date.parse(observedAt) + ttlMs).toISOString();
+  if (!canonicalTimestamp(expiresAt) || Date.parse(expiresAt) <= Date.parse(observedAt)) {
+    throw new Error("Codex rebase capability requires a canonical expiry after observation");
+  }
+  if (!isEndpointId(params.endpointId)) {
+    throw new Error("Codex rebase capability endpoint identity must be a digest or not-observed");
+  }
+  if ((params.status === "payload_rejected") !== isDigest(params.payloadDigest)) {
+    throw new Error("Payload-specific capability rejection requires exactly one payload digest");
+  }
+  const dimensions = normalizedDimensions(params);
   const entry: CodexRebaseCapability = {
     schema: CODEX_REBASE_CAPABILITY_SCHEMA,
-    provider: cleanDimension(params.provider, "unknown-provider"),
-    model: cleanDimension(params.model, "unknown-model"),
-    itemType: cleanDimension(params.itemType, "unknown"),
+    ...dimensions,
     status: params.status,
-    reason: params.reason,
+    evidence: params.evidence,
+    payloadDigest: params.status === "payload_rejected" ? params.payloadDigest : undefined,
+    reason: optionalTrimmedString(params.reason),
     responseStatus: params.responseStatus,
-    errorCode: params.errorCode,
+    errorCode: optionalTrimmedString(params.errorCode),
     observedAt,
+    expiresAt,
   };
   await appendJsonl(codexRebaseCapabilityJournalPath(params.stateDir), entry);
   return entry;
 }
 
-export async function readUnsupportedCodexRebaseItemTypes(params: {
-  stateDir: string;
-  provider: string;
-  model: string;
-  itemTypes: string[];
-}): Promise<string[]> {
-  const journal = await readCodexRebaseCapabilityJournal(params.stateDir);
-  if (journal.readError) return [];
-  const latest = new Map(journal.capabilities.map((entry) => [capabilityKey(entry), entry]));
-  const provider = cleanDimension(params.provider, "unknown-provider");
-  const model = cleanDimension(params.model, "unknown-model");
-  return Array.from(new Set(params.itemTypes))
-    .filter((itemType) => latest.get(capabilityKey({
-      provider,
-      model,
-      itemType: cleanDimension(itemType, "unknown"),
-    }))?.status === "unsupported");
+function itemTypeForPayloadItem(item: JsonObject): string {
+  if (typeof item.type === "string" && item.type.trim()) return item.type.trim();
+  if (typeof item.role === "string" && item.role.trim()) return "message";
+  return "unknown";
 }
 
-function asObject(value: unknown): JsonObject | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? value as JsonObject
-    : undefined;
-}
-
-export function codexRebasePayloadItemTypes(payload: JsonObject): string[] {
+export function codexRebasePayloadItems(payload: JsonObject): CodexRebasePayloadItemDescriptor[] {
+  const grouped = new Map<string, JsonObject[]>();
   const input = Array.isArray(payload.input) ? payload.input : [];
-  const itemTypes: string[] = [];
   for (const item of input) {
     const entry = asObject(item);
     if (!entry) continue;
-    if (typeof entry.type === "string" && entry.type.trim()) itemTypes.push(entry.type.trim());
-    else if (typeof entry.role === "string" && entry.role.trim()) itemTypes.push("message");
-    else itemTypes.push("unknown");
+    const itemType = itemTypeForPayloadItem(entry);
+    const values = grouped.get(itemType) ?? [];
+    values.push(entry);
+    grouped.set(itemType, values);
   }
-  return Array.from(new Set(itemTypes));
+  return Array.from(grouped, ([itemType, items]) => ({
+    itemType,
+    payloadDigest: codexRebasePayloadDigest(items),
+  }));
+}
+
+export function codexRebasePayloadItemTypes(payload: JsonObject): string[] {
+  return codexRebasePayloadItems(payload).map((entry) => entry.itemType);
+}
+
+function findLatest(
+  entries: CodexRebaseCapability[],
+  predicate: (entry: CodexRebaseCapability) => boolean,
+): CodexRebaseCapability | undefined {
+  let latest: CodexRebaseCapability | undefined;
+  for (const entry of entries) {
+    if (predicate(entry)) latest = entry;
+  }
+  return latest;
+}
+
+export async function resolveCodexProviderReplayCompatibility(params: Omit<CapabilityDimensions, "itemType"> & {
+  stateDir: string;
+  items: CodexRebasePayloadItemDescriptor[];
+  acceptedEvidence?: CodexRebaseCapabilityEvidence[];
+  now?: string;
+}): Promise<CodexProviderReplayCompatibilityResult> {
+  const journal = await readCodexRebaseCapabilityJournal(params.stateDir);
+  const acceptedEvidence = new Set(params.acceptedEvidence ?? ["real_provider"]);
+  const now = params.now ?? new Date().toISOString();
+  if (!canonicalTimestamp(now)) throw new Error("Codex provider compatibility requires a canonical current time");
+
+  const baseDimensions = {
+    provider: params.provider,
+    model: params.model,
+    wireMode: params.wireMode,
+    apiVersion: params.apiVersion,
+    endpointId: params.endpointId,
+    itemSchemaVersion: params.itemSchemaVersion,
+  };
+  const unknownDecisions = (reason: string): CodexProviderReplayCompatibilityDecision[] => (
+    params.items.map((item) => ({
+      ...normalizedDimensions({ ...baseDimensions, itemType: item.itemType }),
+      status: "unknown_probe_required",
+      payloadDigest: item.payloadDigest,
+      reason,
+    }))
+  );
+
+  if (journal.readError || journal.malformedLineCount > 0) {
+    return {
+      decisions: unknownDecisions("capability_journal_untrusted"),
+      journalTrusted: false,
+      reason: "capability_journal_untrusted",
+    };
+  }
+
+  const decisions = params.items.map((item): CodexProviderReplayCompatibilityDecision => {
+    const dimensions = normalizedDimensions({ ...baseDimensions, itemType: item.itemType });
+    const matching = journal.capabilities.filter((entry) => dimensionKey(entry) === dimensionKey(dimensions));
+    const accepted = matching.filter((entry) => acceptedEvidence.has(entry.evidence));
+    const unexpired = accepted.filter((entry) => Date.parse(entry.expiresAt) > Date.parse(now));
+    const payloadRejection = findLatest(unexpired, (entry) => (
+      entry.status === "payload_rejected" && entry.payloadDigest === item.payloadDigest
+    ));
+    if (payloadRejection) {
+      return {
+        ...dimensions,
+        status: "payload_rejected",
+        evidence: payloadRejection.evidence,
+        payloadDigest: item.payloadDigest,
+        reason: payloadRejection.reason ?? "payload_rejected",
+        observedAt: payloadRejection.observedAt,
+        expiresAt: payloadRejection.expiresAt,
+      };
+    }
+    const itemCapability = findLatest(unexpired, (entry) => entry.status !== "payload_rejected");
+    if (itemCapability) {
+      return {
+        ...dimensions,
+        status: itemCapability.status,
+        evidence: itemCapability.evidence,
+        payloadDigest: item.payloadDigest,
+        reason: itemCapability.reason ?? itemCapability.status,
+        observedAt: itemCapability.observedAt,
+        expiresAt: itemCapability.expiresAt,
+      };
+    }
+    const reason = accepted.length > 0
+      ? "capability_expired"
+      : matching.some((entry) => entry.evidence === "mock_fixture")
+        ? "mock_fixture_not_provider_verified"
+        : journal.staleLineCount > 0
+          ? "legacy_capability_not_reused"
+          : "capability_not_observed";
+    return {
+      ...dimensions,
+      status: "unknown_probe_required",
+      payloadDigest: item.payloadDigest,
+      reason,
+    };
+  });
+  return { decisions, journalTrusted: true };
+}
+
+export async function readUnsupportedCodexRebaseItemTypes(params: Omit<CapabilityDimensions, "itemType"> & {
+  stateDir: string;
+  itemTypes: string[];
+  acceptedEvidence?: CodexRebaseCapabilityEvidence[];
+  now?: string;
+}): Promise<string[]> {
+  const result = await resolveCodexProviderReplayCompatibility({
+    ...params,
+    items: Array.from(new Set(params.itemTypes)).map((itemType) => ({
+      itemType,
+      payloadDigest: codexRebasePayloadDigest([]),
+    })),
+  });
+  if (!result.journalTrusted) throw new Error("Codex rebase capability journal is untrusted");
+  return result.decisions
+    .filter((entry) => entry.status === "verified_unsupported")
+    .map((entry) => entry.itemType);
 }
 
 function collectStrings(value: unknown, output: string[] = []): string[] {
@@ -196,21 +453,88 @@ function parsedResponseText(text: string): unknown {
   }
 }
 
-function schemaErrorText(response: CodexUpstreamResponse): string {
+function responseErrorText(response: CodexUpstreamResponse): string {
   const parsed = parsedResponseText(response.text);
   return (parsed === undefined ? [response.text] : collectStrings(parsed)).join(" ").toLowerCase();
+}
+
+function nestedErrorCode(value: unknown): string | undefined {
+  const object = asObject(value);
+  if (!object) return undefined;
+  if (typeof object.code === "string" && object.code.trim()) return object.code.trim().toLowerCase();
+  for (const child of Object.values(object)) {
+    const code = nestedErrorCode(child);
+    if (code) return code;
+  }
+  return undefined;
+}
+
+export function classifyCodexRebaseCapabilityRejection(params: {
+  response: CodexUpstreamResponse;
+  items: CodexRebasePayloadItemDescriptor[];
+}): CodexRebaseRejectionClassification {
+  const itemTypes = params.items.map((entry) => entry.itemType);
+  const parsed = parsedResponseText(params.response.text);
+  const detectedErrorCode = nestedErrorCode(parsed);
+  if ([401, 403, 429].includes(params.response.status) || params.response.status >= 500) {
+    return { kind: "transient", itemTypes: [], errorCode: detectedErrorCode };
+  }
+  if (params.response.status !== 400) {
+    return { kind: "unclassified", itemTypes: [], errorCode: detectedErrorCode };
+  }
+
+  const text = responseErrorText(params.response);
+  const encryptedTypes = itemTypes.filter((itemType) => itemType === "reasoning" || itemType === "compaction");
+  const namedEncryptedTypes = encryptedTypes.filter((itemType) => text.includes(itemType.toLowerCase()));
+  const payloadSpecific = detectedErrorCode === "invalid_encrypted_content"
+    || /(encrypted|payload).*(invalid|expired|expiry|lineage|mismatch)/iu.test(text)
+    || /(invalid|expired|expiry|lineage|mismatch).*(encrypted|payload)/iu.test(text);
+  if (payloadSpecific) {
+    const attributable = namedEncryptedTypes.length > 0
+      ? namedEncryptedTypes
+      : encryptedTypes.length === 1
+        ? encryptedTypes
+        : [];
+    return attributable.length > 0
+      ? { kind: "payload_rejected", itemTypes: Array.from(new Set(attributable)), errorCode: detectedErrorCode }
+      : { kind: "ambiguous", itemTypes: [], errorCode: detectedErrorCode };
+  }
+
+  const explicitItemUnsupported = /(unsupported item|item type.*unsupported|unknown item|schema.*item|not supported)/iu.test(text)
+    || detectedErrorCode === "unsupported_item_type";
+  const namedItemTypes = itemTypes.filter((itemType) => text.includes(itemType.toLowerCase()));
+  if (explicitItemUnsupported && namedItemTypes.length > 0) {
+    return {
+      kind: "item_unsupported",
+      itemTypes: Array.from(new Set(namedItemTypes)),
+      errorCode: detectedErrorCode,
+    };
+  }
+  return explicitItemUnsupported || /(schema|invalid_request_error)/iu.test(text)
+    ? { kind: "ambiguous", itemTypes: [], errorCode: detectedErrorCode }
+    : { kind: "unclassified", itemTypes: [], errorCode: detectedErrorCode };
 }
 
 export function unsupportedCodexRebaseItemTypesFromResponse(params: {
   response: CodexUpstreamResponse;
   itemTypes: string[];
 }): string[] {
-  if (params.response.status !== 400) return [];
-  const text = schemaErrorText(params.response);
-  if (!/(schema|unsupported|not supported|invalid_request_error|unknown item)/i.test(text)) return [];
-  return params.itemTypes.filter((itemType) => text.includes(itemType.toLowerCase()));
+  const classification = classifyCodexRebaseCapabilityRejection({
+    response: params.response,
+    items: params.itemTypes.map((itemType) => ({
+      itemType,
+      payloadDigest: codexRebasePayloadDigest([]),
+    })),
+  });
+  return classification.kind === "item_unsupported" ? classification.itemTypes : [];
 }
 
-export function formatCodexRebaseCapabilityStatus(entry: CodexRebaseCapability): string {
-  return `${entry.provider}/${entry.model} ${entry.itemType} ${entry.status}`;
+export function formatCodexRebaseCapabilityStatus(
+  entry: CodexRebaseCapability,
+  now = new Date().toISOString(),
+): string {
+  const evidence = entry.evidence === "real_provider" ? "real-provider" : "mock/fixture";
+  const validity = Date.parse(entry.expiresAt) > Date.parse(now) ? "active" : "expired";
+  return `${entry.provider}/${entry.model} ${entry.wireMode} ${entry.apiVersion} `
+    + `${entry.itemType}@${entry.itemSchemaVersion} ${entry.status} evidence=${evidence} state=${validity}`;
 }

--- a/components/adapters/codex/src/context-rewrite/types.ts
+++ b/components/adapters/codex/src/context-rewrite/types.ts
@@ -16,6 +16,7 @@ export type CodexContextRewriteConfig = {
   failureMode: "bypass";
   retryOriginalRequest: boolean;
   cooldownMs: number;
+  providerCompatibilityProbe: "disabled" | "mock_fixture" | "real_provider";
 };
 
 export type CodexMutationPlan = {
@@ -122,20 +123,59 @@ export type CodexRebaseCooldownStoreParams = {
   now?: string;
 };
 
-export const CODEX_REBASE_CAPABILITY_SCHEMA = "lightmem2.codex.rebase-capability/v1";
+export const CODEX_REBASE_CAPABILITY_SCHEMA = "lightmem2.codex.rebase-capability/v2";
+export const CODEX_REBASE_CAPABILITY_LEGACY_SCHEMA = "lightmem2.codex.rebase-capability/v1";
+export const CODEX_REBASE_CAPABILITY_DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
+export const CODEX_REBASE_WIRE_MODE = "responses";
+export const CODEX_REBASE_API_VERSION = "responses/v1";
+export const CODEX_REBASE_ITEM_SCHEMA_VERSION = "responses-item/v1";
 
-export type CodexRebaseCapabilityStatus = "supported" | "unsupported";
+export type CodexRebaseCapabilityStatus =
+  | "verified_supported"
+  | "verified_unsupported"
+  | "payload_rejected";
+
+export type CodexRebaseCapabilityEvidence = "mock_fixture" | "real_provider";
+
+export type CodexProviderReplayCompatibilityStatus =
+  | "verified_supported"
+  | "verified_unsupported"
+  | "unknown_probe_required"
+  | "payload_rejected";
 
 export type CodexRebaseCapability = {
   schema: typeof CODEX_REBASE_CAPABILITY_SCHEMA;
   provider: string;
   model: string;
+  wireMode: string;
+  apiVersion: string;
+  endpointId: string;
   itemType: string;
+  itemSchemaVersion: string;
   status: CodexRebaseCapabilityStatus;
+  evidence: CodexRebaseCapabilityEvidence;
+  payloadDigest?: string;
   reason?: string;
   responseStatus?: number;
   errorCode?: string;
   observedAt: string;
+  expiresAt: string;
+};
+
+export type CodexProviderReplayCompatibilityDecision = {
+  provider: string;
+  model: string;
+  wireMode: string;
+  apiVersion: string;
+  endpointId: string;
+  itemType: string;
+  itemSchemaVersion: string;
+  status: CodexProviderReplayCompatibilityStatus;
+  evidence?: CodexRebaseCapabilityEvidence;
+  payloadDigest?: string;
+  reason: string;
+  observedAt?: string;
+  expiresAt?: string;
 };
 
 export type CodexRebaseCapabilityNotice = {
@@ -145,6 +185,8 @@ export type CodexRebaseCapabilityNotice = {
   skippedItemTypes?: string[];
   supportedItemTypes?: string[];
   unsupportedItemTypes?: string[];
+  payloadRejectedItemTypes?: string[];
+  decisions?: CodexProviderReplayCompatibilityDecision[];
   reason?: string;
 };
 
@@ -152,6 +194,12 @@ export type CodexRebaseCapabilityStoreParams = {
   stateDir: string;
   provider: string;
   model: string;
+  wireMode: string;
+  apiVersion: string;
+  endpointId: string;
+  itemSchemaVersion: string;
+  probeMode?: "disabled" | CodexRebaseCapabilityEvidence;
+  ttlMs?: number;
   now?: string;
 };
 

--- a/components/adapters/codex/src/doctor.ts
+++ b/components/adapters/codex/src/doctor.ts
@@ -55,6 +55,8 @@ export type CodexDoctorReport = {
   recoveryMcpHealthy: boolean;
   degradedMode: boolean;
   rebaseCapabilityStatus?: string[];
+  rebaseCapabilityTrusted?: boolean;
+  rebaseCapabilityIssue?: string;
 };
 
 const HOOK_EVENT_NAMES = [
@@ -85,6 +87,11 @@ async function checkHealth(baseUrl: string): Promise<boolean> {
 
 export function formatCodexDoctorReport(report: CodexDoctorReport): string {
   const rebaseCapabilityStatus = report.rebaseCapabilityStatus ?? [];
+  const rebaseCapabilitySummary = report.rebaseCapabilityTrusted === false
+    ? `untrusted (${report.rebaseCapabilityIssue ?? "read or validation error"}); runtime will bypass rebase`
+    : rebaseCapabilityStatus.length > 0
+      ? rebaseCapabilityStatus.join(", ")
+      : "(none)";
   const lines = [
     "TokenPilot Codex doctor:",
     `- tokenpilot config: ${report.tokenPilotConfigPath}`,
@@ -118,7 +125,7 @@ export function formatCodexDoctorReport(report: CodexDoctorReport): string {
     `- upstream provider: ${report.upstreamProvider ?? "(unset)"}`,
     `- upstream base URL: ${report.upstreamBaseUrl ?? "(unset)"}`,
     `- upstream loops into local proxy: ${report.upstreamLoopDetected ? "yes" : "no"}`,
-    `- CDR-05 rebase capability cache: ${rebaseCapabilityStatus.length > 0 ? rebaseCapabilityStatus.join(", ") : "(none)"}`,
+    `- CDR-05 rebase capability cache: ${rebaseCapabilitySummary}`,
   ];
   const fixes: string[] = [];
   if (!report.adapterEnabled) {
@@ -212,9 +219,15 @@ export async function inspectCodexDoctor(params: {
     expectedStartupTimeoutSec: DEFAULT_TOKENPILOT_MCP_STARTUP_TIMEOUT_SEC,
   });
   const capabilityJournal = await readCodexRebaseCapabilityJournal(params.config.stateDir);
-  const rebaseCapabilityStatus = capabilityJournal.capabilities
-    .map(formatCodexRebaseCapabilityStatus)
-    .sort();
+  const rebaseCapabilityTrusted = !capabilityJournal.readError
+    && capabilityJournal.malformedLineCount === 0;
+  const rebaseCapabilityStatus = rebaseCapabilityTrusted
+    ? capabilityJournal.capabilities.map((entry) => formatCodexRebaseCapabilityStatus(entry)).sort()
+    : [];
+  const rebaseCapabilityIssue = capabilityJournal.readError
+    ?? (capabilityJournal.malformedLineCount > 0
+      ? `${capabilityJournal.malformedLineCount} malformed row(s)`
+      : undefined);
   const coreRuntimeHealthy = params.config.enabled
     && Boolean(tokenpilotProvider)
     && providerIntercepted
@@ -254,5 +267,7 @@ export async function inspectCodexDoctor(params: {
     recoveryMcpHealthy,
     degradedMode: coreRuntimeHealthy && !recoveryMcpHealthy,
     rebaseCapabilityStatus,
+    rebaseCapabilityTrusted,
+    rebaseCapabilityIssue,
   };
 }

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -71,8 +71,12 @@ import type {
   JsonObject,
 } from "./context-history/types.js";
 import {
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
   acquireCodexRebaseSessionLock,
   buildCodexRebaseRequest,
+  codexRebaseEndpointIdentity,
   executeCodexRebaseWithFallback,
   failPendingCodexRebaseEpochsAfterRestart,
   withCodexRebaseReplayAccountingInput,
@@ -665,6 +669,11 @@ export async function startCodexResponsesProxy(params: {
             stateDir: config.stateDir,
             provider: upstreamProviderName,
             model,
+            wireMode: CODEX_REBASE_WIRE_MODE,
+            apiVersion: CODEX_REBASE_API_VERSION,
+            endpointId: codexRebaseEndpointIdentity(upstream.baseUrl),
+            itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+            probeMode: config.contextRewrite.providerCompatibilityProbe,
           },
         }).then((result) => {
           contextRewriteOutcome = result.outcome;

--- a/components/adapters/codex/src/session-report.ts
+++ b/components/adapters/codex/src/session-report.ts
@@ -120,9 +120,11 @@ async function buildCodexRebaseReportLines(
   const latest = latestEpoch(epochs);
   const currentCooldowns = activeCooldowns(cooldowns);
   const cooldown = latestCooldown(cooldowns);
-  const capabilityStatus = capabilities
-    .map(formatCodexRebaseCapabilityStatus)
-    .sort();
+  const capabilityJournalTrusted = !capabilityJournal.readError
+    && capabilityJournal.malformedLineCount === 0;
+  const capabilityStatus = capabilityJournalTrusted
+    ? capabilities.map((entry) => formatCodexRebaseCapabilityStatus(entry)).sort()
+    : [];
   const malformedRows =
     epochJournal.malformedLineCount
     + cooldownJournal.malformedLineCount
@@ -153,6 +155,8 @@ async function buildCodexRebaseReportLines(
   }
   if (capabilityStatus.length > 0) {
     lines.push(`- CDR-05 rebase capability cache: ${capabilityStatus.join(", ")}`);
+  } else if (!capabilityJournalTrusted) {
+    lines.push("- CDR-05 rebase capability cache: untrusted; runtime will bypass rebase");
   }
   if (malformedRows > 0) {
     lines.push(`- rebase journal malformed rows: ${malformedRows}`);

--- a/components/adapters/codex/tests/config.test.ts
+++ b/components/adapters/codex/tests/config.test.ts
@@ -38,6 +38,7 @@ test("normalizeTokenPilotCodexConfig trims and clamps values", () => {
 test("normalizeTokenPilotCodexConfig preserves context rewrite plan revisions", () => {
   const config = normalizeTokenPilotCodexConfig({
     contextRewrite: {
+      providerCompatibilityProbe: "mock_fixture",
       mutationPlan: {
         baseRevision: "rev-base",
         operations: [{ type: "evict", stableItemId: "item-1" }],
@@ -46,7 +47,15 @@ test("normalizeTokenPilotCodexConfig preserves context rewrite plan revisions", 
   });
 
   assert.equal(config.contextRewrite.mutationPlan?.baseRevision, "rev-base");
+  assert.equal(config.contextRewrite.providerCompatibilityProbe, "mock_fixture");
   assert.deepEqual(config.contextRewrite.mutationPlan?.operations, [
     { type: "evict", stableItemId: "item-1" },
   ]);
+});
+
+test("normalizeTokenPilotCodexConfig disables provider compatibility probing by default", () => {
+  assert.equal(
+    normalizeTokenPilotCodexConfig({}).contextRewrite.providerCompatibilityProbe,
+    "disabled",
+  );
 });

--- a/components/adapters/codex/tests/context-history-journal.test.ts
+++ b/components/adapters/codex/tests/context-history-journal.test.ts
@@ -9,10 +9,12 @@ import { pathToFileURL } from "node:url";
 import {
   appendCodexRequestJournalEntry,
   appendCodexResponseJournalEntry,
+  buildCodexEffectiveHistory,
   codexContextHistoryJournalPath,
   codexContextHistoryJournalLockPath,
   loadCodexContextHistoryJournal,
   readCodexContextHistoryJournal,
+  recoverCodexContextHistoryJournalTail,
 } from "../src/context-history/index.js";
 
 async function withTempState(
@@ -419,7 +421,7 @@ test("CDH-01 stale journal lock recovery uses a claim before concurrent appends"
   });
 });
 
-test("CDH-01 refuses to append after a malformed tail and preserves prior bytes", async () => {
+test("CDH-01 recovers a crash-truncated tail before the next append", async () => {
   await withTempState(async (stateDir) => {
     const sessionId = "codex-session-malformed-tail";
     const path = codexContextHistoryJournalPath(stateDir, sessionId);
@@ -430,24 +432,380 @@ test("CDH-01 refuses to append after a malformed tail and preserves prior bytes"
       payload: { input: [{ role: "user", content: "valid" }] },
       status: "completed",
     });
+    const validPrefix = await readFile(path);
     await appendFile(path, "{\"truncated\":", "utf8");
-    const before = await readFile(path, "utf8");
+    const recovery = await recoverCodexContextHistoryJournalTail(stateDir, sessionId);
 
+    assert.equal(recovery.status, "truncated");
+    assert.equal(recovery.reason, "malformed_trailing_record");
+    assert.equal(recovery.recoveredByteCount, Buffer.byteLength("{\"truncated\":"));
+    assert.match(recovery.tailSha256 ?? "", /^[a-f0-9]{64}$/);
+    assert.deepEqual(await readFile(path), validPrefix);
+    assert.deepEqual(await recoverCodexContextHistoryJournalTail(stateDir, sessionId), {
+      status: "not_needed",
+      recoveredByteCount: 0,
+    });
+
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-2",
+      response: { id: "response-2", output: [] },
+      status: "completed",
+    });
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.entries.length, 2);
+    assert.equal(journal.malformedLineCount, 0);
+  });
+});
+
+test("CDH-01 leaves missing, empty, and newline-terminated journals unchanged", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-tail-noop";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    assert.deepEqual(await recoverCodexContextHistoryJournalTail(stateDir, sessionId), {
+      status: "not_needed",
+      recoveredByteCount: 0,
+    });
+
+    await mkdir(dirname(path), { recursive: true });
+    for (const content of [Buffer.alloc(0), Buffer.from("\n", "utf8")]) {
+      await writeFile(path, content);
+      const before = await readFile(path);
+      assert.deepEqual(await recoverCodexContextHistoryJournalTail(stateDir, sessionId), {
+        status: "not_needed",
+        recoveredByteCount: 0,
+      });
+      assert.deepEqual(await readFile(path), before);
+    }
+  });
+});
+
+test("CDH-01 recovers a truncated first record before creating the first valid entry", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-truncated-first-record";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "{\"schema\":\"lightmem2.codex", "utf8");
+
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-after-empty-recovery",
+      payload: { input: [{ role: "user", content: "first complete entry" }] },
+      status: "completed",
+    });
+
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.readError, undefined);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(journal.entries.length, 1);
+    assert.equal(journal.entries[0]?.kind, "request");
+    assert.equal(journal.entries[0]?.requestId, "request-after-empty-recovery");
+  });
+});
+
+test("CDH-02 response append automatically recovers a crash-truncated tail", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-response-tail-recovery";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-before-response-crash",
+      payload: { input: [{ role: "user", content: "request before response" }] },
+      status: "completed",
+    });
+    await appendFile(path, "{\"partial_response\":", "utf8");
+
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-before-response-crash",
+      response: { id: "response-after-recovery", status: "completed", output: [] },
+      status: "completed",
+    });
+
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.deepEqual(journal.entries.map((entry) => entry.kind), ["request", "response"]);
+  });
+});
+
+test("CDH-01 request status advancement remains idempotent after tail recovery", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-tail-status-advance";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    const params = {
+      stateDir,
+      sessionId,
+      requestId: "request-status-advance",
+      payload: { input: [{ role: "user", content: "same request" }] },
+    };
+    await appendCodexRequestJournalEntry({ ...params, status: "pending" });
+    await appendFile(path, "{\"partial_terminal\":", "utf8");
+
+    await appendCodexRequestJournalEntry({ ...params, status: "completed" });
+    await appendCodexRequestJournalEntry({ ...params, status: "completed" });
+
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.deepEqual(journal.entries.map((entry) => entry.status), ["pending", "completed"]);
+  });
+});
+
+test("CDH-01 preserves a complete final record that only lacks its newline", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-missing-final-newline";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-complete",
+      payload: { input: [{ role: "user", content: "complete record" }] },
+      status: "completed",
+    });
+    const original = await readFile(path);
+    assert.equal(original.at(-1), 0x0a);
+    await writeFile(path, original.subarray(0, original.length - 1));
+
+    const recovery = await recoverCodexContextHistoryJournalTail(stateDir, sessionId);
+
+    assert.equal(recovery.status, "newline_appended");
+    assert.equal(recovery.reason, "complete_record_missing_newline");
+    assert.equal(recovery.recoveredByteCount, 0);
+    assert.deepEqual(await readFile(path), original);
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.entries.length, 1);
+    assert.equal(journal.malformedLineCount, 0);
+  });
+});
+
+test("CDH-01 does not repair a complete but non-canonical trailing record", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-invalid-canonical-tail";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-valid",
+      payload: { input: [{ role: "user", content: "valid" }] },
+      status: "completed",
+    });
+    await appendFile(path, JSON.stringify({
+      schema: "lightmem2.codex.context-history.request/v1",
+      kind: "request",
+      sessionId,
+      status: "completed",
+    }), "utf8");
+    const before = await readFile(path);
+
+    const recovery = await recoverCodexContextHistoryJournalTail(stateDir, sessionId);
+
+    assert.equal(recovery.status, "blocked");
+    assert.equal(recovery.reason, "invalid_trailing_record");
+    assert.deepEqual(await readFile(path), before);
+    await assert.rejects(
+      appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: "request-must-not-append",
+        payload: { input: [{ role: "user", content: "must not append" }] },
+      }),
+      /invalid Codex context-history journal/,
+    );
+  });
+});
+
+test("CDH-01 does not repair a tail when an earlier journal line is malformed", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-invalid-middle";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-valid",
+      payload: { input: [{ role: "user", content: "valid" }] },
+      status: "completed",
+    });
+    await appendFile(path, "not-json\n{\"truncated\":", "utf8");
+    const before = await readFile(path);
+
+    const recovery = await recoverCodexContextHistoryJournalTail(stateDir, sessionId);
+
+    assert.equal(recovery.status, "blocked");
+    assert.equal(recovery.reason, "invalid_prefix");
+    assert.deepEqual(await readFile(path), before);
     await assert.rejects(
       appendCodexResponseJournalEntry({
         stateDir,
         sessionId,
-        requestId: "request-2",
-        response: { id: "response-2", output: [] },
-        status: "completed",
+        requestId: "request-after-corruption",
+        response: { id: "response-after-corruption", output: [] },
       }),
-      /Refusing to append to invalid Codex context-history journal/,
+      /invalid Codex context-history journal/,
     );
+  });
+});
 
-    assert.equal(await readFile(path, "utf8"), before);
+test("CDH-01 keeps a malformed middle line fail-closed even when later records are canonical", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-malformed-middle-with-valid-tail";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-before-middle-corruption",
+      payload: { input: [{ role: "user", content: "before corruption" }] },
+      status: "completed",
+    });
+    const canonicalResponse = {
+      schema: "lightmem2.codex.context-history.response/v1",
+      kind: "response",
+      requestId: "request-before-middle-corruption",
+      sessionId,
+      responseId: "response-after-middle-corruption",
+      previousResponseId: null,
+      stream: false,
+      outputItems: [],
+      outputItemRefs: [],
+      status: "completed",
+      observedAt: "2026-08-06T00:00:00.000Z",
+    };
+    await appendFile(path, `not-json\n${JSON.stringify(canonicalResponse)}\n`, "utf8");
+    const before = await readFile(path);
+
+    assert.deepEqual(await recoverCodexContextHistoryJournalTail(stateDir, sessionId), {
+      status: "not_needed",
+      recoveredByteCount: 0,
+    });
+    assert.deepEqual(await readFile(path), before);
     const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
-    assert.equal(journal.entries.length, 1);
+    assert.equal(journal.entries.length, 2);
     assert.equal(journal.malformedLineCount, 1);
+    await assert.rejects(
+      appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: "request-after-middle-corruption",
+        payload: { input: [{ role: "user", content: "must not append" }] },
+      }),
+      /invalid Codex context-history journal/,
+    );
+  });
+});
+
+test("CDH-01 recovers a partial UTF-8 tail once while concurrent writers wait on the session lock", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-utf8-tail-concurrency";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-before-crash",
+      payload: { input: [{ role: "user", content: "before crash" }] },
+      status: "completed",
+    });
+    await appendFile(path, Buffer.from([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xe2, 0x82]));
+
+    await Promise.all(Array.from({ length: 12 }, (_, index) => appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: `request-after-recovery-${index}`,
+      payload: { input: [{ role: "user", content: `after recovery ${index}` }] },
+      status: "completed",
+    })));
+
+    const raw = await readFile(path, "utf8");
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.doesNotMatch(raw, /\uFFFD/);
+    assert.equal(journal.readError, undefined);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(journal.entries.length, 13);
+  });
+});
+
+test("CDH-01 serializes crash-tail recovery across writer processes", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-cross-process-tail-recovery";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-before-process-crash",
+      payload: { input: [{ role: "user", content: "before process crash" }] },
+      status: "completed",
+    });
+    await appendFile(path, "{\"cross_process_partial\":", "utf8");
+
+    const processCount = 3;
+    const recordsPerProcess = 4;
+    await Promise.all(Array.from({ length: processCount }, (_, index) => runJournalWriterProcess({
+      stateDir,
+      sessionId,
+      prefix: `recovery-writer-${index}`,
+      count: recordsPerProcess,
+    })));
+
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    const requests = journal.entries.filter((entry) => entry.kind === "request");
+    assert.equal(journal.readError, undefined);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(requests.length, 1 + processCount * recordsPerProcess);
+    assert.equal(new Set(requests.map((entry) => entry.requestId)).size, requests.length);
+  });
+});
+
+test("CDH-01 effective history repairs a crash tail during restart recovery", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-restart-tail-recovery";
+    const path = codexContextHistoryJournalPath(stateDir, sessionId);
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-root",
+      payload: {
+        input: [
+          { role: "user", content: "history before crash" },
+          { type: "function_call", call_id: "call-root", name: "inspect", arguments: "{}" },
+          { type: "function_call_output", call_id: "call-root", output: "ok" },
+        ],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-root",
+      response: {
+        id: "response-root",
+        status: "completed",
+        output: [{ id: "message-root", type: "message", role: "assistant", content: [] }],
+      },
+      previousResponseId: null,
+      status: "completed",
+    });
+    const beforeCrash = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: "response-root",
+    });
+    await appendFile(path, "{\"crash_tail\":", "utf8");
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: "response-root",
+    });
+
+    assert.equal(history.incomplete, false);
+    assert.match(JSON.stringify(history.replayableItems), /history before crash/);
+    assert.deepEqual(history.unresolvedCallIds, []);
+    assert.equal(history.revision, beforeCrash.revision);
+    assert.deepEqual(history.replayableItems, beforeCrash.replayableItems);
+    const journal = await readCodexContextHistoryJournal(stateDir, sessionId);
+    assert.equal(journal.malformedLineCount, 0);
+    assert.equal(journal.entries.length, 2);
   });
 });
 
@@ -456,6 +814,12 @@ test("CDH-01 fails closed when the context-history journal cannot be read", asyn
     const sessionId = "codex-session-read-error";
     const path = codexContextHistoryJournalPath(stateDir, sessionId);
     await mkdir(path, { recursive: true });
+
+    assert.deepEqual(await recoverCodexContextHistoryJournalTail(stateDir, sessionId), {
+      status: "blocked",
+      reason: "read_error",
+      recoveredByteCount: 0,
+    });
 
     await assert.rejects(
       appendCodexRequestJournalEntry({

--- a/components/adapters/codex/tests/context-history-replayability.test.ts
+++ b/components/adapters/codex/tests/context-history-replayability.test.ts
@@ -105,6 +105,23 @@ test("CDH-05 Replayability defers compaction without its exact encrypted payload
   assert.equal(isCodexDeferredItem(compaction), true);
 });
 
+test("CDH-05 Replayability separates exact encrypted payloads from malformed payloads", () => {
+  for (const type of ["reasoning", "compaction"] as const) {
+    assertReplayability(
+      { type, encrypted_content: `exact-${type}` },
+      "replayable",
+      "exact_payload_required",
+    );
+    for (const encrypted_content of ["", "   ", 42, { opaque: true }]) {
+      assertReplayability(
+        { type, encrypted_content },
+        "deferred",
+        "exact_payload_missing",
+      );
+    }
+  }
+});
+
 test("CDH-05 Replayability defers unknown provider item types", () => {
   const item = { type: "future_provider_item", payload: "opaque" };
 

--- a/components/adapters/codex/tests/context-reasoning-replay.test.ts
+++ b/components/adapters/codex/tests/context-reasoning-replay.test.ts
@@ -13,6 +13,10 @@ import {
 import {
   appendCodexRebaseCapability,
   buildCodexRebaseRequest,
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
+  codexRebaseEndpointIdentity,
   executeCodexRebaseWithFallback,
 } from "../src/context-rewrite/index.js";
 
@@ -272,8 +276,13 @@ test("CDR-05 known unsupported reasoning replay bypasses before opening a rebase
       stateDir,
       provider: "OpenAI",
       model: fixture.model,
+      wireMode: CODEX_REBASE_WIRE_MODE,
+      apiVersion: CODEX_REBASE_API_VERSION,
+      endpointId: codexRebaseEndpointIdentity("https://api.openai.example/v1"),
       itemType: "reasoning",
-      status: "unsupported",
+      itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+      status: "verified_unsupported",
+      evidence: "real_provider",
       reason: "schema_error",
     });
     const originalPayload: JsonObject = {
@@ -292,7 +301,15 @@ test("CDR-05 known unsupported reasoning replay bypasses before opening a rebase
       epochId: "epoch-reasoning-known-unsupported",
       originalPayload,
       rebasedPayload,
-      capabilityStore: { stateDir, provider: "OpenAI", model: fixture.model },
+      capabilityStore: {
+        stateDir,
+        provider: "OpenAI",
+        model: fixture.model,
+        wireMode: CODEX_REBASE_WIRE_MODE,
+        apiVersion: CODEX_REBASE_API_VERSION,
+        endpointId: codexRebaseEndpointIdentity("https://api.openai.example/v1"),
+        itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+      },
       async sendUpstream(payload) {
         sentPayloads.push(payload);
         return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
@@ -300,7 +317,8 @@ test("CDR-05 known unsupported reasoning replay bypasses before opening a rebase
     });
 
     assert.equal(result.outcome, "bypassed");
-    assert.deepEqual(result.capability?.skippedItemTypes, ["reasoning"]);
+    assert.deepEqual(result.capability?.unsupportedItemTypes, ["reasoning"]);
+    assert.deepEqual(result.capability?.skippedItemTypes, ["reasoning", "message"]);
     assert.deepEqual(sentPayloads, [originalPayload]);
   });
 });

--- a/components/adapters/codex/tests/context-rebase-capability.test.ts
+++ b/components/adapters/codex/tests/context-rebase-capability.test.ts
@@ -1,17 +1,26 @@
 import assert from "node:assert/strict";
-import { appendFile, mkdtemp, rm } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import test from "node:test";
 
 import {
   appendCodexRebaseCapability,
+  classifyCodexRebaseCapabilityRejection,
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_CAPABILITY_LEGACY_SCHEMA,
   CODEX_REBASE_CAPABILITY_SCHEMA,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
   codexRebaseCapabilityJournalPath,
+  codexRebaseEndpointIdentity,
+  codexRebasePayloadItems,
   executeCodexRebaseWithFallback,
   readCodexRebaseCapabilityJournal,
   readCodexRebaseEpochJournal,
-  readUnsupportedCodexRebaseItemTypes,
+  resolveCodexProviderReplayCompatibility,
+  type CodexRebaseCapabilityEvidence,
+  type CodexRebaseCapabilityStoreParams,
   type JsonObject,
 } from "../src/context-rewrite/index.js";
 
@@ -26,122 +35,293 @@ async function withTempState(
   }
 }
 
-test("CDR-05 Provider Capability Cache stores support status by provider, model, and item type", async () => {
+function capabilityStore(
+  stateDir: string,
+  model = "gpt-5.4-mini",
+  options: Partial<CodexRebaseCapabilityStoreParams> = {},
+): CodexRebaseCapabilityStoreParams {
+  return {
+    stateDir,
+    provider: "OpenAI",
+    model,
+    wireMode: CODEX_REBASE_WIRE_MODE,
+    apiVersion: CODEX_REBASE_API_VERSION,
+    endpointId: codexRebaseEndpointIdentity("https://api.openai.example/v1"),
+    itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+    ...options,
+  };
+}
+
+async function appendCapability(params: {
+  stateDir: string;
+  model?: string;
+  itemType: string;
+  status: "verified_supported" | "verified_unsupported" | "payload_rejected";
+  evidence?: CodexRebaseCapabilityEvidence;
+  payloadDigest?: string;
+  reason?: string;
+  observedAt?: string;
+  ttlMs?: number;
+  storeOverrides?: Partial<CodexRebaseCapabilityStoreParams>;
+}) {
+  const store = capabilityStore(params.stateDir, params.model, params.storeOverrides);
+  return appendCodexRebaseCapability({
+    ...store,
+    itemType: params.itemType,
+    status: params.status,
+    evidence: params.evidence ?? "real_provider",
+    payloadDigest: params.payloadDigest,
+    reason: params.reason,
+    observedAt: params.observedAt,
+    ttlMs: params.ttlMs,
+  });
+}
+
+async function decisionsFor(params: {
+  stateDir: string;
+  payload: JsonObject;
+  model?: string;
+  now?: string;
+  acceptedEvidence?: CodexRebaseCapabilityEvidence[];
+  storeOverrides?: Partial<CodexRebaseCapabilityStoreParams>;
+}) {
+  const store = capabilityStore(params.stateDir, params.model, params.storeOverrides);
+  return resolveCodexProviderReplayCompatibility({
+    ...store,
+    items: codexRebasePayloadItems(params.payload),
+    now: params.now,
+    acceptedEvidence: params.acceptedEvidence,
+  });
+}
+
+test("CDR-05 Provider Compatibility binds decisions to provider, model, wire, API, endpoint, item schema, and TTL", async () => {
   await withTempState(async (stateDir) => {
-    await appendCodexRebaseCapability({
+    await appendCapability({
       stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4-mini",
-      itemType: "web_search_call",
-      status: "unsupported",
-      reason: "schema_error",
-      observedAt: "2026-07-28T10:00:00.000Z",
+      itemType: "message",
+      status: "verified_supported",
+      observedAt: "2026-08-06T00:00:00.000Z",
+      ttlMs: 60_000,
     });
 
-    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
+    const supported = await decisionsFor({
       stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4-mini",
-      itemTypes: ["message", "web_search_call"],
-    }), ["web_search_call"]);
-
-    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
-      stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4",
-      itemTypes: ["web_search_call"],
-    }), []);
-
-    await appendCodexRebaseCapability({
-      stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4-mini",
-      itemType: "web_search_call",
-      status: "supported",
-      reason: "rebase_committed",
-      observedAt: "2026-07-28T10:01:00.000Z",
+      payload: { input: [{ role: "user", content: "current" }] },
+      now: "2026-08-06T00:00:30.000Z",
     });
+    assert.equal(supported.journalTrusted, true);
+    assert.equal(supported.decisions[0]?.status, "verified_supported");
+    assert.equal(supported.decisions[0]?.evidence, "real_provider");
 
-    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
+    const expired = await decisionsFor({
       stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4-mini",
-      itemTypes: ["web_search_call"],
-    }), []);
+      payload: { input: [{ role: "user", content: "current" }] },
+      now: "2026-08-06T00:01:01.000Z",
+    });
+    assert.equal(expired.decisions[0]?.status, "unknown_probe_required");
+    assert.equal(expired.decisions[0]?.reason, "capability_expired");
 
-    const journal = await readCodexRebaseCapabilityJournal(stateDir);
-    assert.equal(journal.capabilities.length, 1);
-    assert.equal(journal.capabilities[0]?.status, "supported");
+    for (const storeOverrides of [
+      { apiVersion: "responses/v2" },
+      { wireMode: "chat_completions" },
+      { endpointId: codexRebaseEndpointIdentity("https://other.example/v1") },
+      { itemSchemaVersion: "responses-item/v2" },
+    ]) {
+      const changed = await decisionsFor({
+        stateDir,
+        payload: { input: [{ role: "user", content: "current" }] },
+        now: "2026-08-06T00:00:30.000Z",
+        storeOverrides,
+      });
+      assert.equal(changed.decisions[0]?.status, "unknown_probe_required");
+      assert.equal(changed.decisions[0]?.reason, "capability_not_observed");
+    }
   });
 });
 
-test("CDR-05 Provider Capability Cache records only malformed rows as malformed", async () => {
+test("CDR-05 Provider Compatibility supports supported, unsupported, and revalidated-supported transitions", async () => {
   await withTempState(async (stateDir) => {
-    await appendCodexRebaseCapability({
+    for (const [status, observedAt] of [
+      ["verified_supported", "2026-08-06T00:00:00.000Z"],
+      ["verified_unsupported", "2026-08-06T00:01:00.000Z"],
+      ["verified_supported", "2026-08-06T00:02:00.000Z"],
+    ] as const) {
+      await appendCapability({ stateDir, itemType: "reasoning", status, observedAt });
+    }
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(journal.entries.length, 3);
+    assert.equal(journal.capabilities.length, 1);
+    assert.equal(journal.capabilities[0]?.status, "verified_supported");
+    const result = await decisionsFor({
       stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4-mini",
-      itemType: "reasoning",
-      status: "unsupported",
-      observedAt: "2026-07-28T10:00:00.000Z",
+      payload: { input: [{ type: "reasoning", encrypted_content: "exact" }] },
+      now: "2026-08-06T00:03:00.000Z",
     });
+    assert.equal(result.decisions[0]?.status, "verified_supported");
+  });
+});
+
+test("CDR-05 Provider Compatibility treats mock evidence as distinct from real-provider verification", async () => {
+  await withTempState(async (stateDir) => {
+    await appendCapability({
+      stateDir,
+      itemType: "reasoning",
+      status: "verified_supported",
+      evidence: "mock_fixture",
+    });
+    const payload = { input: [{ type: "reasoning", encrypted_content: "exact" }] };
+    const realDecision = await decisionsFor({ stateDir, payload });
+    assert.equal(realDecision.decisions[0]?.status, "unknown_probe_required");
+    assert.equal(realDecision.decisions[0]?.reason, "mock_fixture_not_provider_verified");
+
+    const mockDecision = await decisionsFor({
+      stateDir,
+      payload,
+      acceptedEvidence: ["real_provider", "mock_fixture"],
+    });
+    assert.equal(mockDecision.decisions[0]?.status, "verified_supported");
+    assert.equal(mockDecision.decisions[0]?.evidence, "mock_fixture");
+  });
+});
+
+test("CDR-05 Provider Compatibility isolates legacy rows and fails closed on malformed or unreadable journals", async () => {
+  await withTempState(async (stateDir) => {
+    await mkdir(dirname(codexRebaseCapabilityJournalPath(stateDir)), { recursive: true });
     await appendFile(
       codexRebaseCapabilityJournalPath(stateDir),
-      [
-        "not-json",
-        "{\"schema\":\"wrong\"}",
-        JSON.stringify({
-          schema: CODEX_REBASE_CAPABILITY_SCHEMA,
-          provider: "OpenAI",
-          model: "gpt-5.4-mini",
-          itemType: "custom_tool_call",
-          status: "unsupported",
-          observedAt: "bad-time",
-        }),
-        "",
-      ].join("\n"),
+      `${JSON.stringify({
+        schema: CODEX_REBASE_CAPABILITY_LEGACY_SCHEMA,
+        provider: "OpenAI",
+        model: "gpt-5.4-mini",
+        itemType: "message",
+        status: "supported",
+        observedAt: "2026-08-06T00:00:00.000Z",
+      })}\n`,
       "utf8",
     );
+    const legacy = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(legacy.staleLineCount, 1);
+    assert.equal(legacy.malformedLineCount, 0);
+    const legacyDecision = await decisionsFor({ stateDir, payload: { input: [{ role: "user", content: "x" }] } });
+    assert.equal(legacyDecision.decisions[0]?.reason, "legacy_capability_not_reused");
 
-    const journal = await readCodexRebaseCapabilityJournal(stateDir);
-    assert.equal(journal.entries.length, 1);
-    assert.equal(journal.capabilities.length, 1);
-    assert.equal(journal.malformedLineCount, 3);
+    await appendFile(codexRebaseCapabilityJournalPath(stateDir), "not-json\n", "utf8");
+    const malformed = await decisionsFor({ stateDir, payload: { input: [{ role: "user", content: "x" }] } });
+    assert.equal(malformed.journalTrusted, false);
+    assert.equal(malformed.decisions[0]?.reason, "capability_journal_untrusted");
+  });
+
+  await withTempState(async (stateDir) => {
+    await mkdir(codexRebaseCapabilityJournalPath(stateDir), { recursive: true });
+    const unreadable = await decisionsFor({ stateDir, payload: { input: [{ role: "user", content: "x" }] } });
+    assert.equal(unreadable.journalTrusted, false);
+    assert.equal(unreadable.decisions[0]?.reason, "capability_journal_untrusted");
   });
 });
 
-test("CDR-05 Provider Capability Cache learns 400 schema item rejection and skips later rebase attempts", async () => {
+test("CDR-05 unknown compatibility bypasses before opening an epoch", async () => {
+  await withTempState(async (stateDir) => {
+    const originalPayload = { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
+    const rebasedPayload = { model: "gpt-5.4-mini", input: [{ role: "user", content: "current" }] };
+    const sentPayloads: JsonObject[] = [];
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-unknown",
+      planId: "plan-unknown",
+      epochId: "epoch-unknown",
+      originalPayload,
+      rebasedPayload,
+      epochStore: { stateDir, oldPreviousResponseId: "resp-old", oldRevision: "rev-old" },
+      capabilityStore: capabilityStore(stateDir),
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.capability?.reason, "provider_replay_probe_required");
+    assert.deepEqual(sentPayloads, [originalPayload]);
+    assert.equal((await readCodexRebaseEpochJournal(stateDir, "codex-session-unknown")).entries.length, 0);
+
+    await appendCapability({
+      stateDir,
+      itemType: "message",
+      status: "verified_unsupported",
+      reason: "item_schema_unsupported",
+    });
+    const unsupportedPayloads: JsonObject[] = [];
+    const unsupported = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-unsupported",
+      planId: "plan-unsupported",
+      epochId: "epoch-unsupported",
+      originalPayload,
+      rebasedPayload,
+      epochStore: { stateDir, oldPreviousResponseId: "resp-old", oldRevision: "rev-old" },
+      capabilityStore: capabilityStore(stateDir),
+      async sendUpstream(payload) {
+        unsupportedPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-unsupported", output: [] }) };
+      },
+    });
+    assert.equal(unsupported.outcome, "bypassed");
+    assert.deepEqual(unsupported.capability?.unsupportedItemTypes, ["message"]);
+    assert.deepEqual(unsupportedPayloads, [originalPayload]);
+    assert.equal((await readCodexRebaseEpochJournal(stateDir, "codex-session-unsupported")).entries.length, 0);
+  });
+});
+
+test("CDR-05 an untrusted capability journal bypasses before opening an epoch", async () => {
+  await withTempState(async (stateDir) => {
+    await mkdir(dirname(codexRebaseCapabilityJournalPath(stateDir)), { recursive: true });
+    await appendFile(codexRebaseCapabilityJournalPath(stateDir), "not-json\n", "utf8");
+    const originalPayload = { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
+    const sentPayloads: JsonObject[] = [];
+    const result = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-untrusted",
+      planId: "plan-untrusted",
+      epochId: "epoch-untrusted",
+      originalPayload,
+      rebasedPayload: { model: "gpt-5.4-mini", input: [{ role: "user", content: "current" }] },
+      epochStore: { stateDir, oldPreviousResponseId: "resp-old", oldRevision: "rev-old" },
+      capabilityStore: capabilityStore(stateDir, undefined, { probeMode: "mock_fixture" }),
+      async sendUpstream(payload) {
+        sentPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+      },
+    });
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.capability?.reason, "capability_journal_untrusted");
+    assert.deepEqual(sentPayloads, [originalPayload]);
+    assert.equal((await readCodexRebaseEpochJournal(stateDir, "codex-session-untrusted")).entries.length, 0);
+  });
+});
+
+test("CDR-05 explicit item schema rejection records only the named item and skips later probes", async () => {
   await withTempState(async (stateDir) => {
     const originalPayload = { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
     const rebasedPayload = { model: "gpt-5.4-mini", input: [{ type: "web_search_call", query: "not replayable" }, { role: "user", content: "current" }] };
-    const sentPayloads: JsonObject[] = [];
-
+    const store = capabilityStore(stateDir, undefined, { probeMode: "mock_fixture" });
+    const firstPayloads: JsonObject[] = [];
     const first = await executeCodexRebaseWithFallback({
       sessionId: "codex-session-capability",
       planId: "plan-capability",
       epochId: "epoch-capability",
       originalPayload,
       rebasedPayload,
-      capabilityStore: {
-        stateDir,
-        provider: "OpenAI",
-        model: "gpt-5.4-mini",
-      },
+      capabilityStore: store,
       async sendUpstream(payload) {
-        sentPayloads.push(payload);
-        return sentPayloads.length === 1
+        firstPayloads.push(payload);
+        return firstPayloads.length === 1
           ? {
             status: 400,
             headers: { "content-type": "application/json" },
-            text: JSON.stringify({ error: { code: "invalid_request_error", message: "Unsupported item type: web_search_call" } }),
+            text: JSON.stringify({ error: { code: "unsupported_item_type", message: "Unsupported item type: web_search_call" } }),
           }
           : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
       },
     });
-
     assert.equal(first.outcome, "bypassed");
     assert.deepEqual(first.capability?.unsupportedItemTypes, ["web_search_call"]);
-    assert.equal(sentPayloads.length, 2);
+    assert.deepEqual(firstPayloads, [rebasedPayload, originalPayload]);
 
     const secondPayloads: JsonObject[] = [];
     const second = await executeCodexRebaseWithFallback({
@@ -150,158 +330,135 @@ test("CDR-05 Provider Capability Cache learns 400 schema item rejection and skip
       epochId: "epoch-capability-next",
       originalPayload,
       rebasedPayload,
-      capabilityStore: {
-        stateDir,
-        provider: "OpenAI",
-        model: "gpt-5.4-mini",
-      },
+      capabilityStore: store,
       async sendUpstream(payload) {
         secondPayloads.push(payload);
         return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-2", output: [] }) };
       },
     });
-
     assert.equal(second.outcome, "bypassed");
-    assert.equal(second.rebaseResponse, undefined);
-    assert.deepEqual(second.capability?.skippedItemTypes, ["web_search_call"]);
+    assert.deepEqual(second.capability?.unsupportedItemTypes, ["web_search_call"]);
     assert.deepEqual(secondPayloads, [originalPayload]);
   });
 });
 
-test("CDR-05 Provider Capability Cache falls back and remembers encrypted compaction rejection", async () => {
+test("CDR-05 encrypted payload rejection is scoped to the exact payload and does not poison the item capability", async () => {
   await withTempState(async (stateDir) => {
-    const originalPayload = {
+    const originalPayload = { model: "gpt-5.6-sol", previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
+    const rejectedPayload = {
       model: "gpt-5.6-sol",
-      previous_response_id: "resp-old",
-      input: [{ role: "user", content: "current" }],
+      input: [{ type: "compaction", encrypted_content: "provider-bound-old" }, { role: "user", content: "current" }],
     };
-    const rebasedPayload = {
-      model: "gpt-5.6-sol",
-      input: [
-        { type: "compaction", encrypted_content: "provider-bound-payload" },
-        { role: "user", content: "current" },
-      ],
-    };
-    const firstPayloads: JsonObject[] = [];
+    const store = capabilityStore(stateDir, "gpt-5.6-sol", { probeMode: "mock_fixture" });
+    let calls = 0;
     const first = await executeCodexRebaseWithFallback({
-      sessionId: "codex-session-compaction-capability",
-      planId: "plan-compaction-capability",
-      epochId: "epoch-compaction-capability",
+      sessionId: "codex-session-payload",
+      planId: "plan-payload",
+      epochId: "epoch-payload",
       originalPayload,
-      rebasedPayload,
-      capabilityStore: {
-        stateDir,
-        provider: "OpenAI",
-        model: "gpt-5.6-sol",
-      },
-      async sendUpstream(payload) {
-        firstPayloads.push(payload);
-        return firstPayloads.length === 1
+      rebasedPayload: rejectedPayload,
+      capabilityStore: store,
+      async sendUpstream() {
+        calls += 1;
+        return calls === 1
           ? {
             status: 400,
-            headers: { "content-type": "application/json" },
-            text: JSON.stringify({
-              error: {
-                code: "invalid_encrypted_content",
-                message: "Unsupported compaction encrypted content",
-              },
-            }),
+            headers: {},
+            text: JSON.stringify({ error: { code: "invalid_encrypted_content", message: "Compaction encrypted payload lineage expired" } }),
           }
           : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
       },
     });
+    assert.deepEqual(first.capability?.payloadRejectedItemTypes, ["compaction"]);
 
-    assert.equal(first.outcome, "bypassed");
-    assert.deepEqual(first.capability?.unsupportedItemTypes, ["compaction"]);
-    assert.deepEqual(firstPayloads, [rebasedPayload, originalPayload]);
-
-    const secondPayloads: JsonObject[] = [];
-    const second = await executeCodexRebaseWithFallback({
-      sessionId: "codex-session-compaction-capability",
-      planId: "plan-compaction-capability-next",
-      epochId: "epoch-compaction-capability-next",
+    const samePayloads: JsonObject[] = [];
+    const same = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-payload",
+      planId: "plan-payload-same",
+      epochId: "epoch-payload-same",
       originalPayload,
-      rebasedPayload,
-      capabilityStore: {
-        stateDir,
-        provider: "OpenAI",
-        model: "gpt-5.6-sol",
-      },
+      rebasedPayload: rejectedPayload,
+      capabilityStore: store,
       async sendUpstream(payload) {
-        secondPayloads.push(payload);
-        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-next", output: [] }) };
+        samePayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-same", output: [] }) };
       },
     });
+    assert.equal(same.outcome, "bypassed");
+    assert.deepEqual(same.capability?.payloadRejectedItemTypes, ["compaction"]);
+    assert.deepEqual(samePayloads, [originalPayload]);
 
-    assert.equal(second.outcome, "bypassed");
-    assert.deepEqual(second.capability?.skippedItemTypes, ["compaction"]);
-    assert.deepEqual(secondPayloads, [originalPayload]);
+    const freshPayload = {
+      model: "gpt-5.6-sol",
+      input: [{ type: "compaction", encrypted_content: "provider-bound-fresh" }, { role: "user", content: "current" }],
+    };
+    const freshPayloads: JsonObject[] = [];
+    const fresh = await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-payload",
+      planId: "plan-payload-fresh",
+      epochId: "epoch-payload-fresh",
+      originalPayload,
+      rebasedPayload: freshPayload,
+      capabilityStore: store,
+      async sendUpstream(payload) {
+        freshPayloads.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-rebased-fresh", output: [] }) };
+      },
+    });
+    assert.equal(fresh.outcome, "committed");
+    assert.deepEqual(freshPayloads, [freshPayload]);
   });
 });
 
-test("CDR-05 Provider Capability Cache skips unsupported rebases before opening an epoch", async () => {
+test("CDR-05 ambiguous multi-item rejection does not mark every item unsupported", async () => {
+  const payload = {
+    input: [
+      { type: "reasoning", encrypted_content: "reasoning" },
+      { type: "compaction", encrypted_content: "compaction" },
+    ],
+  };
+  const classification = classifyCodexRebaseCapabilityRejection({
+    response: {
+      status: 400,
+      headers: {},
+      text: JSON.stringify({ error: { code: "invalid_request_error", message: "Input schema is not supported" } }),
+    },
+    items: codexRebasePayloadItems(payload),
+  });
+  assert.equal(classification.kind, "ambiguous");
+  assert.deepEqual(classification.itemTypes, []);
+
   await withTempState(async (stateDir) => {
-    await appendCodexRebaseCapability({
-      stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4-mini",
-      itemType: "web_search_call",
-      status: "unsupported",
-      reason: "schema_error",
-      observedAt: "2026-07-28T10:00:00.000Z",
-    });
-
-    const originalPayload = { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [{ role: "user", content: "current" }] };
-    const rebasedPayload = { model: "gpt-5.4-mini", input: [{ type: "web_search_call", query: "not replayable" }, { role: "user", content: "current" }] };
-    const sentPayloads: JsonObject[] = [];
-
-    const result = await executeCodexRebaseWithFallback({
-      sessionId: "codex-session-capability-epoch",
-      planId: "plan-capability-epoch",
-      epochId: "epoch-capability-epoch",
-      originalPayload,
-      rebasedPayload,
-      epochStore: {
-        stateDir,
-        oldPreviousResponseId: "resp-old",
-        oldRevision: "rev-old",
-      },
-      capabilityStore: {
-        stateDir,
-        provider: "OpenAI",
-        model: "gpt-5.4-mini",
-      },
-      async sendUpstream(payload) {
-        sentPayloads.push(payload);
-        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
+    let calls = 0;
+    await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-ambiguous",
+      planId: "plan-ambiguous",
+      epochId: "epoch-ambiguous",
+      originalPayload: { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [] },
+      rebasedPayload: payload,
+      capabilityStore: capabilityStore(stateDir, undefined, { probeMode: "mock_fixture" }),
+      async sendUpstream() {
+        calls += 1;
+        return calls === 1
+          ? { status: 400, headers: {}, text: JSON.stringify({ error: { code: "invalid_request_error", message: "Input schema is not supported" } }) }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original", output: [] }) };
       },
     });
-
-    assert.equal(result.outcome, "bypassed");
-    assert.equal(result.rebaseResponse, undefined);
-    assert.deepEqual(result.capability?.skippedItemTypes, ["web_search_call"]);
-    assert.deepEqual(sentPayloads, [originalPayload]);
-
-    const epochJournal = await readCodexRebaseEpochJournal(stateDir, "codex-session-capability-epoch");
-    assert.equal(epochJournal.entries.length, 0);
+    assert.deepEqual((await readCodexRebaseCapabilityJournal(stateDir)).entries, []);
   });
 });
 
-test("CDR-05 Provider Capability Cache does not persist auth, rate limit, or 5xx failures as unsupported", async () => {
+test("CDR-05 auth, rate-limit, 5xx, and network failures do not pollute compatibility", async () => {
   await withTempState(async (stateDir) => {
-    for (const status of [401, 429, 500]) {
+    for (const status of [401, 403, 429, 500]) {
       let calls = 0;
       await executeCodexRebaseWithFallback({
         sessionId: `codex-session-${status}`,
         planId: `plan-${status}`,
         epochId: `epoch-${status}`,
         originalPayload: { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [] },
-        rebasedPayload: { model: "gpt-5.4-mini", input: [{ type: "web_search_call", query: "not replayable" }] },
-        capabilityStore: {
-          stateDir,
-          provider: "OpenAI",
-          model: "gpt-5.4-mini",
-        },
+        rebasedPayload: { model: "gpt-5.4-mini", input: [{ role: "user", content: "current" }] },
+        capabilityStore: capabilityStore(stateDir, undefined, { probeMode: "mock_fixture" }),
         async sendUpstream() {
           calls += 1;
           return calls === 1
@@ -310,17 +467,25 @@ test("CDR-05 Provider Capability Cache does not persist auth, rate limit, or 5xx
         },
       });
     }
-
-    assert.deepEqual(await readUnsupportedCodexRebaseItemTypes({
-      stateDir,
-      provider: "OpenAI",
-      model: "gpt-5.4-mini",
-      itemTypes: ["web_search_call"],
-    }), []);
+    let networkCalls = 0;
+    await executeCodexRebaseWithFallback({
+      sessionId: "codex-session-network",
+      planId: "plan-network",
+      epochId: "epoch-network",
+      originalPayload: { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [] },
+      rebasedPayload: { model: "gpt-5.4-mini", input: [{ role: "user", content: "current" }] },
+      capabilityStore: capabilityStore(stateDir, undefined, { probeMode: "mock_fixture" }),
+      async sendUpstream() {
+        networkCalls += 1;
+        if (networkCalls === 1) throw new Error("network unavailable");
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-original-network", output: [] }) };
+      },
+    });
+    assert.deepEqual((await readCodexRebaseCapabilityJournal(stateDir)).entries, []);
   });
 });
 
-test("CDR-05 Provider Capability Cache records supported item types after committed rebase", async () => {
+test("CDR-05 explicit mock probe records mock evidence without claiming real-provider support", async () => {
   await withTempState(async (stateDir) => {
     const result = await executeCodexRebaseWithFallback({
       sessionId: "codex-session-supported",
@@ -328,21 +493,21 @@ test("CDR-05 Provider Capability Cache records supported item types after commit
       epochId: "epoch-supported",
       originalPayload: { model: "gpt-5.4-mini", previous_response_id: "resp-old", input: [] },
       rebasedPayload: { model: "gpt-5.4-mini", input: [{ role: "user", content: "current" }] },
-      capabilityStore: {
-        stateDir,
-        provider: "OpenAI",
-        model: "gpt-5.4-mini",
-      },
+      capabilityStore: capabilityStore(stateDir, undefined, { probeMode: "mock_fixture" }),
       async sendUpstream() {
         return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-rebased", output: [] }) };
       },
     });
-
     assert.equal(result.outcome, "committed");
-
     const journal = await readCodexRebaseCapabilityJournal(stateDir);
-    assert.equal(journal.capabilities.length, 1);
-    assert.equal(journal.capabilities[0]?.itemType, "message");
-    assert.equal(journal.capabilities[0]?.status, "supported");
+    assert.equal(journal.capabilities[0]?.status, "verified_supported");
+    assert.equal(journal.capabilities[0]?.evidence, "mock_fixture");
+    assert.equal(journal.capabilities[0]?.schema, CODEX_REBASE_CAPABILITY_SCHEMA);
+
+    const realDecision = await decisionsFor({
+      stateDir,
+      payload: { input: [{ role: "user", content: "current" }] },
+    });
+    assert.equal(realDecision.decisions[0]?.status, "unknown_probe_required");
   });
 });

--- a/components/adapters/codex/tests/context-rebase-pipeline.test.ts
+++ b/components/adapters/codex/tests/context-rebase-pipeline.test.ts
@@ -368,6 +368,7 @@ test("CDR-06 proxy pipeline rebases a non-stream request from effective history"
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -494,6 +495,7 @@ test("CDR-06 proxy bootstraps a rebase from the hook-persisted Codex rollout", a
       modules: { stabilizer: false, reduction: false },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -614,6 +616,7 @@ test("CDH-01 proxy bypasses context-history journaling when the journal cannot b
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -666,6 +669,7 @@ test("CDR-01 proxy pipeline defers stale mutation plans", async () => {
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -741,6 +745,7 @@ test("CDR-06 proxy pipeline falls back and cools down rejected rebases", async (
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -857,6 +862,7 @@ test("CDR-04 fallback keeps non-rebase before-call reductions", async () => {
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -943,6 +949,7 @@ test("CDR-06 proxy pipeline falls back and cools down rejected stream rebases", 
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -1115,6 +1122,7 @@ test("CDR-06 proxy pipeline journals current input before reduction", async () =
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -1182,6 +1190,7 @@ test("CDR-06 committed rebase history starts from the new response chain root", 
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -1269,6 +1278,7 @@ test("CDR-06 mock smoke keeps five turns on the new response chain", async () =>
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -1375,6 +1385,7 @@ test("CDR-06 proxy restart keeps the committed rebase response chain", async () 
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,
@@ -1448,6 +1459,7 @@ test("CDR-06 proxy restart keeps the committed rebase response chain", async () 
       },
       contextRewrite: {
         enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
         mode: "response_chain_rebase",
         failureMode: "bypass",
         retryOriginalRequest: true,

--- a/components/adapters/codex/tests/context-rebase-provider-smoke.test.ts
+++ b/components/adapters/codex/tests/context-rebase-provider-smoke.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { createServer, type IncomingMessage } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA,
+  compareProviderUsage,
+  runCodexRebaseProviderSmoke,
+  sanitizedEvidenceLabel,
+} from "../src/context-rebase-provider-smoke.js";
+import type { JsonObject } from "../src/context-history/index.js";
+
+async function requestBody(req: IncomingMessage): Promise<JsonObject> {
+  return new Promise<JsonObject>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))));
+    req.on("error", reject);
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")) as JsonObject);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}
+
+async function startProviderFixture(options: { rejectWithSecret?: boolean } = {}): Promise<{
+  baseUrl: string;
+  authorizationPresent(): boolean;
+  close(): Promise<void>;
+}> {
+  let ordinal = 0;
+  let sawAuthorization = true;
+  const contextCharsByResponse = new Map<string, number>();
+  const server = createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/responses") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    sawAuthorization = sawAuthorization && /^Bearer\s+\S+$/u.test(String(req.headers.authorization ?? ""));
+    if (options.rejectWithSecret) {
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: { code: "invalid_request_error", message: "bad input secret-provider-body" } }));
+      return;
+    }
+    const payload = await requestBody(req);
+    ordinal += 1;
+    const id = `resp-provider-fixture-${ordinal}`;
+    const previousId = typeof payload.previous_response_id === "string"
+      ? payload.previous_response_id
+      : undefined;
+    const previousContextChars = previousId ? contextCharsByResponse.get(previousId) ?? 0 : 0;
+    const currentChars = JSON.stringify(payload.input ?? []).length;
+    const forcedToolCall = payload.tool_choice
+      && typeof payload.tool_choice === "object"
+      && !Array.isArray(payload.tool_choice);
+    const encryptedContent = `opaque-provider-fixture-${ordinal}`;
+    const output = forcedToolCall
+      ? [
+        { id: `reasoning-${ordinal}`, type: "reasoning", encrypted_content: encryptedContent, summary: [] },
+        {
+          id: `call-item-${ordinal}`,
+          type: "function_call",
+          call_id: `call-provider-fixture-${ordinal}`,
+          name: "lookup_smoke_fixture",
+          arguments: "{\"record\":\"retained\"}",
+        },
+      ]
+      : [
+        { id: `reasoning-${ordinal}`, type: "reasoning", encrypted_content: encryptedContent, summary: [] },
+        {
+          id: `message-${ordinal}`,
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "OK" }],
+        },
+      ];
+    const outputChars = JSON.stringify(output).length;
+    const nextContextChars = previousContextChars + currentChars + outputChars;
+    contextCharsByResponse.set(id, nextContextChars);
+    const inputTokens = Math.ceil((previousContextChars + currentChars) / 4);
+    const outputTokens = Math.ceil(outputChars / 4);
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      id,
+      object: "response",
+      status: "completed",
+      previous_response_id: previousId,
+      output,
+      usage: {
+        input_tokens: inputTokens,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens: outputTokens,
+        total_tokens: inputTokens + outputTokens,
+      },
+    }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("fixture server did not expose a TCP address");
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    authorizationPresent: () => sawAuthorization,
+    close() {
+      return new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    },
+  };
+}
+
+test("provider usage comparison reports observed and projected break-even", () => {
+  const observation = (inputTokens: number) => ({
+    inputTokens,
+    cachedInputTokens: 0,
+    outputTokens: 1,
+    totalTokens: inputTokens + 1,
+  });
+  const evidence = compareProviderUsage(
+    [observation(120), observation(140), observation(160)],
+    [observation(150), observation(100), observation(100)],
+    { baseline: [observation(20)], rebase: [observation(20)] },
+  );
+  assert.equal(evidence.comparableSetup, true);
+  assert.equal(evidence.observedBreakEvenTurn, 2);
+  assert.equal(evidence.projectedBreakEvenTurn, 2);
+  assert.equal(evidence.rebaseTurnOverheadTokens, 30);
+  assert.equal(evidence.observedSavedInputTokens, 70);
+  assert.equal(evidence.subsequentSavedInputTokensPerTurn, 50);
+});
+
+test("provider smoke emits sanitized real-chain, capability v2, matrix, and usage evidence", async () => {
+  const provider = await startProviderFixture();
+  const outputDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-provider-smoke-test-"));
+  const previousKey = process.env.OPENAI_API_KEY;
+  const previousCli = process.env.CODEX_CLI_VERSION;
+  process.env.OPENAI_API_KEY = "provider-smoke-test-key-not-secret";
+  process.env.CODEX_CLI_VERSION = "sk-credential-shaped-cli-label";
+  try {
+    const result = await runCodexRebaseProviderSmoke({
+      baseUrl: provider.baseUrl,
+      model: "provider-fixture-model",
+      continuationTurns: 5,
+      outputDir,
+    });
+    const evidence = result.evidence;
+    const artifactText = await readFile(result.artifactPath, "utf8");
+
+    assert.equal(evidence.schema, CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA);
+    assert.equal(evidence.mode, "provider");
+    assert.equal(evidence.runtime.codexCli, "not-observed");
+    assert.equal(evidence.capability.encryptedReasoningPresent, true);
+    assert.equal(evidence.capability.journalTrusted, true);
+    assert.deepEqual(evidence.capability.realProviderVerifiedItemTypes, [
+      "function_call",
+      "function_call_output",
+      "message",
+      "reasoning",
+    ]);
+    assert.equal(evidence.rebase.committed, true);
+    assert.equal(evidence.rebase.oldChainReferenceRemoved, true);
+    assert.equal(evidence.rebase.currentInputOccurrences, 1);
+    assert.deepEqual(evidence.rebase.sentinel, { evictedAbsent: true, retainedPresent: true });
+    assert.equal(evidence.rebase.encryptedPayloadDigestMatches, true);
+    assert.deepEqual(evidence.rebase.toolClosure, { callCount: 1, outputCount: 1, complete: true });
+    assert.equal(evidence.rebase.responseChain.continuationTurns, 5);
+    assert.equal(evidence.rebase.responseChain.linksValid, true);
+    assert.equal(evidence.rebase.responseChain.restartPreserved, true);
+    assert.equal(evidence.rebase.responseChain.finalHistoryComplete, true);
+    assert.equal(evidence.usage.continuationTurns.length, 5);
+    assert.ok(evidence.usage.observedSavedInputTokens > 0);
+    assert.equal(evidence.compatibilityMatrix.find((entry) => entry.itemType === "reasoning")?.providerDecision, "real-pass");
+    assert.equal(evidence.compatibilityMatrix.find((entry) => entry.itemType === "compaction")?.providerDecision, "not-observed");
+    assert.equal(provider.authorizationPresent(), true);
+    assert.match(result.artifactSha256, /^[a-f0-9]{64}$/u);
+    assert.equal(JSON.parse(artifactText).schema, CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA);
+    assert.doesNotMatch(artifactText, /EVICT_ME_|KEEP_ME_|CURRENT_INPUT_|opaque-provider-fixture-/u);
+    assert.doesNotMatch(artifactText, /provider-smoke-test-key-not-secret|sk-credential-shaped-cli-label/u);
+    assert.doesNotMatch(artifactText, /previous_response_id|authorization|bearer/iu);
+  } finally {
+    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousKey;
+    if (previousCli === undefined) delete process.env.CODEX_CLI_VERSION;
+    else process.env.CODEX_CLI_VERSION = previousCli;
+    await provider.close();
+    await rm(outputDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+});
+
+test("provider smoke rejects credential-shaped evidence labels and raw provider errors", async () => {
+  assert.equal(sanitizedEvidenceLabel("sk-sensitive-model-label"), "not-observed");
+  assert.equal(sanitizedEvidenceLabel("gpt-safe-model"), "gpt-safe-model");
+  const provider = await startProviderFixture({ rejectWithSecret: true });
+  const previousKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "fixture-key";
+  try {
+    await assert.rejects(
+      runCodexRebaseProviderSmoke({ baseUrl: provider.baseUrl, continuationTurns: 5 }),
+      (error: unknown) => {
+        assert.match(String(error), /control setup turn 1 failed with HTTP 400 \(invalid_request_error; input-schema\)/u);
+        assert.doesNotMatch(String(error), /secret-provider-body/u);
+        return true;
+      },
+    );
+  } finally {
+    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousKey;
+    await provider.close();
+  }
+});

--- a/components/adapters/codex/tests/context-rebase-report.test.ts
+++ b/components/adapters/codex/tests/context-rebase-report.test.ts
@@ -8,7 +8,11 @@ import {
   appendCodexRebaseCapability,
   appendCodexRebaseCooldown,
   appendPendingCodexRebaseEpoch,
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
   commitCodexRebaseEpoch,
+  codexRebaseEndpointIdentity,
   codexRebaseEpochJournalPath,
 } from "../src/context-rewrite/index.js";
 import { appendCodexRecentTurnBinding, upsertCodexSessionSnapshot } from "../src/session-state.js";
@@ -62,10 +66,16 @@ test("CDR-07 Codex session report renders rebase state", async () => {
       stateDir: dir,
       provider: "OpenAI",
       model: "gpt-test",
+      wireMode: CODEX_REBASE_WIRE_MODE,
+      apiVersion: CODEX_REBASE_API_VERSION,
+      endpointId: codexRebaseEndpointIdentity("https://api.openai.example/v1"),
       itemType: "web_search_call",
-      status: "unsupported",
+      itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+      status: "verified_unsupported",
+      evidence: "mock_fixture",
       reason: "schema_error",
       observedAt: "2026-07-28T10:00:02.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
     });
 
     const report = await renderCodexSessionReport(dir, "sess-rebase-report");
@@ -73,7 +83,7 @@ test("CDR-07 Codex session report renders rebase state", async () => {
     assert.match(report, /rebase epochs: committed=1, rolled_back=0, failed=0, pending=0/i);
     assert.match(report, /latest rebase epoch: committed epoch-report old=resp-old new=resp-new/i);
     assert.match(report, /rebase cooldowns: active=1\/1 latest=rebase_upstream_rejected/i);
-    assert.match(report, /rebase capability cache: OpenAI\/gpt-test web_search_call unsupported/i);
+    assert.match(report, /web_search_call@responses-item\/v1 verified_unsupported evidence=mock\/fixture/i);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/components/adapters/codex/tests/doctor.test.ts
+++ b/components/adapters/codex/tests/doctor.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { appendFile, mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "node:net";
@@ -8,7 +8,14 @@ import { createServer as createHttpServer } from "node:http";
 
 import { normalizeTokenPilotCodexConfig } from "../src/config.js";
 import { formatCodexDoctorReport, inspectCodexDoctor } from "../src/doctor.js";
-import { appendCodexRebaseCapability } from "../src/context-rewrite/index.js";
+import {
+  appendCodexRebaseCapability,
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
+  codexRebaseCapabilityJournalPath,
+  codexRebaseEndpointIdentity,
+} from "../src/context-rewrite/index.js";
 
 async function reserveUnusedPort(): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -422,10 +429,31 @@ test("inspectCodexDoctor reports cached rebase capabilities", async () => {
       stateDir,
       provider: "OpenAI",
       model: "gpt-5.4-mini",
+      wireMode: CODEX_REBASE_WIRE_MODE,
+      apiVersion: CODEX_REBASE_API_VERSION,
+      endpointId: codexRebaseEndpointIdentity("https://api.openai.example/v1"),
       itemType: "web_search_call",
-      status: "unsupported",
+      itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+      status: "verified_unsupported",
+      evidence: "mock_fixture",
       reason: "schema_error",
       observedAt: "2026-07-28T10:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+    });
+    await appendCodexRebaseCapability({
+      stateDir,
+      provider: "OpenAI",
+      model: "gpt-5.4-mini",
+      wireMode: CODEX_REBASE_WIRE_MODE,
+      apiVersion: CODEX_REBASE_API_VERSION,
+      endpointId: codexRebaseEndpointIdentity("https://api.openai.example/v1"),
+      itemType: "reasoning",
+      itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+      status: "verified_supported",
+      evidence: "real_provider",
+      reason: "provider_smoke_committed",
+      observedAt: "2026-07-28T10:01:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
     });
 
     const report = await inspectCodexDoctor({
@@ -438,8 +466,23 @@ test("inspectCodexDoctor reports cached rebase capabilities", async () => {
       tokenPilotConfigPath,
     });
 
-    assert.deepEqual(report.rebaseCapabilityStatus, ["OpenAI/gpt-5.4-mini web_search_call unsupported"]);
-    assert.match(formatCodexDoctorReport(report), /rebase capability cache: OpenAI\/gpt-5\.4-mini web_search_call unsupported/);
+    assert.deepEqual(report.rebaseCapabilityStatus, [
+      "OpenAI/gpt-5.4-mini responses responses/v1 reasoning@responses-item/v1 verified_supported evidence=real-provider state=active",
+      "OpenAI/gpt-5.4-mini responses responses/v1 web_search_call@responses-item/v1 verified_unsupported evidence=mock/fixture state=active",
+    ]);
+    const formatted = formatCodexDoctorReport(report);
+    assert.match(formatted, /reasoning@responses-item\/v1 verified_supported evidence=real-provider/);
+    assert.match(formatted, /web_search_call@responses-item\/v1 verified_unsupported evidence=mock\/fixture/);
+
+    await appendFile(codexRebaseCapabilityJournalPath(stateDir), "not-json\n", "utf8");
+    const untrustedReport = await inspectCodexDoctor({
+      config: normalizeTokenPilotCodexConfig({ stateDir, proxyPort }),
+      configPath: codexConfigPath,
+      hooksConfigPath,
+      tokenPilotConfigPath,
+    });
+    assert.equal(untrustedReport.rebaseCapabilityTrusted, false);
+    assert.match(formatCodexDoctorReport(untrustedReport), /capability cache: untrusted .*runtime will bypass rebase/i);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/components/adapters/codex/tests/install.test.ts
+++ b/components/adapters/codex/tests/install.test.ts
@@ -50,6 +50,51 @@ function installCodexTokenPilot(
   });
 }
 
+function parseGeneratedShellCommand(command: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quoted = false;
+  let started = false;
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index] ?? "";
+    if (quoted) {
+      if (character === "\\") {
+        const escaped = command[index + 1];
+        if (escaped === "\\" || escaped === "\"") {
+          current += escaped;
+          index += 1;
+        } else {
+          current += character;
+        }
+      } else if (character === "\"") {
+        quoted = false;
+      } else {
+        current += character;
+      }
+      continue;
+    }
+
+    if (character === "\"") {
+      quoted = true;
+      started = true;
+    } else if (/\s/u.test(character)) {
+      if (started) {
+        args.push(current);
+        current = "";
+        started = false;
+      }
+    } else {
+      current += character;
+      started = true;
+    }
+  }
+
+  assert.equal(quoted, false, "generated shell command contains an unterminated quote");
+  if (started) args.push(current);
+  return args;
+}
+
 test("installCodexTokenPilot writes provider, MCP, and hooks with expected commands", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-install-"));
   const originalHome = process.env.HOME;
@@ -513,11 +558,20 @@ test("installCodexTokenPilot stops an existing daemon before resolving the proxy
 test("resolveCodexHookCommandForInstall finds the adapter root from the bundled CLI tree", async () => {
   const repoRoot = resolve(__dirname, "..", "..", "..", "..");
   const bundledCliModuleDir = join(repoRoot, "components", "products", "cli", "dist");
+  const adapterDistDir = join(repoRoot, "components", "adapters", "codex", "dist");
   const originalCwd = process.cwd();
   try {
     process.chdir(dirname(repoRoot));
-    const command = await resolveCodexHookCommandForInstall(process.platform, bundledCliModuleDir);
-    assert.match(command, /adapters[\/\\]codex[\/\\]dist[\/\\](hooks-handler\.js|tokenpilot-codex-hook\.cmd)/);
+    const windowsCommand = await resolveCodexHookCommandForInstall("win32", bundledCliModuleDir);
+    assert.deepEqual(parseGeneratedShellCommand(windowsCommand), [
+      join(adapterDistDir, "tokenpilot-codex-hook.cmd"),
+    ]);
+
+    const posixCommand = await resolveCodexHookCommandForInstall("linux", bundledCliModuleDir);
+    assert.deepEqual(parseGeneratedShellCommand(posixCommand), [
+      process.execPath,
+      join(adapterDistDir, "hooks-handler.js"),
+    ]);
   } finally {
     process.chdir(originalCwd);
   }


### PR DESCRIPTION
## Summary

This PR hardens the remaining Codex response-chain rebase path:

- recover crash-truncated context-history journal tails under the session lock;
- replace the broad provider capability cache with a scoped v2 compatibility journal;
- add an opt-in provider rebase smoke harness with sanitized evidence;
- fix Windows install command assertions;
- add cross-platform portable release packaging.

## Context-history journal recovery

A process crash can leave the JSONL journal with a partial final record. The recovery path now:

- runs under the existing session-scoped cross-process lock;
- restores a complete canonical record that only lost its final newline;
- truncates an incomplete JSON or UTF-8 suffix after validating the complete prefix;
- refuses to repair a structurally invalid canonical record;
- fails closed when an earlier record is malformed or the journal cannot be read;
- fsyncs the repaired journal before normal append/replay continues;
- exposes only a SHA-256 digest of the removed suffix in recovery diagnostics.

Regression coverage includes first-record crashes, request/response appends, restart recovery, partial UTF-8, concurrent writers, multi-process writers, invalid prefixes, and idempotent recovery.

## Provider replay compatibility

The provider compatibility journal is upgraded to v2 and scopes decisions by:

- provider and model;
- wire mode and API version;
- endpoint digest;
- response item type and item schema version;
- exact payload digest for payload-specific encrypted reasoning failures;
- mock/fixture versus real-provider evidence;
- observation and expiry timestamps.

Runtime behavior remains fail closed:

- provider probing is disabled by default;
- unknown compatibility bypasses rebase unless probing is explicitly enabled;
- malformed or unreadable capability journals bypass rebase;
- authentication, rate-limit, network, and 5xx failures do not poison capability state;
- ambiguous 400 responses do not mark every item unsupported;
- encrypted payload rejection is limited to the exact rejected payload;
- doctor and session reports surface untrusted capability state.

## Provider smoke

An explicit `--mode=provider` smoke path now checks:

- Responses API availability;
- exact encrypted reasoning replay;
- function call/result closure;
- new response-chain root creation;
- five continuation turns;
- proxy restart and session mapping recovery;
- response journal persistence before epoch commit;
- sentinel retention/eviction;
- provider usage and break-even accounting;
- capability v2 observations and the item compatibility matrix.

Success evidence is written only after all positive gates pass. Evidence excludes raw prompts, response IDs, encrypted payloads, authorization headers, provider error bodies, and credential-shaped labels.

The automated loopback fixture validates harness behavior only and is not treated as external provider acceptance.

## Windows and release packaging

- Parse the complete generated install command instead of treating it as one executable path.
- Verify both Windows wrapper and POSIX Node command generation.
- Preserve the existing Bash release path for Linux/CI.
- Add `pack:release:portable` for Windows and other Node environments.
- The portable package contains only the built Codex adapter, bundled CLI/MCP entry points, README, and a dependency-free release manifest.

## Validation

- `npm test` — 241/241 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run pack:release:portable` — passed
- `git diff --check` — passed

Portable archive contents and manifest were validated. The generated archive is ignored and is not included in this PR.

## Real provider status

Using the existing project provider:

- the Responses endpoint is available;
- encrypted reasoning is returned;
- exact stateless encrypted reasoning replay succeeds;
- function call/result closure succeeds with `gpt-5.4-mini`.

However, the provider currently rejects a newly generated `previous_response_id` with HTTP 400 (`chain-reference`). Therefore this PR does not claim successful real-provider five-turn continuation, restart recovery, or break-even accounting, and no successful real-provider smoke artifact was generated.

A chain-capable provider/model is still required to close that external acceptance gate.

## Safety

- Context rewrite remains disabled by default.
- Provider probing remains disabled by default.
- Unknown or untrusted compatibility falls back to the original request.
- Mock evidence cannot satisfy normal real-provider compatibility checks.
- API credentials are read only from the environment and are never persisted.