### PR TITLE
Complete Codex context rebase provider replay support

### DIFF
--- a/components/adapters/codex/README.md
+++ b/components/adapters/codex/README.md
@@ -182,11 +182,17 @@ closure, response links, restart mapping, and provider usage gates all pass.
 Evidence contains only safe endpoint/model labels, an endpoint digest,
 booleans, counts, item types, payload length/digest, and provider usage totals.
 It never contains the API key, raw prompts, response IDs, encrypted payloads,
-headers, or raw provider error bodies. Authentication and schema failures are
-not retried; only 429 and 5xx receive two bounded retries. A provider that can
-return encrypted reasoning but rejects `previous_response_id` is recorded as a
-partial compatibility result and must not be described as a successful
-response-chain rebase.
+headers, or raw provider error bodies. Authentication and unrelated schema
+failures are not retried; only 429 and 5xx receive two bounded retries. If a
+provider explicitly rejects `previous_response_id`, the proxy retries once with
+journal-derived stateless history, forces `store: false`, requests encrypted
+reasoning state, and caches the transport decision by provider/model/endpoint.
+Later turns use stateless replay directly while preserving every supported
+response output item. A 2xx response that omits explicitly requested encrypted
+reasoning receives at most two transport-level repair retries. Journal parent
+links always follow the client request (including an explicit root), never an
+inconsistent provider echo. Reused provider response IDs remain ordered journal
+occurrences, so a restart does not collapse a valid logical chain.
 
 Context-history journal writers use a session-scoped cross-process lock. A
 successful append is one complete JSONL record followed by `sync`; concurrent
@@ -208,16 +214,18 @@ accept that item. Capability journal v2 keys observations by provider, model,
 Responses wire/API mode, a SHA-256 endpoint identity, item type, and item schema
 version, and expires observations after a bounded TTL.
 
-The default `contextRewrite.providerCompatibilityProbe` value is `disabled`.
-With that default, unknown, expired, verified-unsupported, payload-rejected, or
-untrusted capability state bypasses rebase before an epoch is opened and sends
-the original request. `mock_fixture` and `real_provider` are explicit probe
-modes. Mock evidence can drive mock tests but is never presented as real-provider
-verification. Explicit item-schema rejection is scoped to the named item type;
-encrypted-content lineage/expiry rejection is scoped to the exact payload
-digest; authentication, rate-limit, server, network, and ambiguous multi-item
-failures do not poison the capability cache. Doctor and session reports label
-the evidence source and whether each observation is active or expired.
+The default `contextRewrite.providerCompatibilityProbe` value is
+`real_provider`. Unknown item compatibility is learned from the actual
+rebased/stateless request; an explicit rejection is cached, while a successful
+replay records support. `disabled` keeps the conservative bypass behavior and
+`mock_fixture` is reserved for fixtures. Mock evidence can drive mock tests but
+is never presented as real-provider verification. Explicit item-schema
+rejection is scoped to the named item type; encrypted-content lineage/expiry
+rejection is scoped to the exact payload digest; authentication, rate-limit,
+server, network, and ambiguous multi-item failures do not poison the capability
+cache. `program`, `program_output`, and program-issued tool outputs retain their
+fingerprint, status, and exact `caller` relationship. Doctor and session reports
+label the evidence source and whether each observation is active or expired.
 
 If install finishes in degraded MCP mode, Codex stable-prefix and reduction remain usable; only the real `memory_fault_recover` tool path is unavailable until MCP startup succeeds.
 

--- a/components/adapters/codex/scripts/context-rebase-smoke.ts
+++ b/components/adapters/codex/scripts/context-rebase-smoke.ts
@@ -97,6 +97,7 @@ async function main(): Promise<void> {
       artifactSha256: result.artifactSha256,
       encryptedReasoningPresent: result.evidence.capability.encryptedReasoningPresent,
       verifiedItemTypes: result.evidence.capability.realProviderVerifiedItemTypes,
+      rejectedItemTypes: result.evidence.capability.realProviderRejectedItemTypes,
       rebaseCommitted: result.evidence.rebase.committed,
       sentinel: result.evidence.rebase.sentinel,
       continuationTurns: result.evidence.rebase.responseChain.continuationTurns,

--- a/components/adapters/codex/src/config.ts
+++ b/components/adapters/codex/src/config.ts
@@ -200,7 +200,7 @@ export function normalizeTokenPilotCodexConfig(
       providerCompatibilityProbe: contextRewrite.providerCompatibilityProbe === "mock_fixture"
         || contextRewrite.providerCompatibilityProbe === "real_provider"
         ? contextRewrite.providerCompatibilityProbe
-        : "disabled",
+        : "real_provider",
       mutationPlan: sanitizeCodexMutationPlan(contextRewrite.mutationPlan),
     },
     reduction: {

--- a/components/adapters/codex/src/context-history/effective-history.ts
+++ b/components/adapters/codex/src/context-history/effective-history.ts
@@ -1,5 +1,5 @@
 import { readCodexContextHistoryJournalRecoveringTail } from "./journal-append.js";
-import { codexReplayabilityForItem } from "./replayability.js";
+import { codexReplayabilityForItem, codexReplayPairRef } from "./replayability.js";
 import { cloneJson, hashJson } from "./shared.js";
 import type {
   CodexContextHistoryJournalEntry,
@@ -25,6 +25,17 @@ type CommittedTurn = {
   response: IndexedResponse;
 };
 
+function findLastResponse(
+  responses: IndexedResponse[],
+  predicate: (response: IndexedResponse) => boolean,
+): IndexedResponse | undefined {
+  for (let index = responses.length - 1; index >= 0; index -= 1) {
+    const response = responses[index];
+    if (response && predicate(response)) return response;
+  }
+  return undefined;
+}
+
 function latestRequests(journal: CodexContextHistoryJournalEntry[]): Map<string, IndexedRequest> {
   const requests = new Map<string, IndexedRequest>();
   journal.forEach((entry, journalIndex) => {
@@ -33,11 +44,13 @@ function latestRequests(journal: CodexContextHistoryJournalEntry[]): Map<string,
   return requests;
 }
 
-function latestResponsesById(journal: CodexContextHistoryJournalEntry[]): Map<string, IndexedResponse> {
-  const responses = new Map<string, IndexedResponse>();
+function responsesById(journal: CodexContextHistoryJournalEntry[]): Map<string, IndexedResponse[]> {
+  const responses = new Map<string, IndexedResponse[]>();
   journal.forEach((entry, journalIndex) => {
     if (entry.kind === "response" && entry.responseId) {
-      responses.set(entry.responseId, { entry, journalIndex });
+      const occurrences = responses.get(entry.responseId) ?? [];
+      occurrences.push({ entry, journalIndex });
+      responses.set(entry.responseId, occurrences);
     }
   });
   return responses;
@@ -51,10 +64,10 @@ function isCommittedResponseEntry(entry: CodexResponseJournalEntry): boolean {
 }
 
 function committedResponses(
-  responses: Map<string, IndexedResponse>,
+  responses: Map<string, IndexedResponse[]>,
   requests: Map<string, IndexedRequest>,
 ): IndexedResponse[] {
-  return Array.from(responses.values())
+  return Array.from(responses.values()).flat()
     .filter(({ entry }) => {
       if (!isCommittedResponseEntry(entry) || !entry.requestId) return false;
       return requests.get(entry.requestId)?.entry.status === "completed";
@@ -78,18 +91,18 @@ function committedInputItems(turn: CommittedTurn): JsonObject[] {
 function buildCommittedChain(params: {
   headResponseId?: string;
   requests: Map<string, IndexedRequest>;
-  responses: Map<string, IndexedResponse>;
+  responses: Map<string, IndexedResponse[]>;
 }): { chain: CommittedTurn[]; complete: boolean } {
   const committed = committedResponses(params.responses, params.requests);
   const head = params.headResponseId
-    ? params.responses.get(params.headResponseId)
+    ? findLastResponse(committed, ({ entry }) => entry.responseId === params.headResponseId)
     : committed.at(-1);
   if (!head) {
     return { chain: [], complete: params.headResponseId === undefined && params.requests.size === 0 };
   }
 
   const chain: CommittedTurn[] = [];
-  const seenResponseIds = new Set<string>();
+  const seenJournalIndexes = new Set<number>();
   let cursor: IndexedResponse | undefined = head;
   while (cursor) {
     const responseId = cursor.entry.responseId;
@@ -97,8 +110,8 @@ function buildCommittedChain(params: {
     if (!responseId || !requestId || !isCommittedResponseEntry(cursor.entry)) {
       return { chain: [], complete: false };
     }
-    if (seenResponseIds.has(responseId)) return { chain: [], complete: false };
-    seenResponseIds.add(responseId);
+    if (seenJournalIndexes.has(cursor.journalIndex)) return { chain: [], complete: false };
+    seenJournalIndexes.add(cursor.journalIndex);
 
     const request = params.requests.get(requestId);
     if (!request || request.entry.status !== "completed") {
@@ -109,7 +122,10 @@ function buildCommittedChain(params: {
 
     const previousId = previousResponseId(turn);
     if (!previousId) break;
-    cursor = params.responses.get(previousId);
+    cursor = findLastResponse(committed, (candidate) => (
+      candidate.entry.responseId === previousId
+      && candidate.journalIndex < cursor!.journalIndex
+    ));
     if (!cursor) return { chain, complete: false };
   }
   return { chain, complete: true };
@@ -169,11 +185,9 @@ function unresolvedCallIds(items: CodexEffectiveHistoryItem[]): string[] {
   const calls = new Set<string>();
   const outputs = new Set<string>();
   for (const entry of items) {
-    const type = String(entry.item.type ?? "").toLowerCase();
-    if ((type === "function_call" || type === "custom_tool_call") && entry.callId) calls.add(entry.callId);
-    if ((type === "function_call_output" || type === "custom_tool_call_output") && entry.callId) {
-      outputs.add(entry.callId);
-    }
+    const ref = codexReplayPairRef(entry.item);
+    if (ref.side === "call" && ref.callId) calls.add(ref.callId);
+    if (ref.side === "output" && ref.callId) outputs.add(ref.callId);
   }
   return Array.from(calls).filter((callId) => !outputs.has(callId)).sort();
 }
@@ -345,7 +359,7 @@ export async function buildCodexEffectiveHistory(params: {
 }): Promise<CodexEffectiveHistory> {
   const journalRead = await readCodexContextHistoryJournalRecoveringTail(params.stateDir, params.sessionId);
   const requests = latestRequests(journalRead.entries);
-  const responses = latestResponsesById(journalRead.entries);
+  const responses = responsesById(journalRead.entries);
   const committedChain = buildCommittedChain({
     headResponseId: params.headResponseId,
     requests,

--- a/components/adapters/codex/src/context-history/replayability.ts
+++ b/components/adapters/codex/src/context-history/replayability.ts
@@ -8,6 +8,9 @@ export type CodexReplayabilityReason =
   | "tool_call_id_missing"
   | "exact_payload_required"
   | "exact_payload_missing"
+  | "program_payload_required"
+  | "program_payload_missing"
+  | "provider_output_replay"
   | "provider_observation"
   | "turn_context_instruction"
   | "unsupported_item_type";
@@ -17,29 +20,123 @@ export type CodexItemReplayability = {
   reason: CodexReplayabilityReason;
 };
 
+export type CodexReplayPairKind =
+  | "function"
+  | "custom"
+  | "computer"
+  | "local_shell"
+  | "shell"
+  | "apply_patch"
+  | "tool_search";
+
+export type CodexReplayPairRef = {
+  callId?: string;
+  kind?: CodexReplayPairKind;
+  side?: "call" | "output";
+  type: string;
+};
+
+const REPLAY_PAIR_TYPES = new Map<string, Omit<CodexReplayPairRef, "callId" | "type">>([
+  ["function_call", { kind: "function", side: "call" }],
+  ["function_call_output", { kind: "function", side: "output" }],
+  ["custom_tool_call", { kind: "custom", side: "call" }],
+  ["custom_tool_call_output", { kind: "custom", side: "output" }],
+  ["computer_call", { kind: "computer", side: "call" }],
+  ["computer_call_output", { kind: "computer", side: "output" }],
+  ["local_shell_call", { kind: "local_shell", side: "call" }],
+  ["local_shell_call_output", { kind: "local_shell", side: "output" }],
+  ["shell_call", { kind: "shell", side: "call" }],
+  ["shell_call_output", { kind: "shell", side: "output" }],
+  ["apply_patch_call", { kind: "apply_patch", side: "call" }],
+  ["apply_patch_call_output", { kind: "apply_patch", side: "output" }],
+]);
+
+const OPTIONAL_REPLAY_PAIR_TYPES = new Map<string, Omit<CodexReplayPairRef, "callId" | "type">>([
+  ["tool_search_call", { kind: "tool_search", side: "call" }],
+  ["tool_search_output", { kind: "tool_search", side: "output" }],
+]);
+
+// These are provider-produced Responses items that can be copied back into a
+// stateless input array. Provider acceptance is still checked separately by
+// the capability store before a rebase is committed.
+const PROVIDER_OUTPUT_REPLAY_TYPES = new Set([
+  "web_search_call",
+  "file_search_call",
+  "code_interpreter_call",
+  "image_generation_call",
+  "mcp_call",
+  "mcp_list_tools",
+  "mcp_approval_request",
+  "mcp_approval_response",
+  "tool_search_call",
+  "tool_search_output",
+  "additional_tools",
+]);
+
+function nonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function codexReplayPairRef(item: JsonObject): CodexReplayPairRef {
+  const type = String(item.type ?? "").toLowerCase();
+  const callId = nonBlankString(item.call_id);
+  const pair = REPLAY_PAIR_TYPES.get(type) ?? (callId ? OPTIONAL_REPLAY_PAIR_TYPES.get(type) : undefined);
+  return pair
+    ? { ...pair, type, callId }
+    : { type };
+}
+
+export function codexProgramCallerId(item: JsonObject): string | undefined {
+  const caller = item.caller;
+  if (!caller || typeof caller !== "object" || Array.isArray(caller)) return undefined;
+  const callerObject = caller as JsonObject;
+  return String(callerObject.type ?? "").toLowerCase() === "program"
+    ? nonBlankString(callerObject.caller_id)
+    : undefined;
+}
+
 export function codexReplayabilityForItem(item: JsonObject): CodexItemReplayability {
   const type = String(item.type ?? "").toLowerCase();
   const role = String(item.role ?? "").toLowerCase();
-  if (type === "web_search_call" || type === "event_msg") {
+  if (type === "event_msg") {
     return { mode: "observation_only", reason: "provider_observation" };
   }
   if (type === "turn_context") {
     return { mode: "observation_only", reason: "turn_context_instruction" };
   }
-  if (
-    type === "function_call"
-    || type === "custom_tool_call"
-    || type === "function_call_output"
-    || type === "custom_tool_call_output"
-  ) {
-    return typeof item.call_id === "string" && item.call_id.trim().length > 0
+  if (REPLAY_PAIR_TYPES.has(type)) {
+    return nonBlankString(item.call_id)
+      ? { mode: "replayable", reason: "tool_closure_required" }
+      : { mode: "deferred", reason: "tool_call_id_missing" };
+  }
+  if (OPTIONAL_REPLAY_PAIR_TYPES.has(type)
+    && String(item.execution ?? "").toLowerCase() === "client") {
+    return nonBlankString(item.call_id)
       ? { mode: "replayable", reason: "tool_closure_required" }
       : { mode: "deferred", reason: "tool_call_id_missing" };
   }
   if (type === "reasoning" || type === "compaction") {
-    return typeof item.encrypted_content === "string" && item.encrypted_content.trim().length > 0
+    return nonBlankString(item.encrypted_content)
       ? { mode: "replayable", reason: "exact_payload_required" }
       : { mode: "deferred", reason: "exact_payload_missing" };
+  }
+  if (type === "program") {
+    return nonBlankString(item.call_id)
+      && nonBlankString(item.code)
+      && nonBlankString(item.fingerprint)
+      ? { mode: "replayable", reason: "program_payload_required" }
+      : { mode: "deferred", reason: "program_payload_missing" };
+  }
+  if (type === "program_output") {
+    const status = String(item.status ?? "").toLowerCase();
+    return nonBlankString(item.call_id)
+      && typeof item.result === "string"
+      && (status === "completed" || status === "incomplete")
+      ? { mode: "replayable", reason: "program_payload_required" }
+      : { mode: "deferred", reason: "program_payload_missing" };
+  }
+  if (PROVIDER_OUTPUT_REPLAY_TYPES.has(type)) {
+    return { mode: "replayable", reason: "provider_output_replay" };
   }
   if (type === "message" || (!type && ["system", "developer", "user", "assistant"].includes(role))) {
     return { mode: "replayable", reason: "default_replayable" };

--- a/components/adapters/codex/src/context-history/rollout-parser.ts
+++ b/components/adapters/codex/src/context-history/rollout-parser.ts
@@ -6,7 +6,7 @@ import {
   hashJson,
   sanitizeValue,
 } from "./shared.js";
-import { codexReplayabilityForItem } from "./replayability.js";
+import { codexReplayabilityForItem, codexReplayPairRef } from "./replayability.js";
 import type {
   CodexEffectiveHistory,
   CodexEffectiveHistoryItem,
@@ -32,8 +32,7 @@ function itemCallId(item: JsonObject): string | undefined {
 }
 
 function isToolOutput(item: JsonObject): boolean {
-  const type = itemType(item);
-  return type === "function_call_output" || type === "custom_tool_call_output";
+  return codexReplayPairRef(item).side === "output";
 }
 
 type RolloutAccumulator = {
@@ -60,10 +59,8 @@ function createAccumulator(): RolloutAccumulator {
 }
 
 function expectedOutputType(item: JsonObject): string | undefined {
-  const type = itemType(item);
-  if (type === "function_call") return "function_call_output";
-  if (type === "custom_tool_call") return "custom_tool_call_output";
-  return undefined;
+  const ref = codexReplayPairRef(item);
+  return ref.side === "call" ? `${ref.type}_output` : undefined;
 }
 
 function createEffectiveItem(

--- a/components/adapters/codex/src/context-rebase-provider-smoke.ts
+++ b/components/adapters/codex/src/context-rebase-provider-smoke.ts
@@ -25,6 +25,7 @@ import { resolveCodexSessionIdByResponseId } from "./session-state.js";
 
 export const CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA =
   "lightmem2.codex.context-rebase-provider-smoke-evidence/v2";
+const PROVIDER_SMOKE_MAX_OUTPUT_TOKENS = 2_048;
 
 export type ProviderUsageObservation = {
   inputTokens: number;
@@ -60,7 +61,7 @@ export type ProviderUsageEvidence = {
 
 export type ProviderCompatibilityMatrixEntry = {
   itemType: string;
-  structuralPolicy: "replay-candidate" | "closure-required" | "exact-payload" | "observation-only" | "deferred";
+  structuralPolicy: "transport" | "replay-candidate" | "closure-required" | "exact-payload" | "deferred";
   providerDecision: "real-pass" | "real-reject" | "mock" | "not-observed";
   evidence: "real-provider" | "mock-fixture" | "none";
   reason: string;
@@ -95,6 +96,7 @@ export type CodexRebaseProviderSmokeEvidence = {
     toolCallPresent: boolean;
     journalTrusted: boolean;
     realProviderVerifiedItemTypes: string[];
+    realProviderRejectedItemTypes: string[];
   };
   compatibilityMatrix: ProviderCompatibilityMatrixEntry[];
   rebase: {
@@ -161,6 +163,27 @@ type ProviderConversationResult = {
   setupUsage: ProviderUsageObservation[];
   continuationUsage: ProviderUsageObservation[];
 };
+
+async function replayDiagnostic(params: {
+  stateDir: string;
+  sessionId: string;
+  headResponseId: string;
+}): Promise<string> {
+  try {
+    const history = await buildCodexEffectiveHistory(params);
+    const deferredTypes = Array.from(new Set(history.deferredItems.map((entry) => (
+      typeof entry.item.type === "string" ? entry.item.type : "unknown"
+    )))).sort();
+    return [
+      `source=${history.source}`,
+      `incomplete=${history.incomplete}`,
+      `deferred=${deferredTypes.join(",") || "none"}`,
+      `unresolved=${history.unresolvedCallIds.length}`,
+    ].join(";");
+  } catch {
+    return "history-diagnostic-unavailable";
+  }
+}
 
 type ProviderRebaseResult = ProviderConversationResult & {
   capability: CodexRebaseProviderSmokeEvidence["capability"];
@@ -384,6 +407,10 @@ async function postProviderResponse(
     try {
       const parsed = JSON.parse(text) as JsonObject;
       responseId(parsed, phase);
+      const lifecycleStatus = typeof parsed.status === "string" ? parsed.status.toLowerCase() : undefined;
+      if (lifecycleStatus && lifecycleStatus !== "completed") {
+        throw new Error(`Provider smoke ${phase} returned response status ${lifecycleStatus}`);
+      }
       return parsed;
     } catch (error) {
       if (error instanceof SyntaxError) throw new Error(`Provider smoke ${phase} returned malformed JSON`);
@@ -420,7 +447,7 @@ function firstTurnPayload(params: {
     store: false,
     include: ["reasoning.encrypted_content"],
     reasoning: { effort: "medium", summary: "auto" },
-    max_output_tokens: 512,
+    max_output_tokens: PROVIDER_SMOKE_MAX_OUTPUT_TOKENS,
     metadata: { tokenpilotSessionId: params.sessionId },
     instructions: "Reason about the two synthetic records, then reply with the single word READY.",
     input: [
@@ -440,8 +467,8 @@ function continuationPayload(params: {
     stream: false,
     store: true,
     include: ["reasoning.encrypted_content"],
-    reasoning: { effort: "medium", summary: "auto" },
-    max_output_tokens: 512,
+    reasoning: { effort: "low", summary: "auto" },
+    max_output_tokens: PROVIDER_SMOKE_MAX_OUTPUT_TOKENS,
     tools: [toolDefinition()],
     tool_choice: "none",
     previous_response_id: params.previousResponseId,
@@ -463,8 +490,8 @@ function requiredToolCallPayload(params: {
     stream: false,
     store: false,
     include: ["reasoning.encrypted_content"],
-    reasoning: { effort: "medium", summary: "auto" },
-    max_output_tokens: 512,
+    reasoning: { effort: "low", summary: "auto" },
+    max_output_tokens: PROVIDER_SMOKE_MAX_OUTPUT_TOKENS,
     metadata: { tokenpilotSessionId: params.sessionId },
     tools: [toolDefinition()],
     tool_choice: { type: "function", name: "lookup_smoke_fixture" },
@@ -480,10 +507,12 @@ function storedRootPayload(params: {
   return {
     model: params.model,
     stream: false,
-    store: true,
+    // The provider smoke validates the stateless path, so every setup response
+    // must return the opaque reasoning state required by later replay.
+    store: false,
     include: ["reasoning.encrypted_content"],
-    reasoning: { effort: "medium", summary: "auto" },
-    max_output_tokens: 512,
+    reasoning: { effort: "low", summary: "auto" },
+    max_output_tokens: PROVIDER_SMOKE_MAX_OUTPUT_TOKENS,
     metadata: { tokenpilotSessionId: params.sessionId },
     tools: [toolDefinition()],
     tool_choice: "none",
@@ -506,6 +535,28 @@ function firstReasoning(response: JsonObject): {
   }
   if (!encryptedPayload) throw new Error("Provider response did not include encrypted reasoning content");
   return { reasoning, encryptedPayload };
+}
+
+async function postProviderEncryptedReasoningSample(params: {
+  runtime: CodexProxyRuntime;
+  payload: JsonObject;
+  phase: string;
+}): Promise<{ response: JsonObject; encryptedPayload: string }> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const response = await postProviderResponse(params.runtime, params.payload, params.phase);
+    try {
+      return {
+        response,
+        encryptedPayload: firstReasoning(response).encryptedPayload,
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Provider response did not include replayable encrypted reasoning");
 }
 
 function requiredToolCall(response: JsonObject): { call: JsonObject; callId: string } {
@@ -536,15 +587,20 @@ async function setupStoredRoot(params: {
   firstEncryptedPayload: string;
   toolResponse: JsonObject;
   toolOutputResponse: JsonObject;
+  historyInput: JsonObject[];
   previousResponseId: string;
 }> {
-  const first = await postProviderResponse(params.runtime, firstTurnPayload({
-    model: params.model,
-    sessionId: params.sessionId,
-    evictText: params.evictText,
-    keepText: params.keepText,
-  }), `${params.phase} setup turn 1`);
-  const firstOutput = firstReasoning(first);
+  const firstSample = await postProviderEncryptedReasoningSample({
+    runtime: params.runtime,
+    payload: firstTurnPayload({
+      model: params.model,
+      sessionId: params.sessionId,
+      evictText: params.evictText,
+      keepText: params.keepText,
+    }),
+    phase: `${params.phase} setup turn 1`,
+  });
+  const first = firstSample.response;
   const initialHistory = [
     { role: "user", content: params.evictText },
     { role: "user", content: params.keepText },
@@ -556,25 +612,27 @@ async function setupStoredRoot(params: {
     historyInput: initialHistory,
   }), `${params.phase} setup turn 2`);
   const toolCall = requiredToolCall(toolResponse);
+  const toolOutputHistory = [
+    ...initialHistory,
+    toolRequestItem(),
+    ...jsonItems(toolResponse.output),
+    {
+      type: "function_call_output",
+      call_id: toolCall.callId,
+      output: "retained synthetic tool result",
+    },
+  ];
   const toolOutputResponse = await postProviderResponse(params.runtime, storedRootPayload({
     model: params.model,
     sessionId: params.sessionId,
-    historyInput: [
-      ...initialHistory,
-      toolRequestItem(),
-      ...jsonItems(toolResponse.output),
-      {
-        type: "function_call_output",
-        call_id: toolCall.callId,
-        output: "retained synthetic tool result",
-      },
-    ],
+    historyInput: toolOutputHistory,
   }), `${params.phase} setup turn 3`);
   return {
     first,
-    firstEncryptedPayload: firstOutput.encryptedPayload,
+    firstEncryptedPayload: firstSample.encryptedPayload,
     toolResponse,
     toolOutputResponse,
+    historyInput: [...toolOutputHistory, ...jsonItems(toolOutputResponse.output)],
     previousResponseId: responseId(toolOutputResponse, `${params.phase} setup turn 3`),
   };
 }
@@ -604,15 +662,16 @@ async function runControlConversation(params: {
       ...values,
       phase: "control",
     });
-    let previousResponseId = setup.previousResponseId;
+    let historyInput = setup.historyInput;
     const continuationUsage: ProviderUsageObservation[] = [];
     for (let turn = 1; turn <= params.continuationTurns; turn += 1) {
-      const response = await postProviderResponse(runtime, continuationPayload({
-        model: params.model,
-        previousResponseId,
-        input: [{ role: "user", content: `Acknowledge continuation turn ${turn} with one word.` }],
-      }), `control continuation turn ${turn}`);
-      previousResponseId = responseId(response, `control continuation turn ${turn}`);
+      const currentInput = { role: "user", content: `Acknowledge continuation turn ${turn} with one word.` };
+      const response = await postProviderResponse(runtime, storedRootPayload({
+          model: params.model,
+          sessionId,
+          historyInput: [...historyInput, currentInput],
+        }), `control continuation turn ${turn}`);
+      historyInput = [...historyInput, currentInput, ...jsonItems(response.output)];
       continuationUsage.push(usageObservation(response));
     }
     return {
@@ -629,24 +688,53 @@ async function runControlConversation(params: {
   }
 }
 
-function compatibilityMatrix(realProviderVerifiedItemTypes: string[]): ProviderCompatibilityMatrixEntry[] {
+function compatibilityMatrix(
+  realProviderVerifiedItemTypes: string[],
+  realProviderRejectedItemTypes: string[],
+): ProviderCompatibilityMatrixEntry[] {
   const verified = new Set(realProviderVerifiedItemTypes);
+  const rejected = new Set(realProviderRejectedItemTypes);
   const real = (itemType: string, policy: ProviderCompatibilityMatrixEntry["structuralPolicy"]): ProviderCompatibilityMatrixEntry => ({
     itemType,
     structuralPolicy: policy,
-    providerDecision: verified.has(itemType) ? "real-pass" : "not-observed",
-    evidence: verified.has(itemType) ? "real-provider" : "none",
-    reason: verified.has(itemType) ? "provider_rebase_committed" : "not_observed_in_provider_smoke",
+    providerDecision: verified.has(itemType)
+      ? "real-pass"
+      : rejected.has(itemType) ? "real-reject" : "not-observed",
+    evidence: verified.has(itemType) || rejected.has(itemType) ? "real-provider" : "none",
+    reason: verified.has(itemType)
+      ? "provider_replay_succeeded"
+      : rejected.has(itemType) ? "provider_replay_rejected" : "not_observed_in_provider_smoke",
   });
   return [
+    real("previous_response_id", "transport"),
     real("message", "replay-candidate"),
     real("function_call", "closure-required"),
     real("function_call_output", "closure-required"),
     { itemType: "custom_tool_call", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
     { itemType: "custom_tool_call_output", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "computer_call", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "computer_call_output", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "local_shell_call", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "local_shell_call_output", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "shell_call", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "shell_call_output", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "apply_patch_call", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "apply_patch_call_output", structuralPolicy: "closure-required", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
     real("reasoning", "exact-payload"),
     { itemType: "compaction", structuralPolicy: "exact-payload", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
-    { itemType: "web_search_call", structuralPolicy: "observation-only", providerDecision: "not-observed", evidence: "none", reason: "server_owned_observation_not_replayed" },
+    { itemType: "program", structuralPolicy: "exact-payload", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "program_output", structuralPolicy: "exact-payload", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "web_search_call", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "file_search_call", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "code_interpreter_call", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "image_generation_call", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "mcp_call", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "mcp_list_tools", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "mcp_approval_request", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "mcp_approval_response", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "tool_search_call", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "tool_search_output", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
+    { itemType: "additional_tools", structuralPolicy: "replay-candidate", providerDecision: "not-observed", evidence: "none", reason: "not_emitted_by_provider" },
     { itemType: "unknown", structuralPolicy: "deferred", providerDecision: "not-observed", evidence: "none", reason: "unknown_items_require_explicit_adapter_support" },
   ];
 }
@@ -684,19 +772,31 @@ async function runRebaseConversation(params: {
       headResponseId: previousResponseId,
     });
     const evictedItem = beforeRebase.replayableItems.find((entry) => (
-      JSON.stringify(entry.item).includes(`EVICT_ME_${params.marker}`)
+      JSON.stringify(entry.item).includes(values.evictText)
+      || JSON.stringify(entry.item).includes("discardable provider smoke context")
     ));
-    if (!evictedItem) throw new Error("Provider smoke could not resolve the eviction target");
+    if (!evictedItem) {
+      const diagnostic = await replayDiagnostic({ stateDir, sessionId, headResponseId: previousResponseId });
+      throw new Error(
+        `Provider smoke could not resolve the eviction target; ${diagnostic}; replayable=${beforeRebase.replayableItems.length}`,
+      );
+    }
     config.contextRewrite.mutationPlan = {
       operations: [{ type: "evict", stableItemId: evictedItem.stableItemId }],
     };
 
     const continuationUsage: ProviderUsageObservation[] = [];
-    const rebaseResponse = await postProviderResponse(runtime, continuationPayload({
-      model: params.model,
-      previousResponseId,
-      input: [{ role: "user", content: currentInput }],
-    }), "rebase continuation turn 1");
+    let rebaseResponse: JsonObject;
+    try {
+      rebaseResponse = await postProviderResponse(runtime, continuationPayload({
+        model: params.model,
+        previousResponseId,
+        input: [{ role: "user", content: currentInput }],
+      }), "rebase continuation turn 1");
+    } catch (error) {
+      const diagnostic = await replayDiagnostic({ stateDir, sessionId, headResponseId: previousResponseId });
+      throw new Error(`${error instanceof Error ? error.message : String(error)}; ${diagnostic}`);
+    }
     const newRootResponseId = responseId(rebaseResponse, "rebase continuation turn 1");
     previousResponseId = newRootResponseId;
     continuationUsage.push(usageObservation(rebaseResponse));
@@ -719,11 +819,17 @@ async function runRebaseConversation(params: {
         restartPreserved = await resolveCodexSessionIdByResponseId(stateDir, headBeforeRestart) === sessionId;
       }
       expectedPreviousIds.push(previousResponseId);
-      const response = await postProviderResponse(runtime, continuationPayload({
-        model: params.model,
-        previousResponseId,
-        input: [{ role: "user", content: `Acknowledge continuation turn ${turn} with one word.` }],
-      }), `rebase continuation turn ${turn}`);
+      let response: JsonObject;
+      try {
+        response = await postProviderResponse(runtime, continuationPayload({
+          model: params.model,
+          previousResponseId,
+          input: [{ role: "user", content: `Acknowledge continuation turn ${turn} with one word.` }],
+        }), `rebase continuation turn ${turn}`);
+      } catch (error) {
+        const diagnostic = await replayDiagnostic({ stateDir, sessionId, headResponseId: previousResponseId });
+        throw new Error(`${error instanceof Error ? error.message : String(error)}; ${diagnostic}`);
+      }
       previousResponseId = responseId(response, `rebase continuation turn ${turn}`);
       continuationUsage.push(usageObservation(response));
     }
@@ -773,6 +879,14 @@ async function runRebaseConversation(params: {
         .filter((entry) => entry.status === "verified_supported" && entry.evidence === "real_provider")
         .map((entry) => entry.itemType),
     )).sort();
+    const realProviderRejectedItemTypes = Array.from(new Set(
+      capabilityJournal.capabilities
+        .filter((entry) => (
+          entry.evidence === "real_provider"
+          && (entry.status === "verified_unsupported" || entry.status === "payload_rejected")
+        ))
+        .map((entry) => entry.itemType),
+    )).sort();
 
     return {
       setupUsage: [
@@ -790,8 +904,12 @@ async function runRebaseConversation(params: {
         toolCallPresent: true,
         journalTrusted: !capabilityJournal.readError && capabilityJournal.malformedLineCount === 0,
         realProviderVerifiedItemTypes,
+        realProviderRejectedItemTypes,
       },
-      compatibilityMatrix: compatibilityMatrix(realProviderVerifiedItemTypes),
+      compatibilityMatrix: compatibilityMatrix(
+        realProviderVerifiedItemTypes,
+        realProviderRejectedItemTypes,
+      ),
       rebase: {
         committed: epoch?.status === "committed",
         oldChainReferenceRemoved: Boolean(committedRootResponse)
@@ -888,11 +1006,15 @@ function assertProviderEvidence(evidence: CodexRebaseProviderSmokeEvidence): voi
   const missingVerified = requiredVerified.filter((itemType) => (
     !evidence.capability.realProviderVerifiedItemTypes.includes(itemType)
   ));
+  const contradictoryCapabilities = evidence.capability.realProviderVerifiedItemTypes.filter((itemType) => (
+    evidence.capability.realProviderRejectedItemTypes.includes(itemType)
+  ));
   const checks: Array<[boolean, string]> = [
     [evidence.capability.responsesEndpointAccepted, "Responses endpoint was not accepted"],
     [evidence.capability.encryptedReasoningPresent, "Encrypted reasoning was not observed"],
     [evidence.capability.journalTrusted, "Capability journal was not trusted"],
     [missingVerified.length === 0, `Missing real-provider capability: ${missingVerified.join(",")}`],
+    [contradictoryCapabilities.length === 0, `Contradictory capability evidence: ${contradictoryCapabilities.join(",")}`],
     [evidence.rebase.committed, "Rebase epoch was not committed"],
     [evidence.rebase.oldChainReferenceRemoved, "Old chain reference remained on the new root"],
     [evidence.rebase.currentInputOccurrences === 1, "Current input was not replayed exactly once"],

--- a/components/adapters/codex/src/context-rewrite/index.ts
+++ b/components/adapters/codex/src/context-rewrite/index.ts
@@ -2,6 +2,11 @@ export * from "./types.js";
 export { applyCodexContextRewrite } from "./disabled.js";
 export { executeCodexRebaseWithFallback } from "./fallback.js";
 export {
+  executeCodexProviderContinuationWithReplay,
+  resolveCodexProviderContinuationCompatibility,
+} from "./provider-continuation.js";
+export type { CodexProviderContinuationCompatibility } from "./provider-continuation.js";
+export {
   buildCodexRebaseRequest,
   validateCodexRebaseRequest,
   withCodexRebaseReplayAccountingInput,

--- a/components/adapters/codex/src/context-rewrite/provider-continuation.ts
+++ b/components/adapters/codex/src/context-rewrite/provider-continuation.ts
@@ -1,0 +1,263 @@
+import { collectCodexResponseItemsFromStream } from "../context-history/sse-item-collector.js";
+import { cloneJson } from "./shared.js";
+import {
+  appendCodexRebaseCapability,
+  classifyCodexRebaseCapabilityRejection,
+  codexRebasePayloadDigest,
+  codexRebasePayloadItems,
+  resolveCodexProviderReplayCompatibility,
+} from "./rebase-capability.js";
+import {
+  CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE,
+  type CodexProviderContinuationResult,
+  type CodexRebaseCapabilityStoreParams,
+  type CodexRebaseCapabilityStatus,
+  type CodexUpstreamResponse,
+  type CodexUpstreamSender,
+  type JsonObject,
+} from "./types.js";
+
+export type CodexProviderContinuationCompatibility =
+  | "verified_supported"
+  | "verified_unsupported"
+  | "unknown";
+
+function successful(response: CodexUpstreamResponse): boolean {
+  return response.status >= 200 && response.status < 300;
+}
+
+function previousResponseId(payload: JsonObject): string | undefined {
+  return typeof payload.previous_response_id === "string" && payload.previous_response_id.trim()
+    ? payload.previous_response_id.trim()
+    : undefined;
+}
+
+function replayRequiresEncryptedReasoning(payload: JsonObject): boolean {
+  if (payload.reasoning && typeof payload.reasoning === "object") return true;
+  return Array.isArray(payload.input) && payload.input.some((item) => (
+    item && typeof item === "object" && !Array.isArray(item)
+    && ["reasoning", "compaction", "program", "program_output"].includes(
+      String((item as JsonObject).type ?? "").toLowerCase(),
+    )
+  ));
+}
+
+function statelessContinuationPayload(payload: JsonObject): JsonObject {
+  const next = cloneJson(payload);
+  delete next.previous_response_id;
+  // A provider that cannot dereference response ids cannot supply future
+  // reasoning state from storage. Keep each continuation self-contained.
+  next.store = false;
+  if (replayRequiresEncryptedReasoning(next)) {
+    const include = Array.isArray(next.include)
+      ? next.include.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    if (!include.includes("reasoning.encrypted_content")) {
+      include.push("reasoning.encrypted_content");
+    }
+    next.include = include;
+  }
+  return next;
+}
+
+export async function resolveCodexProviderContinuationCompatibility(params: {
+  chainedPayload: JsonObject;
+  capabilityStore: CodexRebaseCapabilityStoreParams;
+}): Promise<CodexProviderContinuationCompatibility> {
+  const chainId = previousResponseId(params.chainedPayload);
+  if (!chainId) return "unknown";
+  try {
+    const compatibility = await resolveCodexProviderReplayCompatibility({
+      ...params.capabilityStore,
+      items: [{
+        itemType: CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE,
+        payloadDigest: codexRebasePayloadDigest(chainId),
+      }],
+      acceptedEvidence: params.capabilityStore.probeMode === "mock_fixture"
+        ? ["real_provider", "mock_fixture"]
+        : ["real_provider"],
+    });
+    if (!compatibility.journalTrusted) return "unknown";
+    const status = compatibility.decisions[0]?.status;
+    return status === "verified_supported" || status === "verified_unsupported"
+      ? status
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function responseOutputItems(response: CodexUpstreamResponse): JsonObject[] {
+  const contentType = Object.entries(response.headers)
+    .find(([name]) => name.toLowerCase() === "content-type")?.[1]
+    ?.toLowerCase();
+  if (contentType?.includes("text/event-stream") || /^event:\s*response\./mu.test(response.text)) {
+    return collectCodexResponseItemsFromStream(response.text).outputItems;
+  }
+  try {
+    const parsed = JSON.parse(response.text) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+    const output = (parsed as JsonObject).output;
+    return Array.isArray(output)
+      ? output.filter((item): item is JsonObject => Boolean(item && typeof item === "object" && !Array.isArray(item)))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function responseMissingRequestedEncryptedReasoning(
+  request: JsonObject,
+  response: CodexUpstreamResponse,
+): boolean {
+  const include = Array.isArray(request.include) ? request.include : [];
+  if (!include.includes("reasoning.encrypted_content")) return false;
+  return responseOutputItems(response).some((item) => {
+    const type = String(item.type ?? "").toLowerCase();
+    return (type === "reasoning" || type === "compaction")
+      && (typeof item.encrypted_content !== "string" || !item.encrypted_content.trim());
+  });
+}
+
+export async function executeCodexProviderContinuationWithReplay(params: {
+  chainedPayload: JsonObject;
+  statelessReplayPayload: JsonObject;
+  sendUpstream: CodexUpstreamSender;
+  capabilityStore: CodexRebaseCapabilityStoreParams;
+}): Promise<CodexProviderContinuationResult> {
+  const chainId = previousResponseId(params.chainedPayload);
+  if (!chainId || "previous_response_id" in params.statelessReplayPayload) {
+    throw new Error("Codex provider continuation fallback requires chained and stateless payloads");
+  }
+
+  const store = params.capabilityStore;
+  const evidence = store.probeMode === "mock_fixture" ? "mock_fixture" : "real_provider";
+  const statelessPayload = statelessContinuationPayload(params.statelessReplayPayload);
+  const replayItems = codexRebasePayloadItems(statelessPayload);
+  const chainItem = {
+    itemType: CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE,
+    payloadDigest: codexRebasePayloadDigest(chainId),
+  };
+
+  async function safeRecord(paramsForRecord: {
+    itemType: string;
+    status: CodexRebaseCapabilityStatus;
+    reason: string;
+    responseStatus?: number;
+    errorCode?: string;
+    payloadDigest?: string;
+  }): Promise<void> {
+    try {
+      await appendCodexRebaseCapability({
+        stateDir: store.stateDir,
+        provider: store.provider,
+        model: store.model,
+        wireMode: store.wireMode,
+        apiVersion: store.apiVersion,
+        endpointId: store.endpointId,
+        itemType: paramsForRecord.itemType,
+        itemSchemaVersion: store.itemSchemaVersion,
+        status: paramsForRecord.status,
+        evidence,
+        payloadDigest: paramsForRecord.status === "payload_rejected"
+          ? paramsForRecord.payloadDigest
+          : undefined,
+        reason: paramsForRecord.reason,
+        responseStatus: paramsForRecord.responseStatus,
+        errorCode: paramsForRecord.errorCode,
+        observedAt: store.now,
+        ttlMs: store.ttlMs,
+      });
+    } catch {
+      // Provider capability evidence is advisory. Request delivery must continue.
+    }
+  }
+
+  async function recordReplayResult(response: CodexUpstreamResponse): Promise<void> {
+    if (successful(response)) {
+      for (const item of replayItems) {
+        await safeRecord({
+          itemType: item.itemType,
+          status: "verified_supported",
+          reason: "stateless_continuation_succeeded",
+          responseStatus: response.status,
+        });
+      }
+      return;
+    }
+    const classification = classifyCodexRebaseCapabilityRejection({ response, items: replayItems });
+    if (classification.kind === "item_unsupported") {
+      for (const itemType of classification.itemTypes) {
+        await safeRecord({
+          itemType,
+          status: "verified_unsupported",
+          reason: "item_schema_unsupported",
+          responseStatus: response.status,
+          errorCode: classification.errorCode,
+        });
+      }
+    } else if (classification.kind === "payload_rejected") {
+      const rejected = replayItems.filter((item) => classification.itemTypes.includes(item.itemType));
+      for (const item of rejected) {
+        await safeRecord({
+          itemType: item.itemType,
+          status: "payload_rejected",
+          payloadDigest: item.payloadDigest,
+          reason: "encrypted_payload_rejected",
+          responseStatus: response.status,
+          errorCode: classification.errorCode,
+        });
+      }
+    }
+  }
+
+  async function sendStateless(
+    chainedResponse?: CodexUpstreamResponse,
+  ): Promise<CodexProviderContinuationResult> {
+    let response = await params.sendUpstream(cloneJson(statelessPayload));
+    if (successful(response) && responseMissingRequestedEncryptedReasoning(statelessPayload, response)) {
+      response = await params.sendUpstream(cloneJson(statelessPayload));
+    }
+    await recordReplayResult(response);
+    return {
+      response,
+      outcome: successful(response) ? "stateless_replay" : "failed",
+      chainedResponse,
+    };
+  }
+
+  if (await resolveCodexProviderContinuationCompatibility({
+    chainedPayload: params.chainedPayload,
+    capabilityStore: store,
+  }) === "verified_unsupported") {
+    return sendStateless();
+  }
+
+  const chainedResponse = await params.sendUpstream(cloneJson(params.chainedPayload));
+  if (successful(chainedResponse)) {
+    await safeRecord({
+      itemType: chainItem.itemType,
+      status: "verified_supported",
+      reason: "response_chain_continuation_succeeded",
+      responseStatus: chainedResponse.status,
+    });
+    return { response: chainedResponse, outcome: "chained" };
+  }
+
+  const classification = classifyCodexRebaseCapabilityRejection({
+    response: chainedResponse,
+    items: [chainItem],
+  });
+  if (classification.kind !== "chain_reference_unsupported") {
+    return { response: chainedResponse, outcome: "failed" };
+  }
+
+  await safeRecord({
+    itemType: chainItem.itemType,
+    status: "verified_unsupported",
+    reason: "response_chain_reference_unsupported",
+    responseStatus: chainedResponse.status,
+    errorCode: classification.errorCode,
+  });
+  return sendStateless(chainedResponse);
+}

--- a/components/adapters/codex/src/context-rewrite/rebase-capability.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-capability.ts
@@ -37,7 +37,13 @@ export type CodexProviderReplayCompatibilityResult = {
 };
 
 export type CodexRebaseRejectionClassification = {
-  kind: "item_unsupported" | "payload_rejected" | "ambiguous" | "transient" | "unclassified";
+  kind:
+    | "chain_reference_unsupported"
+    | "item_unsupported"
+    | "payload_rejected"
+    | "ambiguous"
+    | "transient"
+    | "unclassified";
   itemTypes: string[];
   errorCode?: string;
 };
@@ -616,6 +622,14 @@ export function classifyCodexRebaseCapabilityRejection(params: {
   }
 
   const text = responseErrorText(params.response);
+  const chainReferenceRejected = text.includes("previous_response_id") && (
+    detectedErrorCode === "invalid_request_error"
+    || detectedErrorCode === "unsupported_parameter"
+    || /(unsupported|not supported|unknown|invalid|unrecognized|does not exist|not found)/iu.test(text)
+  );
+  if (chainReferenceRejected) {
+    return { kind: "chain_reference_unsupported", itemTypes: [], errorCode: detectedErrorCode };
+  }
   const encryptedTypes = itemTypes.filter((itemType) => itemType === "reasoning" || itemType === "compaction");
   const namedEncryptedTypes = encryptedTypes.filter((itemType) => text.includes(itemType.toLowerCase()));
   const payloadSpecific = detectedErrorCode === "invalid_encrypted_content"

--- a/components/adapters/codex/src/context-rewrite/rebase-request.ts
+++ b/components/adapters/codex/src/context-rewrite/rebase-request.ts
@@ -1,3 +1,7 @@
+import {
+  codexProgramCallerId,
+  codexReplayPairRef,
+} from "../context-history/replayability.js";
 import { cloneJson, stableInputKey } from "./shared.js";
 import type {
   CodexEffectiveHistory,
@@ -16,39 +20,45 @@ function evictedStableItemIds(plan: CodexMutationPlan): Set<string> {
   );
 }
 
-type ToolCallRef = {
-  callId?: string;
+type IndexedToolCallRef = ReturnType<typeof codexReplayPairRef> & {
   index?: number;
-  kind?: "function" | "custom";
-  side?: "call" | "output";
-  type?: string;
+  item: JsonObject;
 };
 
-function itemCallRef(item: JsonObject): ToolCallRef {
-  const type = String(item.type ?? "").toLowerCase();
-  const callId = typeof item.call_id === "string" && item.call_id.trim()
-    ? item.call_id.trim()
-    : undefined;
-  if (type === "function_call") return { callId, kind: "function", side: "call", type };
-  if (type === "function_call_output") return { callId, kind: "function", side: "output", type };
-  if (type === "custom_tool_call") return { callId, kind: "custom", side: "call", type };
-  if (type === "custom_tool_call_output") return { callId, kind: "custom", side: "output", type };
-  return {};
+function sameCaller(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }
 
 function closureReasons(items: JsonObject[]): string[] {
-  const refs = new Map<string, { calls: ToolCallRef[]; outputs: ToolCallRef[] }>();
+  const refs = new Map<string, { calls: IndexedToolCallRef[]; outputs: IndexedToolCallRef[] }>();
+  const programs = new Map<string, number[]>();
+  const programOutputs = new Map<string, number[]>();
   const reasons: string[] = [];
   for (const [index, item] of items.entries()) {
-    const ref = { ...itemCallRef(item), index };
-    if (!ref.side) continue;
-    if (!ref.callId) {
-      reasons.push(`tool_call_id_missing:${ref.type}`);
-      continue;
+    const type = String(item.type ?? "").toLowerCase();
+    const callId = typeof item.call_id === "string" && item.call_id.trim()
+      ? item.call_id.trim()
+      : undefined;
+    if (type === "program" || type === "program_output") {
+      if (!callId) reasons.push(`program_call_id_missing:${type}`);
+      else {
+        const target = type === "program" ? programs : programOutputs;
+        const indexes = target.get(callId) ?? [];
+        indexes.push(index);
+        target.set(callId, indexes);
+      }
     }
-    const entry = refs.get(ref.callId) ?? { calls: [], outputs: [] };
-    entry[ref.side === "call" ? "calls" : "outputs"].push(ref);
-    refs.set(ref.callId, entry);
+
+    const ref: IndexedToolCallRef = { ...codexReplayPairRef(item), index, item };
+    if (ref.side) {
+      if (!ref.callId) {
+        reasons.push(`tool_call_id_missing:${ref.type}`);
+        continue;
+      }
+      const entry = refs.get(ref.callId) ?? { calls: [], outputs: [] };
+      entry[ref.side === "call" ? "calls" : "outputs"].push(ref);
+      refs.set(ref.callId, entry);
+    }
   }
   for (const [callId, entry] of refs) {
     if (entry.calls.length !== 1 || entry.outputs.length !== 1) {
@@ -65,6 +75,32 @@ function closureReasons(items: JsonObject[]): string[] {
     }
     if ((entry.outputs[0]?.index ?? -1) <= (entry.calls[0]?.index ?? -1)) {
       reasons.push(`tool_output_before_call:${callId}`);
+    }
+    const programCallerId = codexProgramCallerId(entry.calls[0]!.item);
+    const outputProgramCallerId = codexProgramCallerId(entry.outputs[0]!.item);
+    if (programCallerId) {
+      if (!programs.has(programCallerId)) {
+        reasons.push(`program_caller_missing:${programCallerId}`);
+      } else if ((programs.get(programCallerId)?.[0] ?? Number.MAX_SAFE_INTEGER) >= (entry.calls[0]?.index ?? -1)) {
+        reasons.push(`program_caller_before_program:${programCallerId}`);
+      }
+      if (!sameCaller(entry.calls[0]!.item.caller, entry.outputs[0]!.item.caller)) {
+        reasons.push(`program_caller_mismatch:${callId}`);
+      }
+    } else if (outputProgramCallerId) {
+      reasons.push(`program_caller_mismatch:${callId}`);
+    }
+  }
+  for (const [callId, indexes] of programs) {
+    if (indexes.length > 1) reasons.push(`program_duplicate:${callId}`);
+  }
+  for (const [callId, indexes] of programOutputs) {
+    if (indexes.length > 1) reasons.push(`program_output_duplicate:${callId}`);
+    const programIndexes = programs.get(callId);
+    if (!programIndexes || programIndexes.length === 0) {
+      reasons.push(`program_output_orphan:${callId}`);
+    } else if ((indexes[0] ?? -1) <= (programIndexes[0] ?? -1)) {
+      reasons.push(`program_output_before_program:${callId}`);
     }
   }
   return Array.from(new Set(reasons)).sort();
@@ -115,7 +151,11 @@ export function validateCodexRebaseRequest(params: {
 function stripServerOwnedResponsesFields(item: JsonObject): JsonObject {
   const next = cloneJson(item);
   delete next.id;
-  delete next.status;
+  // These status values are part of their input replay contracts, not merely
+  // response-envelope state.
+  if (!["program_output", "tool_search_call", "tool_search_output"].includes(
+    String(next.type ?? "").toLowerCase(),
+  )) delete next.status;
   delete next.created_at;
   return next;
 }

--- a/components/adapters/codex/src/context-rewrite/types.ts
+++ b/components/adapters/codex/src/context-rewrite/types.ts
@@ -93,6 +93,12 @@ export type CodexRebaseFallbackResult = {
   capability?: CodexRebaseCapabilityNotice;
 };
 
+export type CodexProviderContinuationResult = {
+  response: CodexUpstreamResponse;
+  outcome: "chained" | "stateless_replay" | "failed";
+  chainedResponse?: CodexUpstreamResponse;
+};
+
 export type CodexRebaseEpochStoreParams = {
   stateDir: string;
   oldPreviousResponseId: string;
@@ -129,7 +135,8 @@ export const CODEX_REBASE_CAPABILITY_LEGACY_SCHEMA = "lightmem2.codex.rebase-cap
 export const CODEX_REBASE_CAPABILITY_DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1_000;
 export const CODEX_REBASE_WIRE_MODE = "responses";
 export const CODEX_REBASE_API_VERSION = "responses/v1";
-export const CODEX_REBASE_ITEM_SCHEMA_VERSION = "responses-item/v1";
+export const CODEX_REBASE_ITEM_SCHEMA_VERSION = "responses-item/v2";
+export const CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE = "previous_response_id";
 
 export type CodexRebaseCapabilityStatus =
   | "verified_supported"

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -77,11 +77,14 @@ import {
   acquireCodexRebaseSessionLock,
   buildCodexRebaseRequest,
   codexRebaseEndpointIdentity,
+  executeCodexProviderContinuationWithReplay,
   executeCodexRebaseWithFallback,
   failPendingCodexRebaseEpochsAfterRestart,
+  resolveCodexProviderContinuationCompatibility,
   withCodexRebaseReplayAccountingInput,
 } from "./context-rewrite/index.js";
 import type {
+  CodexRebaseCapabilityEvidence,
   CodexMutationPlan,
   CodexRebaseRequestResult,
 } from "./context-rewrite/types.js";
@@ -374,45 +377,54 @@ export async function startCodexResponsesProxy(params: {
 
       let rebaseRequest: CodexRebaseRequestResult | undefined;
       let rebasePlanId: string | undefined;
+      let continuationReplayRequest: CodexRebaseRequestResult | undefined;
       let rebaseAccounting = rebaseRequest?.accounting;
       const mutationPlan = activeMutationPlan(config);
+      let effectiveHistoryPromise: ReturnType<typeof buildCodexEffectiveHistory> | undefined;
+      const effectiveHistoryForHead = (): ReturnType<typeof buildCodexEffectiveHistory> => {
+        if (!requestJournalEntry || typeof originalPayload.previous_response_id !== "string") {
+          throw new Error("Codex effective history requires a journaled response-chain request");
+        }
+        effectiveHistoryPromise ??= buildCodexEffectiveHistory({
+          stateDir: config.stateDir,
+          sessionId,
+          headResponseId: originalPayload.previous_response_id,
+          currentRequestId: requestJournalEntry.requestId,
+          async rolloutParserBootstrap() {
+            const snapshot = await loadCodexSessionSnapshot(config.stateDir, sessionId);
+            if (!snapshot?.transcriptPath) return null;
+            const rollout = await parseCodexRollout(snapshot.transcriptPath);
+            if (!rollout) return null;
+            const validation = validateCodexRolloutBootstrap({
+              rollout,
+              // prompt_cache_key is an upstream cache namespace, not the
+              // Codex host session identity used by rollout metadata.
+              expectedCodexSessionId: snapshot.codexSessionId,
+              snapshotCodexSessionId: snapshot.codexSessionId,
+              sourceModel: snapshot.latestModel,
+              sourceUpstreamProvider: snapshot.latestUpstreamProvider,
+              currentModel: model,
+              currentCodexProvider: config.providerName,
+              currentUpstreamProvider: upstreamProviderName,
+            });
+            if (validation.rejectionReason) {
+              await appendTrace(config.stateDir, {
+                stage: "context_history_rollout_bootstrap_rejected",
+                sessionId,
+                reason: validation.rejectionReason,
+              });
+            }
+            return validation.history;
+          },
+        });
+        return effectiveHistoryPromise;
+      };
       if (canAttemptCodexRebase({ config, payload: originalPayload, requestEntry: requestJournalEntry })
         && mutationPlan
         && requestJournalEntry) {
         const planId = codexMutationPlanId(mutationPlan);
         try {
-          const effectiveHistory = await buildCodexEffectiveHistory({
-            stateDir: config.stateDir,
-            sessionId,
-            headResponseId: String(originalPayload.previous_response_id),
-            currentRequestId: requestJournalEntry.requestId,
-            async rolloutParserBootstrap() {
-              const snapshot = await loadCodexSessionSnapshot(config.stateDir, sessionId);
-              if (!snapshot?.transcriptPath) return null;
-              const rollout = await parseCodexRollout(snapshot.transcriptPath);
-              if (!rollout) return null;
-              const validation = validateCodexRolloutBootstrap({
-                rollout,
-                // prompt_cache_key is an upstream cache namespace, not the
-                // Codex host session identity used by rollout metadata.
-                expectedCodexSessionId: snapshot.codexSessionId,
-                snapshotCodexSessionId: snapshot.codexSessionId,
-                sourceModel: snapshot.latestModel,
-                sourceUpstreamProvider: snapshot.latestUpstreamProvider,
-                currentModel: model,
-                currentCodexProvider: config.providerName,
-                currentUpstreamProvider: upstreamProviderName,
-              });
-              if (validation.rejectionReason) {
-                await appendTrace(config.stateDir, {
-                  stage: "context_history_rollout_bootstrap_rejected",
-                  sessionId,
-                  reason: validation.rejectionReason,
-                });
-              }
-              return validation.history;
-            },
-          });
+          const effectiveHistory = await effectiveHistoryForHead();
           rebaseRequest = buildCodexRebaseRequest({
             sessionId,
             planId,
@@ -426,6 +438,32 @@ export async function startCodexResponsesProxy(params: {
         } catch (err) {
           await appendTrace(config.stateDir, {
             stage: "context_rewrite_rebase_deferred",
+            sessionId,
+            model,
+            reason: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      const canPrepareContinuationReplay = !rebaseRequest
+        && requestJournalEntry
+        && typeof originalPayload.previous_response_id === "string"
+        && config.contextRewrite.providerCompatibilityProbe !== "disabled";
+      if (canPrepareContinuationReplay) {
+        try {
+          const effectiveHistory = await effectiveHistoryForHead();
+          continuationReplayRequest = buildCodexRebaseRequest({
+            sessionId,
+            planId: "provider-continuation-replay",
+            baseRevision: effectiveHistory.revision,
+            originalPayload,
+            effectiveHistory,
+            currentInput: originalPayload.input,
+            mutationPlan: { baseRevision: effectiveHistory.revision, operations: [] },
+          });
+        } catch (err) {
+          await appendTrace(config.stateDir, {
+            stage: "provider_continuation_replay_deferred",
             sessionId,
             model,
             reason: err instanceof Error ? err.message : String(err),
@@ -511,6 +549,20 @@ export async function startCodexResponsesProxy(params: {
         syncPayloadFromEnvelope(fallbackPayload, fallbackPrepared.envelope, codec);
         normalizeResponsesInputForUpstream(fallbackPayload?.input);
       }
+      let continuationReplayPayload: JsonObject | undefined;
+      if (continuationReplayRequest) {
+        continuationReplayPayload = cloneJsonObject(continuationReplayRequest.payload);
+        const continuationEnvelope = codec.decodeRequest(continuationReplayPayload);
+        const continuationPrepared = await prepareBeforeCallWithReductionSummary<CodexReductionSummary>({
+          envelope: continuationEnvelope,
+          codec,
+          config: { mode: "normal" },
+          prepareStablePrefix: prepareStablePrefixForCodex,
+          applyBeforeCallReduction: applyBeforeCallReductionForCodex,
+        });
+        syncPayloadFromEnvelope(continuationReplayPayload, continuationPrepared.envelope, codec);
+        normalizeResponsesInputForUpstream(continuationReplayPayload?.input);
+      }
       const requestText = extractResponsesInputText(payload?.input);
       const cacheAuditSnapshot = buildCodexCacheAuditSnapshot({
         envelope: prepared.envelope,
@@ -544,6 +596,7 @@ export async function startCodexResponsesProxy(params: {
         promptCacheKey: prepared.envelope.metadata?.promptCacheKey ?? null,
         contextRewriteEnabled: config.contextRewrite.enabled,
         contextRewritePlanned: Boolean(rebaseRequest),
+        providerContinuationReplayPrepared: Boolean(continuationReplayPayload),
       });
 
       const authorization = typeof req.headers.authorization === "string" ? req.headers.authorization : undefined;
@@ -553,6 +606,27 @@ export async function startCodexResponsesProxy(params: {
         inboundAuthorization: authorization,
         stateDir: config.stateDir,
       });
+      const acceptedEvidence: CodexRebaseCapabilityEvidence[] = params.allowMockFixtureEvidence
+        ? ["real_provider", "mock_fixture"]
+        : ["real_provider"];
+      const capabilityStore = {
+        stateDir: config.stateDir,
+        provider: upstreamProviderName,
+        model,
+        wireMode: CODEX_REBASE_WIRE_MODE,
+        apiVersion: CODEX_REBASE_API_VERSION,
+        endpointId: codexRebaseEndpointIdentity(upstream.baseUrl),
+        itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+        probeMode: config.contextRewrite.providerCompatibilityProbe,
+        acceptedEvidence,
+        evidenceSource: params.allowMockFixtureEvidence ? "mock_fixture" : "real_provider",
+      } as const;
+      const nativeStreamChainVerified = payload.stream === true
+        && continuationReplayPayload
+        && await resolveCodexProviderContinuationCompatibility({
+          chainedPayload: payload,
+          capabilityStore,
+        }) === "verified_supported";
       let contextRewriteOutcome: string | undefined;
       let contextHistoryJournalPersisted = false;
 
@@ -573,7 +647,11 @@ export async function startCodexResponsesProxy(params: {
           sessionId,
           requestId: requestJournalEntry.requestId,
           rawStreamText: paramsForJournal.rawStreamText,
-          previousResponseId: paramsForJournal.committed ? null : undefined,
+          previousResponseId: paramsForJournal.committed
+            ? null
+            : typeof originalPayload.previous_response_id === "string"
+              ? originalPayload.previous_response_id
+              : null,
           status,
           error,
         });
@@ -607,7 +685,11 @@ export async function startCodexResponsesProxy(params: {
           sessionId,
           requestId: requestJournalEntry.requestId,
           response: paramsForJournal.response,
-          previousResponseId: paramsForJournal.committed ? null : undefined,
+          previousResponseId: paramsForJournal.committed
+            ? null
+            : typeof originalPayload.previous_response_id === "string"
+              ? originalPayload.previous_response_id
+              : null,
           status,
           error,
         });
@@ -646,51 +728,55 @@ export async function startCodexResponsesProxy(params: {
         contextHistoryJournalPersisted = true;
       };
 
-      const sendRebasedOrCurrentPayload = () => rebaseRequest && requestJournalEntry && rebasePlanId
-        ? executeCodexRebaseWithFallback({
-          sessionId,
-          planId: rebasePlanId,
-          epochId: `epoch-${requestJournalEntry.requestId}`,
-          originalPayload: fallbackPayload,
-          rebasedPayload: payload,
-          sendUpstream,
-          beforeCommit: persistAcceptedRebaseResponse,
-          accounting: rebaseAccounting,
-          epochStore: {
-            stateDir: config.stateDir,
-            oldPreviousResponseId: String(originalPayload.previous_response_id),
-            oldRevision: rebaseRequest.oldRevision,
-            newRevision: rebaseRequest.rebaseRevision,
-          },
-          cooldownStore: {
-            stateDir: config.stateDir,
-            cooldownMs: config.contextRewrite.cooldownMs,
-          },
-          capabilityStore: {
-            stateDir: config.stateDir,
-            provider: upstreamProviderName,
-            model,
-            wireMode: CODEX_REBASE_WIRE_MODE,
-            apiVersion: CODEX_REBASE_API_VERSION,
-            endpointId: codexRebaseEndpointIdentity(upstream.baseUrl),
-            itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
-            probeMode: config.contextRewrite.providerCompatibilityProbe,
-            acceptedEvidence: params.allowMockFixtureEvidence
-              ? ["real_provider", "mock_fixture"]
-              : ["real_provider"],
-            evidenceSource: params.allowMockFixtureEvidence ? "mock_fixture" : "real_provider",
-          },
-        }).then((result) => {
+      const sendRebasedOrCurrentPayload = async () => {
+        if (rebaseRequest && requestJournalEntry && rebasePlanId) {
+          const result = await executeCodexRebaseWithFallback({
+            sessionId,
+            planId: rebasePlanId,
+            epochId: `epoch-${requestJournalEntry.requestId}`,
+            originalPayload: fallbackPayload,
+            rebasedPayload: payload,
+            sendUpstream,
+            beforeCommit: persistAcceptedRebaseResponse,
+            accounting: rebaseAccounting,
+            epochStore: {
+              stateDir: config.stateDir,
+              oldPreviousResponseId: String(originalPayload.previous_response_id),
+              oldRevision: rebaseRequest.oldRevision,
+              newRevision: rebaseRequest.rebaseRevision,
+            },
+            cooldownStore: {
+              stateDir: config.stateDir,
+              cooldownMs: config.contextRewrite.cooldownMs,
+            },
+            capabilityStore,
+          });
           contextRewriteOutcome = result.outcome;
           if (result.outcome !== "committed") contextHistoryJournalPersisted = false;
           return result.response;
-        })
-        : sendUpstream(payload);
+        }
+        if (continuationReplayPayload) {
+          const result = await executeCodexProviderContinuationWithReplay({
+            chainedPayload: payload,
+            statelessReplayPayload: continuationReplayPayload,
+            sendUpstream,
+            capabilityStore,
+          });
+          contextRewriteOutcome = result.outcome;
+          return result.response;
+        }
+        return sendUpstream(payload);
+      };
       const recordStreamResponse = async (paramsForRecord: {
         status: number;
         rawStreamText: string;
       }): Promise<void> => {
         const snapshot = snapshotCodexResponsesStream(paramsForRecord.rawStreamText);
+        const logicalPreviousResponseId = contextRewriteOutcome === "committed"
+          ? undefined
+          : typeof originalPayload.previous_response_id === "string"
+            ? originalPayload.previous_response_id
+            : undefined;
         const collected = collectCodexResponseItemsFromStream(paramsForRecord.rawStreamText);
         const requestStatus = streamRequestStatus({
           httpStatus: paramsForRecord.status,
@@ -739,12 +825,12 @@ export async function startCodexResponsesProxy(params: {
           responseChars: paramsForRecord.rawStreamText.length,
           assistantChars: snapshot.assistantText.length,
           responseId: snapshot.responseId ?? null,
-          previousResponseId: snapshot.previousResponseId ?? null,
+          previousResponseId: logicalPreviousResponseId ?? null,
           contextRewriteOutcome: contextRewriteOutcome ?? null,
         });
         await upsertCodexSessionSnapshot(config.stateDir, sessionId, {
           latestResponseId: snapshot.responseId,
-          previousResponseId: snapshot.previousResponseId,
+          previousResponseId: logicalPreviousResponseId,
           latestModel: model,
           latestUpstreamProvider: upstreamProviderName,
           disclosedReadPaths: reductionSummary?.disclosedReadPaths,
@@ -755,7 +841,7 @@ export async function startCodexResponsesProxy(params: {
         await appendCodexRecentTurnBinding(config.stateDir, {
           sessionId,
           responseId: snapshot.responseId,
-          previousResponseId: snapshot.previousResponseId,
+          previousResponseId: logicalPreviousResponseId,
           model,
           requestChars: requestText.length,
           responseChars: paramsForRecord.rawStreamText.length,
@@ -765,7 +851,8 @@ export async function startCodexResponsesProxy(params: {
         });
       };
       if (payload.stream === true) {
-        if (rebaseRequest && requestJournalEntry) {
+        if ((rebaseRequest && requestJournalEntry)
+          || (continuationReplayPayload && !nativeStreamChainVerified)) {
           const upstreamResp = await sendRebasedOrCurrentPayload();
           res.statusCode = upstreamResp.status;
           setForwardResponseHeaders(res, upstreamResp.headers, "text/event-stream; charset=utf-8");
@@ -832,14 +919,21 @@ export async function startCodexResponsesProxy(params: {
 
       const upstreamResp = await sendRebasedOrCurrentPayload();
       const responseJson = parseJsonObject(upstreamResp.text);
-      let responseId: string | undefined;
-      let previousResponseId: string | undefined;
+      let responseId = typeof responseJson?.id === "string" && responseJson.id.trim()
+        ? responseJson.id
+        : undefined;
+      const previousResponseId = contextRewriteOutcome === "committed"
+        ? undefined
+        : typeof originalPayload.previous_response_id === "string"
+          ? originalPayload.previous_response_id
+          : undefined;
       let assistantChars = 0;
       let toolCallCount = 0;
       try {
         const decoded = codec.decodeResponse(responseJson ?? JSON.parse(upstreamResp.text), prepared.envelope);
-        responseId = typeof decoded.metadata?.responseId === "string" ? decoded.metadata.responseId : undefined;
-        previousResponseId = typeof decoded.metadata?.previousResponseId === "string" ? decoded.metadata.previousResponseId : undefined;
+        responseId = typeof decoded.metadata?.responseId === "string" && decoded.metadata.responseId
+          ? decoded.metadata.responseId
+          : responseId;
         assistantChars = decoded.assistantText?.length ?? 0;
         toolCallCount = decoded.toolCalls?.length ?? 0;
         await appendCodexCacheAuditRecord({

--- a/components/adapters/codex/src/upstream.ts
+++ b/components/adapters/codex/src/upstream.ts
@@ -2,6 +2,7 @@
 import { readJsonFile, writeJsonFileAtomic } from "@lightmem2/host-adapter";
 import { join } from "node:path";
 import { Readable } from "node:stream";
+import { collectCodexResponseItemsFromStream } from "./context-history/sse-item-collector.js";
 import type { CodexProviderConfig } from "./config.js";
 
 export type UpstreamHttpResponse = {
@@ -71,6 +72,31 @@ function unsupportedOptionalFieldFromText(text: string): OptionalResponsesField 
     return "prompt_cache_key";
   }
   return undefined;
+}
+
+function encryptedReasoningRequested(payload: any): boolean {
+  return Array.isArray(payload?.include) && payload.include.includes("reasoning.encrypted_content");
+}
+
+function outputItemsFromResponse(text: string, contentType: string | null): any[] {
+  if (contentType?.toLowerCase().includes("text/event-stream") || /^event:\s*response\./mu.test(text)) {
+    return collectCodexResponseItemsFromStream(text).outputItems;
+  }
+  try {
+    const parsed = JSON.parse(text) as any;
+    return Array.isArray(parsed?.output) ? parsed.output : [];
+  } catch {
+    return [];
+  }
+}
+
+function requestedEncryptedReasoningMissing(payload: any, resp: Response, text: string): boolean {
+  if (!encryptedReasoningRequested(payload)) return false;
+  return outputItemsFromResponse(text, resp.headers.get("content-type")).some((item) => {
+    const type = String(item?.type ?? "").toLowerCase();
+    return (type === "reasoning" || type === "compaction")
+      && (typeof item?.encrypted_content !== "string" || !item.encrypted_content.trim());
+  });
 }
 
 function upstreamCapabilityPath(stateDir: string, upstream: CodexProviderConfig): string {
@@ -143,6 +169,14 @@ export async function requestUpstreamResponses(params: {
         text = await resp.text();
       }
     }
+  }
+  let encryptedRepairAttempts = 0;
+  while (resp.ok
+    && requestedEncryptedReasoningMissing(payload, resp, text)
+    && encryptedRepairAttempts < 2) {
+    encryptedRepairAttempts += 1;
+    resp = await send(payload);
+    text = await resp.text();
   }
   return {
     status: resp.status,

--- a/components/adapters/codex/tests/config.test.ts
+++ b/components/adapters/codex/tests/config.test.ts
@@ -53,9 +53,9 @@ test("normalizeTokenPilotCodexConfig preserves context rewrite plan revisions", 
   ]);
 });
 
-test("normalizeTokenPilotCodexConfig disables provider compatibility probing by default", () => {
+test("normalizeTokenPilotCodexConfig enables real-provider compatibility learning by default", () => {
   assert.equal(
     normalizeTokenPilotCodexConfig({}).contextRewrite.providerCompatibilityProbe,
-    "disabled",
+    "real_provider",
   );
 });

--- a/components/adapters/codex/tests/context-history-effective-history.test.ts
+++ b/components/adapters/codex/tests/context-history-effective-history.test.ts
@@ -68,6 +68,48 @@ test("CDH-04 Effective History Builder marks an orphan incomplete response after
   });
 });
 
+test("CDH-04 Effective History Builder preserves ordered turns when a provider reuses response ids", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-reused-response-id";
+    for (let turn = 1; turn <= 3; turn += 1) {
+      const requestId = `request-${turn}`;
+      await appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId,
+        turnOrdinal: turn,
+        payload: {
+          ...(turn > 1 ? { previous_response_id: "resp-provider-reused" } : {}),
+          input: [{ role: "user", content: `reused id turn ${turn}` }],
+        },
+        status: "completed",
+      });
+      await appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId,
+        requestId,
+        response: {
+          id: "resp-provider-reused",
+          output: [{ type: "message", role: "assistant", content: `answer ${turn}` }],
+        },
+        previousResponseId: turn > 1 ? "resp-provider-reused" : null,
+        status: "completed",
+      });
+    }
+
+    const history = await buildCodexEffectiveHistory({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-provider-reused",
+    });
+
+    assert.equal(history.incomplete, false);
+    assert.match(JSON.stringify(history.replayableItems), /reused id turn 1/);
+    assert.match(JSON.stringify(history.replayableItems), /reused id turn 2/);
+    assert.match(JSON.stringify(history.replayableItems), /reused id turn 3/);
+  });
+});
+
 test("CDH-04 Effective History Builder builds proxy journal history in strict order with replay and observation split", async () => {
   await withTempState(async (stateDir) => {
     await appendCodexRequestJournalEntry({
@@ -137,11 +179,10 @@ test("CDH-04 Effective History Builder builds proxy journal history in strict or
     assert.equal(history.source, "proxy_journal");
     assert.equal(history.incomplete, false);
     assert.equal(history.unresolvedCallIds.length, 0);
-    assert.equal(history.observationOnlyItems.length, 1);
-    assert.equal(history.observationOnlyItems[0]?.item.type, "web_search_call");
+    assert.equal(history.observationOnlyItems.length, 0);
     assert.deepEqual(
       history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
-      ["developer", "user", "message", "function_call", "function_call_output", "user", "message"],
+      ["developer", "user", "message", "function_call", "web_search_call", "function_call_output", "user", "message"],
     );
     assert.match(history.revision, /^rev-[0-9a-f]+$/);
   });

--- a/components/adapters/codex/tests/context-history-replayability.test.ts
+++ b/components/adapters/codex/tests/context-history-replayability.test.ts
@@ -105,6 +105,86 @@ test("CDH-05 Replayability defers compaction without its exact encrypted payload
   assert.equal(isCodexDeferredItem(compaction), true);
 });
 
+test("CDH-05 Replayability recognizes the full Responses client-tool closure family", () => {
+  for (const type of [
+    "computer_call",
+    "computer_call_output",
+    "local_shell_call",
+    "local_shell_call_output",
+    "shell_call",
+    "shell_call_output",
+    "apply_patch_call",
+    "apply_patch_call_output",
+  ]) {
+    assertReplayability({ type, call_id: `call-${type}` }, "replayable", "tool_closure_required");
+  }
+});
+
+test("CDH-05 Replayability requires exact program replay state", () => {
+  assertReplayability({
+    type: "program",
+    call_id: "call-program",
+    code: "text('done')",
+    fingerprint: "opaque-program-state",
+  }, "replayable", "program_payload_required");
+  assertReplayability({
+    type: "program_output",
+    call_id: "call-program",
+    result: "done",
+    status: "completed",
+  }, "replayable", "program_payload_required");
+  assertReplayability({
+    type: "program",
+    call_id: "call-program",
+    code: "text('done')",
+  }, "deferred", "program_payload_missing");
+  assertReplayability({
+    type: "program_output",
+    call_id: "call-program",
+  }, "deferred", "program_payload_missing");
+});
+
+test("CDH-05 Replayability recognizes provider-produced Responses replay items", () => {
+  for (const type of [
+    "web_search_call",
+    "file_search_call",
+    "code_interpreter_call",
+    "image_generation_call",
+    "mcp_call",
+    "mcp_list_tools",
+    "mcp_approval_request",
+    "mcp_approval_response",
+    "tool_search_call",
+    "tool_search_output",
+    "additional_tools",
+  ]) {
+    assertReplayability({ type }, "replayable", "provider_output_replay");
+  }
+});
+
+test("CDH-05 Replayability requires client tool-search call/output ids but accepts hosted items", () => {
+  assertReplayability({
+    type: "tool_search_call",
+    execution: "client",
+    call_id: "search-1",
+  }, "replayable", "tool_closure_required");
+  assertReplayability({
+    type: "tool_search_output",
+    execution: "client",
+    call_id: "search-1",
+    tools: [],
+  }, "replayable", "tool_closure_required");
+  assertReplayability({
+    type: "tool_search_call",
+    execution: "client",
+  }, "deferred", "tool_call_id_missing");
+  assertReplayability({
+    type: "tool_search_call",
+    execution: "server",
+    call_id: null,
+  }, "replayable", "provider_output_replay");
+});
+
 test("CDH-05 Replayability separates exact encrypted payloads from malformed payloads", () => {
   for (const type of ["reasoning", "compaction"] as const) {
     assertReplayability(
@@ -129,14 +209,13 @@ test("CDH-05 Replayability defers unknown provider item types", () => {
   assert.equal(isCodexDeferredItem(item), true);
 });
 
-test("CDH-05 Replayability classifies provider observations as observation-only by default", () => {
-  for (const item of [
-    { type: "web_search_call", query: "provider-owned observation" },
-    { type: "event_msg", message: "runtime event" },
-  ]) {
-    assertReplayability(item, "observation_only", "provider_observation");
-    assert.equal(isCodexObservationOnlyItem(item), true);
-  }
+test("CDH-05 Replayability replays Responses output items but keeps runtime events observation-only", () => {
+  const webSearch = { type: "web_search_call", query: "provider-owned output" };
+  assertReplayability(webSearch, "replayable", "provider_output_replay");
+  assert.equal(isCodexObservationOnlyItem(webSearch), false);
+  const event = { type: "event_msg", message: "runtime event" };
+  assertReplayability(event, "observation_only", "provider_observation");
+  assert.equal(isCodexObservationOnlyItem(event), true);
   const turnContext = { type: "turn_context", content: "current turn metadata" };
   assertReplayability(turnContext, "observation_only", "turn_context_instruction");
   assert.equal(isCodexObservationOnlyItem(turnContext), true);

--- a/components/adapters/codex/tests/context-provider-continuation.test.ts
+++ b/components/adapters/codex/tests/context-provider-continuation.test.ts
@@ -1,0 +1,227 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  appendCodexRebaseCapability,
+  codexRebaseEndpointIdentity,
+  executeCodexProviderContinuationWithReplay,
+  readCodexRebaseCapabilityJournal,
+  resolveCodexProviderContinuationCompatibility,
+} from "../src/context-rewrite/index.js";
+import {
+  CODEX_REBASE_API_VERSION,
+  CODEX_REBASE_ITEM_SCHEMA_VERSION,
+  CODEX_REBASE_WIRE_MODE,
+  CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE,
+  type CodexRebaseCapabilityStoreParams,
+  type JsonObject,
+} from "../src/context-rewrite/types.js";
+
+async function withTempState(run: (stateDir: string) => Promise<void>): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-provider-continuation-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function capabilityStore(stateDir: string): CodexRebaseCapabilityStoreParams {
+  return {
+    stateDir,
+    provider: "provider-fixture",
+    model: "gpt-fixture",
+    wireMode: CODEX_REBASE_WIRE_MODE,
+    apiVersion: CODEX_REBASE_API_VERSION,
+    endpointId: codexRebaseEndpointIdentity("https://provider.example/v1/responses"),
+    itemSchemaVersion: CODEX_REBASE_ITEM_SCHEMA_VERSION,
+    probeMode: "real_provider",
+    now: "2026-08-08T00:00:00.000Z",
+  };
+}
+
+const chainedPayload: JsonObject = {
+  model: "gpt-fixture",
+  previous_response_id: "resp-root",
+  input: [{ type: "function_call_output", call_id: "call-1", output: "ok" }],
+};
+const encryptedReasoning = {
+  type: "reasoning",
+  encrypted_content: "opaque-encrypted-payload",
+  summary: [],
+};
+const statelessReplayPayload: JsonObject = {
+  model: "gpt-fixture",
+  input: [
+    { role: "user", content: "start" },
+    encryptedReasoning,
+    { type: "function_call", call_id: "call-1", name: "lookup", arguments: "{}" },
+    { type: "function_call_output", call_id: "call-1", output: "ok" },
+  ],
+};
+
+test("CDR-05 provider continuation retries explicit chain rejection as exact stateless replay", async () => {
+  await withTempState(async (stateDir) => {
+    const requests: JsonObject[] = [];
+    const result = await executeCodexProviderContinuationWithReplay({
+      chainedPayload,
+      statelessReplayPayload,
+      capabilityStore: capabilityStore(stateDir),
+      async sendUpstream(payload) {
+        requests.push(payload);
+        return "previous_response_id" in payload
+          ? {
+            status: 400,
+            headers: {},
+            text: JSON.stringify({ error: { code: "invalid_request_error", message: "previous_response_id is not supported" } }),
+          }
+          : { status: 200, headers: {}, text: JSON.stringify({ id: "resp-stateless", status: "completed" }) };
+      },
+    });
+
+    assert.equal(result.outcome, "stateless_replay");
+    assert.equal(result.chainedResponse?.status, 400);
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0]?.previous_response_id, "resp-root");
+    assert.equal("previous_response_id" in (requests[1] ?? {}), false);
+    assert.equal(requests[1]?.store, false);
+    assert.deepEqual(requests[1]?.include, ["reasoning.encrypted_content"]);
+    assert.deepEqual((requests[1]?.input as JsonObject[])[1], encryptedReasoning);
+
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    const statuses = new Map(journal.capabilities.map((entry) => [entry.itemType, entry.status]));
+    assert.equal(statuses.get(CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE), "verified_unsupported");
+    assert.equal(statuses.get("reasoning"), "verified_supported");
+    assert.equal(statuses.get("function_call"), "verified_supported");
+    assert.equal(statuses.get("function_call_output"), "verified_supported");
+  });
+});
+
+test("CDR-05 provider continuation uses cached chain incompatibility without repeating the rejected request", async () => {
+  await withTempState(async (stateDir) => {
+    const store = capabilityStore(stateDir);
+    await appendCodexRebaseCapability({
+      ...store,
+      itemType: CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE,
+      status: "verified_unsupported",
+      evidence: "real_provider",
+      reason: "response_chain_reference_unsupported",
+      ttlMs: 60_000,
+    });
+    const requests: JsonObject[] = [];
+    const result = await executeCodexProviderContinuationWithReplay({
+      chainedPayload,
+      statelessReplayPayload,
+      capabilityStore: store,
+      async sendUpstream(payload) {
+        requests.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-stateless", status: "completed" }) };
+      },
+    });
+
+    assert.equal(result.outcome, "stateless_replay");
+    assert.equal(requests.length, 1);
+    assert.equal("previous_response_id" in (requests[0] ?? {}), false);
+  });
+});
+
+test("CDR-05 provider continuation retries once when requested encrypted reasoning is omitted", async () => {
+  await withTempState(async (stateDir) => {
+    const responses = [
+      {
+        status: 400,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({ error: { code: "invalid_request_error", message: "previous_response_id is invalid" } }),
+      },
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({
+          id: "resp-missing-encrypted",
+          status: "completed",
+          output: [{ type: "reasoning", summary: [] }, { type: "message", role: "assistant", content: [] }],
+        }),
+      },
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({
+          id: "resp-with-encrypted",
+          status: "completed",
+          output: [{ type: "reasoning", encrypted_content: "next-opaque-state", summary: [] }],
+        }),
+      },
+    ];
+    let requestCount = 0;
+    const result = await executeCodexProviderContinuationWithReplay({
+      chainedPayload,
+      statelessReplayPayload,
+      capabilityStore: capabilityStore(stateDir),
+      async sendUpstream() {
+        const response = responses[requestCount];
+        requestCount += 1;
+        if (!response) throw new Error("unexpected provider request");
+        return response;
+      },
+    });
+
+    assert.equal(result.outcome, "stateless_replay");
+    assert.equal(requestCount, 3);
+    assert.match(result.response.text, /next-opaque-state/);
+  });
+});
+
+test("CDR-05 provider continuation keeps native chaining after a successful provider response", async () => {
+  await withTempState(async (stateDir) => {
+    const requests: JsonObject[] = [];
+    const result = await executeCodexProviderContinuationWithReplay({
+      chainedPayload,
+      statelessReplayPayload,
+      capabilityStore: capabilityStore(stateDir),
+      async sendUpstream(payload) {
+        requests.push(payload);
+        return { status: 200, headers: {}, text: JSON.stringify({ id: "resp-chain", status: "completed" }) };
+      },
+    });
+
+    assert.equal(result.outcome, "chained");
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0]?.previous_response_id, "resp-root");
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(
+      journal.capabilities.find((entry) => entry.itemType === CODEX_RESPONSE_CHAIN_CAPABILITY_ITEM_TYPE)?.status,
+      "verified_supported",
+    );
+    assert.equal(await resolveCodexProviderContinuationCompatibility({
+      chainedPayload,
+      capabilityStore: capabilityStore(stateDir),
+    }), "verified_supported");
+  });
+});
+
+test("CDR-05 provider continuation does not retry unrelated provider rejections", async () => {
+  await withTempState(async (stateDir) => {
+    let requestCount = 0;
+    const result = await executeCodexProviderContinuationWithReplay({
+      chainedPayload,
+      statelessReplayPayload,
+      capabilityStore: capabilityStore(stateDir),
+      async sendUpstream() {
+        requestCount += 1;
+        return {
+          status: 400,
+          headers: {},
+          text: JSON.stringify({ error: { code: "invalid_request_error", message: "invalid tool schema" } }),
+        };
+      },
+    });
+
+    assert.equal(result.outcome, "failed");
+    assert.equal(requestCount, 1);
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(journal.capabilities.length, 0);
+  });
+});

--- a/components/adapters/codex/tests/context-rebase-behavior.test.ts
+++ b/components/adapters/codex/tests/context-rebase-behavior.test.ts
@@ -323,6 +323,236 @@ test("CDR-01 rejects malformed, duplicate, and protocol-mismatched tool closure"
   ], /tool_output_before_call:reversed/);
 });
 
+test("CDR-01 replays PTC program state and caller links exactly", () => {
+  const caller = { type: "program", caller_id: "call-program-1" };
+  const effectiveHistory: CodexEffectiveHistory = {
+    revision: "history-ptc-1",
+    replayableItems: [
+      {
+        stableItemId: "program-1",
+        nativeId: "prog-1",
+        item: {
+          id: "prog-server-1",
+          type: "program",
+          call_id: "call-program-1",
+          code: "const value = await tools.lookup({}); text(value);",
+          fingerprint: "opaque-program-fingerprint",
+        },
+      },
+      {
+        stableItemId: "program-call-1",
+        nativeId: "fc-program-1",
+        item: {
+          id: "fc-server-1",
+          type: "function_call",
+          call_id: "call-nested-1",
+          name: "lookup",
+          arguments: "{}",
+          caller,
+        },
+      },
+      {
+        stableItemId: "program-call-output-1",
+        nativeId: "fco-program-1",
+        item: {
+          type: "function_call_output",
+          call_id: "call-nested-1",
+          output: "value",
+          caller,
+        },
+      },
+      {
+        stableItemId: "program-output-1",
+        nativeId: "prog-out-1",
+        item: {
+          id: "prog-out-server-1",
+          type: "program_output",
+          call_id: "call-program-1",
+          result: "value",
+          status: "completed",
+        },
+      },
+    ],
+    observationOnlyItems: [],
+    deferredItems: [],
+    unresolvedCallIds: [],
+    source: "proxy_journal",
+    incomplete: false,
+  };
+  const originalPayload = { ...baseResponsesPayload(), input: [{ role: "user", content: "continue" }] };
+  const result = buildCodexRebaseRequest({
+    sessionId: "codex-session-ptc",
+    planId: "plan-ptc",
+    baseRevision: effectiveHistory.revision,
+    originalPayload,
+    effectiveHistory,
+    currentInput: originalPayload.input,
+    mutationPlan: { operations: [] },
+  });
+  const input = result.payload.input as JsonObject[];
+  const program = input.find((item) => item.type === "program");
+  const call = input.find((item) => item.type === "function_call");
+  const output = input.find((item) => item.type === "function_call_output");
+  const programOutput = input.find((item) => item.type === "program_output");
+  assert.equal(program?.id, undefined);
+  assert.equal(program?.fingerprint, "opaque-program-fingerprint");
+  assert.deepEqual(call?.caller, caller);
+  assert.deepEqual(output?.caller, caller);
+  assert.equal(programOutput?.id, undefined);
+  assert.equal(programOutput?.status, "completed");
+});
+
+test("CDR-01 rejects broken PTC program dependencies and changed caller payloads", () => {
+  const program = {
+    stableItemId: "program-1",
+    nativeId: "prog-1",
+    item: {
+      type: "program",
+      call_id: "call-program-1",
+      code: "const value = await tools.lookup({}); text(value);",
+      fingerprint: "opaque-program-fingerprint",
+    },
+  };
+  const call = {
+    stableItemId: "program-call-1",
+    nativeId: "fc-program-1",
+    callId: "call-nested-1",
+    item: {
+      type: "function_call",
+      call_id: "call-nested-1",
+      name: "lookup",
+      arguments: "{}",
+      caller: { type: "program", caller_id: "call-program-1" },
+    },
+  };
+  const effectiveHistory: CodexEffectiveHistory = {
+    revision: "history-ptc-broken",
+    replayableItems: [program, call],
+    observationOnlyItems: [],
+    deferredItems: [],
+    unresolvedCallIds: ["call-nested-1"],
+    source: "proxy_journal",
+    incomplete: false,
+  };
+  const mismatchedOutput = [{
+    type: "function_call_output",
+    call_id: "call-nested-1",
+    output: "value",
+    caller: { type: "program", caller_id: "different-program" },
+  }];
+  assert.throws(() => buildCodexRebaseRequest({
+    sessionId: "codex-session-ptc",
+    planId: "plan-ptc-caller-mismatch",
+    baseRevision: effectiveHistory.revision,
+    originalPayload: { ...baseResponsesPayload(), input: mismatchedOutput },
+    effectiveHistory,
+    currentInput: mismatchedOutput,
+    mutationPlan: { operations: [] },
+  }), /program_caller_mismatch:call-nested-1/);
+
+  const exactOutput = [{
+    type: "function_call_output",
+    call_id: "call-nested-1",
+    output: "value",
+    caller: { type: "program", caller_id: "call-program-1" },
+  }];
+  assert.throws(() => buildCodexRebaseRequest({
+    sessionId: "codex-session-ptc",
+    planId: "plan-ptc-evict-program",
+    baseRevision: effectiveHistory.revision,
+    originalPayload: { ...baseResponsesPayload(), input: exactOutput },
+    effectiveHistory,
+    currentInput: exactOutput,
+    mutationPlan: { operations: [{ type: "evict", stableItemId: "program-1" }] },
+  }), /program_caller_missing:call-program-1/);
+
+  assert.throws(() => buildCodexRebaseRequest({
+    sessionId: "codex-session-ptc",
+    planId: "plan-ptc-orphan-output",
+    baseRevision: "history-empty",
+    originalPayload: baseResponsesPayload(),
+    effectiveHistory: {
+      revision: "history-empty",
+      replayableItems: [],
+      observationOnlyItems: [],
+      deferredItems: [],
+      unresolvedCallIds: [],
+      source: "proxy_journal",
+      incomplete: false,
+    },
+    currentInput: [{
+      type: "program_output",
+      call_id: "call-orphan-program",
+      result: "done",
+      status: "completed",
+    }],
+    mutationPlan: { operations: [] },
+  }), /program_output_orphan:call-orphan-program/);
+});
+
+test("CDR-01 preserves client tool-search closure and replay status", () => {
+  const toolSearchInput = [
+    {
+      id: "tool-search-server-call",
+      type: "tool_search_call",
+      call_id: "tool-search-1",
+      execution: "client",
+      status: "completed",
+      query: "weather tool",
+    },
+    {
+      id: "tool-search-server-output",
+      type: "tool_search_output",
+      call_id: "tool-search-1",
+      execution: "client",
+      status: "completed",
+      tools: [{ type: "function", name: "weather" }],
+    },
+  ];
+  const effectiveHistory: CodexEffectiveHistory = {
+    revision: "history-tool-search",
+    replayableItems: toolSearchInput.map((item, index) => ({
+      stableItemId: `tool-search-${index}`,
+      nativeId: `tool-search-native-${index}`,
+      callId: "tool-search-1",
+      item,
+    })),
+    observationOnlyItems: [],
+    deferredItems: [],
+    unresolvedCallIds: [],
+    source: "proxy_journal",
+    incomplete: false,
+  };
+  const result = buildCodexRebaseRequest({
+    sessionId: "codex-session-tool-search",
+    planId: "plan-tool-search",
+    baseRevision: effectiveHistory.revision,
+    originalPayload: { ...baseResponsesPayload(), input: [{ role: "user", content: "continue" }] },
+    effectiveHistory,
+    currentInput: [{ role: "user", content: "continue" }],
+    mutationPlan: { operations: [] },
+  });
+  const input = result.payload.input as JsonObject[];
+  assert.equal(input[0]?.id, undefined);
+  assert.equal(input[0]?.status, "completed");
+  assert.equal(input[1]?.id, undefined);
+  assert.equal(input[1]?.status, "completed");
+
+  const incompleteHistory = {
+    ...effectiveHistory,
+    replayableItems: [effectiveHistory.replayableItems[0]!],
+  };
+  assert.throws(() => buildCodexRebaseRequest({
+    sessionId: "codex-session-tool-search",
+    planId: "plan-tool-search-incomplete",
+    baseRevision: incompleteHistory.revision,
+    originalPayload: { ...baseResponsesPayload(), input: [{ role: "user", content: "continue" }] },
+    effectiveHistory: incompleteHistory,
+    currentInput: [{ role: "user", content: "continue" }],
+    mutationPlan: { operations: [] },
+  }), /tool_closure_incomplete:tool-search-1/);
+});
+
 test("CDR-04 retries the original request once when rebase replay is rejected upstream", async () => {
   const originalPayload = baseResponsesPayload();
   const rebasedPayload: ResponsesPayload = {

--- a/components/adapters/codex/tests/context-rebase-capability.test.ts
+++ b/components/adapters/codex/tests/context-rebase-capability.test.ts
@@ -127,7 +127,7 @@ test("CDR-05 Provider Compatibility binds decisions to provider, model, wire, AP
       { apiVersion: "responses/v2" },
       { wireMode: "chat_completions" },
       { endpointId: codexRebaseEndpointIdentity("https://other.example/v1") },
-      { itemSchemaVersion: "responses-item/v2" },
+      { itemSchemaVersion: "responses-item/v3" },
     ]) {
       const changed = await decisionsFor({
         stateDir,

--- a/components/adapters/codex/tests/context-rebase-pipeline.test.ts
+++ b/components/adapters/codex/tests/context-rebase-pipeline.test.ts
@@ -18,6 +18,7 @@ import { startCodexResponsesProxy } from "../src/proxy-runtime.js";
 import {
   acquireCodexRebaseSessionLock,
   appendPendingCodexRebaseEpoch,
+  readCodexRebaseCapabilityJournal,
   readLatestCodexRebaseEpoch,
 } from "../src/context-rewrite/index.js";
 import {
@@ -47,6 +48,7 @@ async function reserveFetchPort(): Promise<number> {
 }
 
 async function startSequencedResponsesUpstream(params?: {
+  rejectChain?: boolean;
   rejectRebase?: boolean;
   responseStatus?: string;
 }): Promise<{
@@ -70,6 +72,14 @@ async function startSequencedResponsesUpstream(params?: {
     });
     const payload = JSON.parse(body) as JsonObject;
     requests.push(payload);
+    if (params?.rejectChain && "previous_response_id" in payload) {
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        error: { code: "invalid_request_error", message: "previous_response_id is not supported" },
+      }));
+      return;
+    }
     const isRebase = !("previous_response_id" in payload) && requests.length > 1;
     if (params?.rejectRebase && isRebase) {
       res.statusCode = 400;
@@ -84,7 +94,11 @@ async function startSequencedResponsesUpstream(params?: {
       id,
       object: "response",
       status: params?.responseStatus,
-      previous_response_id: typeof payload.previous_response_id === "string" ? payload.previous_response_id : undefined,
+      previous_response_id: typeof payload.previous_response_id === "string"
+        ? payload.previous_response_id
+        : params?.rejectChain
+          ? "provider-internal-unrelated-chain"
+          : undefined,
       output: [
         {
           type: "message",
@@ -425,6 +439,106 @@ test("CDR-06 proxy pipeline rebases a non-stream request from effective history"
     assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
     assert.doesNotMatch(inputText(upstream.requests[1]), /OLD_SENTINEL_PIPELINE/);
     assert.match(inputText(upstream.requests[1]), /CURRENT_SENTINEL_PIPELINE/);
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("CDR-06 proxy automatically replaces an unsupported response chain with stateless replay", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-provider-chain-fallback-"));
+  const upstream = await startSequencedResponsesUpstream({ rejectChain: true });
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const sessionId = "codex-session-provider-chain-fallback";
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveFetchPort(),
+      upstreamProvider: "provider-fixture",
+      upstream: {
+        name: "provider-fixture",
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: { stabilizer: false, reduction: false },
+      contextRewrite: {
+        enabled: false,
+        providerCompatibilityProbe: "real_provider",
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({ config, logger: createConsoleLogger(false) });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-fixture",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "CHAIN_ROOT_SENTINEL" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-fixture",
+        stream: false,
+        previous_response_id: "resp-pipeline-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "CHAIN_CURRENT_SENTINEL" }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    assert.equal(upstream.requests.length, 3);
+    assert.equal(upstream.requests[1]?.previous_response_id, "resp-pipeline-1");
+    assert.equal("previous_response_id" in (upstream.requests[2] ?? {}), false);
+    assert.match(inputText(upstream.requests[2]), /CHAIN_ROOT_SENTINEL/);
+    assert.match(inputText(upstream.requests[2]), /CHAIN_CURRENT_SENTINEL/);
+    assert.deepEqual(
+      await loadCodexSessionSnapshot(stateDir, sessionId).then((snapshot) => ({
+        latestResponseId: snapshot?.latestResponseId,
+        previousResponseId: snapshot?.previousResponseId,
+      })),
+      { latestResponseId: "resp-pipeline-3", previousResponseId: "resp-pipeline-1" },
+    );
+
+    const journal = await readCodexRebaseCapabilityJournal(stateDir);
+    assert.equal(
+      journal.capabilities.find((entry) => entry.itemType === "previous_response_id")?.status,
+      "verified_unsupported",
+    );
+    assert.equal(
+      journal.capabilities.find((entry) => entry.itemType === "message")?.status,
+      "verified_supported",
+    );
+
+    const third = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-fixture",
+        stream: false,
+        previous_response_id: "resp-pipeline-3",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "CHAIN_THIRD_SENTINEL" }],
+      }),
+    });
+    assert.equal(third.status, 200);
+    assert.equal(upstream.requests.length, 4);
+    assert.equal("previous_response_id" in (upstream.requests[3] ?? {}), false);
+    assert.match(inputText(upstream.requests[3]), /CHAIN_THIRD_SENTINEL/);
+    assert.deepEqual(
+      await loadCodexSessionSnapshot(stateDir, sessionId).then((snapshot) => ({
+        latestResponseId: snapshot?.latestResponseId,
+        previousResponseId: snapshot?.previousResponseId,
+      })),
+      { latestResponseId: "resp-pipeline-4", previousResponseId: "resp-pipeline-3" },
+    );
   } finally {
     await runtime?.close();
     await upstream.close();
@@ -1387,7 +1501,7 @@ test("CDR-06 mock smoke keeps five turns on the new response chain", async () =>
 
 test("CDR-06 proxy restart keeps the committed rebase response chain", async () => {
   const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pipeline-restart-"));
-  const upstream = await startSequencedResponsesUpstream();
+  const upstream = await startSequencedResponsesUpstream({ rejectChain: true });
   let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
   try {
     const sessionId = "codex-session-pipeline-restart";
@@ -1464,6 +1578,23 @@ test("CDR-06 proxy restart keeps the committed rebase response chain", async () 
     assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
     assert.doesNotMatch(inputText(upstream.requests[1]), new RegExp(evict));
     assert.match(inputText(upstream.requests[1]), new RegExp(keep));
+    (config as any).contextRewrite.mutationPlan = { operations: [] };
+
+    const beforeRestartContinuation = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: previousResponseId,
+        input: [{ role: "user", content: "TURN_3_PRE_RESTART" }],
+      }),
+    });
+    assert.equal(beforeRestartContinuation.status, 200);
+    previousResponseId = String((await beforeRestartContinuation.json() as JsonObject).id);
+    assert.equal(upstream.requests.length, 4);
+    assert.equal(upstream.requests[2]?.previous_response_id, "resp-pipeline-2");
+    assert.equal("previous_response_id" in (upstream.requests[3] ?? {}), false);
 
     await runtime.close();
     runtime = undefined;
@@ -1504,14 +1635,14 @@ test("CDR-06 proxy restart keeps the committed rebase response chain", async () 
         model: "gpt-5.4-mini",
         stream: false,
         previous_response_id: previousResponseId,
-        input: [{ role: "user", content: "TURN_3_restart_smoke" }],
+        input: [{ role: "user", content: "TURN_4_restart_smoke" }],
       }),
     });
     assert.equal(third.status, 200);
     const finalResponseId = String((await third.json() as JsonObject).id);
 
-    assert.equal(upstream.requests.length, 3);
-    assert.equal(upstream.requests[2]?.previous_response_id, previousResponseId);
+    assert.equal(upstream.requests.length, 5);
+    assert.equal("previous_response_id" in (upstream.requests[4] ?? {}), false);
     assert.equal(await resolveCodexSessionIdByResponseId(stateDir, finalResponseId), sessionId);
     const finalHistory = await buildCodexEffectiveHistory({
       stateDir,
@@ -1521,7 +1652,8 @@ test("CDR-06 proxy restart keeps the committed rebase response chain", async () 
     assert.equal(finalHistory.incomplete, false);
     assert.doesNotMatch(JSON.stringify(finalHistory.replayableItems), new RegExp(evict));
     assert.match(JSON.stringify(finalHistory.replayableItems), new RegExp(keep));
-    assert.match(JSON.stringify(finalHistory.replayableItems), /TURN_3_restart_smoke/);
+    assert.match(JSON.stringify(finalHistory.replayableItems), /TURN_3_PRE_RESTART/);
+    assert.match(JSON.stringify(finalHistory.replayableItems), /TURN_4_restart_smoke/);
   } finally {
     await runtime?.close();
     await upstream.close();

--- a/components/adapters/codex/tests/context-rebase-provider-smoke.test.ts
+++ b/components/adapters/codex/tests/context-rebase-provider-smoke.test.ts
@@ -168,8 +168,10 @@ test("provider smoke emits sanitized real-chain, capability v2, matrix, and usag
       "function_call",
       "function_call_output",
       "message",
+      "previous_response_id",
       "reasoning",
     ]);
+    assert.deepEqual(evidence.capability.realProviderRejectedItemTypes, []);
     assert.equal(evidence.rebase.committed, true);
     assert.equal(evidence.rebase.oldChainReferenceRemoved, true);
     assert.equal(evidence.rebase.currentInputOccurrences, 1);
@@ -183,13 +185,14 @@ test("provider smoke emits sanitized real-chain, capability v2, matrix, and usag
     assert.equal(evidence.usage.continuationTurns.length, 5);
     assert.ok(evidence.usage.observedSavedInputTokens > 0);
     assert.equal(evidence.compatibilityMatrix.find((entry) => entry.itemType === "reasoning")?.providerDecision, "real-pass");
+    assert.equal(evidence.compatibilityMatrix.find((entry) => entry.itemType === "previous_response_id")?.providerDecision, "real-pass");
     assert.equal(evidence.compatibilityMatrix.find((entry) => entry.itemType === "compaction")?.providerDecision, "not-observed");
     assert.equal(provider.authorizationPresent(), true);
     assert.match(result.artifactSha256, /^[a-f0-9]{64}$/u);
     assert.equal(JSON.parse(artifactText).schema, CODEX_REBASE_PROVIDER_SMOKE_EVIDENCE_SCHEMA);
     assert.doesNotMatch(artifactText, /EVICT_ME_|KEEP_ME_|CURRENT_INPUT_|opaque-provider-fixture-/u);
     assert.doesNotMatch(artifactText, /provider-smoke-test-key-not-secret|sk-credential-shaped-cli-label/u);
-    assert.doesNotMatch(artifactText, /previous_response_id|authorization|bearer/iu);
+    assert.doesNotMatch(artifactText, /authorization|bearer/iu);
   } finally {
     if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
     else process.env.OPENAI_API_KEY = previousKey;

--- a/components/adapters/codex/tests/context-rebase-report.test.ts
+++ b/components/adapters/codex/tests/context-rebase-report.test.ts
@@ -83,7 +83,7 @@ test("CDR-07 Codex session report renders rebase state", async () => {
     assert.match(report, /rebase epochs: committed=1, rolled_back=0, failed=0, pending=0/i);
     assert.match(report, /latest rebase epoch: committed epoch-report old=resp-old new=resp-new/i);
     assert.match(report, /rebase cooldowns: active=1\/1 latest=rebase_upstream_rejected/i);
-    assert.match(report, /web_search_call@responses-item\/v1 verified_unsupported evidence=mock\/fixture/i);
+    assert.match(report, /web_search_call@responses-item\/v2 verified_unsupported evidence=mock\/fixture/i);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/components/adapters/codex/tests/doctor.test.ts
+++ b/components/adapters/codex/tests/doctor.test.ts
@@ -467,12 +467,12 @@ test("inspectCodexDoctor reports cached rebase capabilities", async () => {
     });
 
     assert.deepEqual(report.rebaseCapabilityStatus, [
-      "OpenAI/gpt-5.4-mini responses responses/v1 reasoning@responses-item/v1 verified_supported evidence=real-provider state=active",
-      "OpenAI/gpt-5.4-mini responses responses/v1 web_search_call@responses-item/v1 verified_unsupported evidence=mock/fixture state=active",
+      "OpenAI/gpt-5.4-mini responses responses/v1 reasoning@responses-item/v2 verified_supported evidence=real-provider state=active",
+      "OpenAI/gpt-5.4-mini responses responses/v1 web_search_call@responses-item/v2 verified_unsupported evidence=mock/fixture state=active",
     ]);
     const formatted = formatCodexDoctorReport(report);
-    assert.match(formatted, /reasoning@responses-item\/v1 verified_supported evidence=real-provider/);
-    assert.match(formatted, /web_search_call@responses-item\/v1 verified_unsupported evidence=mock\/fixture/);
+    assert.match(formatted, /reasoning@responses-item\/v2 verified_supported evidence=real-provider/);
+    assert.match(formatted, /web_search_call@responses-item\/v2 verified_unsupported evidence=mock\/fixture/);
 
     await appendFile(codexRebaseCapabilityJournalPath(stateDir), "not-json\n", "utf8");
     const untrustedReport = await inspectCodexDoctor({

--- a/components/adapters/codex/tests/upstream.test.ts
+++ b/components/adapters/codex/tests/upstream.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { requestUpstreamResponses } from "../src/upstream.js";
+
+async function withReasoningFixture(
+  responses: Array<{ encrypted?: string }>,
+  run: (baseUrl: string, requestCount: () => number) => Promise<void>,
+): Promise<void> {
+  let count = 0;
+  const server = createServer(async (req, res) => {
+    for await (const _chunk of req) {
+      // Drain the request body before replying.
+    }
+    const fixture = responses[Math.min(count, responses.length - 1)] ?? {};
+    count += 1;
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      id: `resp-${count}`,
+      status: "completed",
+      output: [{
+        type: "reasoning",
+        encrypted_content: fixture.encrypted,
+        summary: [],
+      }],
+    }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("fixture did not bind a port");
+  try {
+    await run(`http://127.0.0.1:${address.port}/v1`, () => count);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+test("upstream retries up to twice when requested encrypted reasoning is omitted", async () => {
+  await withReasoningFixture([{}, {}, { encrypted: "opaque-retry-state" }], async (baseUrl, requestCount) => {
+    const response = await requestUpstreamResponses({
+      upstream: { baseUrl, wireApi: "responses", requiresOpenAIAuth: false },
+      payload: {
+        model: "gpt-fixture",
+        store: false,
+        include: ["reasoning.encrypted_content"],
+        input: [{ role: "user", content: "test" }],
+      },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(requestCount(), 3);
+    assert.match(response.text, /opaque-retry-state/);
+  });
+});
+
+test("upstream encrypted-reasoning repair is bounded to two retries", async () => {
+  await withReasoningFixture([{}, {}, {}], async (baseUrl, requestCount) => {
+    const response = await requestUpstreamResponses({
+      upstream: { baseUrl, wireApi: "responses", requiresOpenAIAuth: false },
+      payload: {
+        model: "gpt-fixture",
+        include: ["reasoning.encrypted_content"],
+        input: [{ role: "user", content: "test" }],
+      },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(requestCount(), 3);
+    assert.doesNotMatch(response.text, /encrypted_content":"opaque/);
+  });
+});


### PR DESCRIPTION
## Summary

Complete the remaining Codex context rebase work:

- add crash-safe journal tail recovery coverage and keep history reconstruction robust
- add real-provider encrypted reasoning replay support, including bounded retry when encrypted content is omitted
- replace capability-bypass-only behavior with provider continuation fallback and broader replay compatibility
- expand replay validation for tool call/output closure, provider item types, PTC payloads, and repeated response IDs
- update provider smoke coverage, tests, and documentation

## Validation

- `npm run typecheck`
- `node --import tsx --test --test-concurrency=1 tests/*.test.ts` from `components/adapters/codex`  
  257/257 tests passed
- `npm run build`
- `npm run smoke:context-rebase:codex -- --mode=mock`
- `npm --prefix components/adapters/codex run smoke:context-rebase:codex -- --mode=provider --model=gpt-5.4-mini --output-dir=work\codex-real-provider-evidence`

## Real Provider Smoke

The real provider smoke now passes with `kuaipao.ai`.

Result:

- `ok=true`
- `mode=provider`
- `endpointHost=kuaipao.ai`
- `encryptedReasoningPresent=true`
- `rebaseCommitted=true`
- `continuationTurns=5`
- `restartPreserved=true`
- `observedSavedInputTokens=5503`
- artifact generated: `codex-context-rebase-provider-smoke.json`

`kuaipao.ai` rejects `previous_response_id`, but the stateless replay fallback handles that path successfully, so the provider smoke still completes.