### PR TITLE
feat(codex): complete shared rewrite lifecycle and GUA-02

### DIFF
--- a/components/adapters/codex/src/context-rebase-provider-smoke.ts
+++ b/components/adapters/codex/src/context-rebase-provider-smoke.ts
@@ -245,9 +245,18 @@ function responseChainLinksValid(params: {
     ));
     if (matchingRequests.length !== 1) return false;
     const request = matchingRequests[0]!;
+    // Native continuation keeps the provider parent. A stateless replay is a
+    // deliberate new root and is valid only when the journal retained the
+    // exact full input that was actually sent for that root.
     const matchingResponses = Array.from(responses.values()).filter((entry) => (
       entry.requestId === request.requestId
-      && entry.previousResponseId === expectedPreviousId
+      && (
+        entry.previousResponseId === expectedPreviousId
+        || (
+          entry.previousResponseId === null
+          && Array.isArray(request.committedInputItems)
+        )
+      )
     ));
     if (matchingResponses.length !== 1) return false;
     previousResponseId = matchingResponses[0]!.responseId!;

--- a/components/adapters/codex/src/context-rewrite/backend.ts
+++ b/components/adapters/codex/src/context-rewrite/backend.ts
@@ -1,0 +1,530 @@
+import { createHash } from "node:crypto";
+
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  revalidateContextMutationPlan,
+  validateContextMutationProtocolClosure,
+  type ContextItemKind,
+  type ContextItemRef,
+  type ContextMutationPlan,
+  type ContextRewriteResult,
+  type ContextRewriteValidation,
+  type ModelContextRewriteBackend,
+  type ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+
+import { codexReplayPairRef } from "../context-history/replayability.js";
+import type {
+  CodexEffectiveHistory,
+  CodexEffectiveHistoryItem,
+  JsonObject,
+} from "../context-history/types.js";
+import { buildCodexRebaseRequest, validateCodexRebaseRequest } from "./rebase-request.js";
+import type { CodexRebaseAccounting, CodexMutationPlan } from "./types.js";
+
+const CODEX_HOST_ID = "codex";
+
+export type CodexSharedBackendRequest = {
+  sessionId: string;
+  payload: JsonObject;
+  effectiveHistory: CodexEffectiveHistory;
+  currentInput?: unknown;
+  taskIdsByItemId?: Record<string, string[]>;
+  activeTaskIds?: string[];
+  evictableTaskIds?: string[];
+};
+
+export type CodexSharedBackendMetadata = {
+  effectiveHistory: CodexEffectiveHistory;
+  currentInput: unknown;
+  replayableItemIds: string[];
+  activeTaskIds: string[];
+  evictableTaskIds: string[];
+};
+
+export type CodexSharedBackendDetails = {
+  rebasePrepared: true;
+  accounting: CodexRebaseAccounting;
+};
+
+export type CodexSharedContextRewriteBackend = ModelContextRewriteBackend<
+  CodexSharedBackendRequest,
+  CodexSharedBackendMetadata,
+  never,
+  CodexSharedBackendDetails
+>;
+
+function hashJson(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(value) ?? "undefined")
+    .digest("hex");
+}
+
+function normalizedStrings(values: readonly string[] | undefined): string[] {
+  return [...new Set(
+    (values ?? [])
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  )];
+}
+
+function textChars(value: unknown): number {
+  const serialized = JSON.stringify(value);
+  return typeof serialized === "string" ? serialized.length : 0;
+}
+
+function itemKind(item: JsonObject): ContextItemKind {
+  const type = String(item.type ?? "").trim().toLowerCase();
+  const role = String(item.role ?? "").trim().toLowerCase();
+  const replayPair = codexReplayPairRef(item);
+  if (replayPair.side === "call") return "tool_call";
+  if (replayPair.side === "output") return "tool_result";
+  if (type === "reasoning") return "reasoning";
+  if (type === "compaction") return "compaction";
+  if (role === "system") return "system";
+  if (role === "developer") return "developer";
+  if (role === "user") return "user";
+  if (role === "assistant" || type === "message") return "assistant";
+  return "unknown";
+}
+
+function itemRef(
+  entry: CodexEffectiveHistoryItem,
+  taskIdsByItemId: Record<string, string[]> | undefined,
+): ContextItemRef {
+  const role = typeof entry.item.role === "string" && entry.item.role.trim()
+    ? entry.item.role.trim()
+    : undefined;
+  const callId = entry.callId
+    ?? (typeof entry.item.call_id === "string" ? entry.item.call_id.trim() : undefined);
+  const taskIds = normalizedStrings(taskIdsByItemId?.[entry.stableItemId]);
+  return {
+    stableId: entry.stableItemId,
+    kind: itemKind(entry.item),
+    ...(role ? { role } : {}),
+    ...(callId ? { callId } : {}),
+    ...(taskIds.length > 0 ? { taskIds } : {}),
+    fingerprint: hashJson(entry.item),
+    chars: textChars(entry.item),
+  };
+}
+
+function orderedOperationIds(
+  plan: ContextMutationPlan,
+  ids: ReadonlySet<string>,
+): string[] {
+  return [...new Set(plan.operations.map((operation) => operation.id))]
+    .filter((operationId) => ids.has(operationId));
+}
+
+function requestSnapshot(
+  sessionId: string,
+  request: CodexSharedBackendRequest,
+): ModelContextSnapshot<CodexSharedBackendMetadata> {
+  if (request.sessionId !== sessionId) {
+    throw new Error(`Codex shared backend session mismatch: expected ${sessionId}`);
+  }
+  const history = structuredClone(request.effectiveHistory);
+  const allItems = [
+    ...history.replayableItems,
+    ...history.observationOnlyItems,
+    ...history.deferredItems,
+  ];
+  const currentInput = structuredClone(request.currentInput ?? request.payload.input ?? []);
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    hostId: CODEX_HOST_ID,
+    sessionId,
+    revision: history.revision,
+    items: allItems.map((entry) => itemRef(entry, request.taskIdsByItemId)),
+    adapterMetadata: {
+      effectiveHistory: history,
+      currentInput,
+      replayableItemIds: history.replayableItems.map((entry) => entry.stableItemId),
+      activeTaskIds: normalizedStrings(request.activeTaskIds),
+      evictableTaskIds: normalizedStrings(request.evictableTaskIds),
+    },
+  };
+}
+
+function snapshotsMatch(
+  left: ModelContextSnapshot<CodexSharedBackendMetadata>,
+  right: ModelContextSnapshot<CodexSharedBackendMetadata>,
+): boolean {
+  if (left.hostId !== right.hostId
+    || left.sessionId !== right.sessionId
+    || left.revision !== right.revision
+    || left.items.length !== right.items.length) return false;
+  const rightItems = new Map(right.items.map((item) => [item.stableId, item.fingerprint]));
+  return left.items.every((item) => rightItems.get(item.stableId) === item.fingerprint);
+}
+
+function codexMutationPlanFor(
+  plan: ContextMutationPlan,
+  applicableOperationIds: ReadonlySet<string>,
+): CodexMutationPlan {
+  return {
+    baseRevision: plan.baseRevision,
+    operations: plan.operations
+      .filter((operation) => applicableOperationIds.has(operation.id))
+      .flatMap((operation) => operation.targetItemIds.map((stableItemId) => ({
+        type: "evict",
+        stableItemId,
+      }))),
+  };
+}
+
+function unchangedResult(params: {
+  snapshot: ModelContextSnapshot<CodexSharedBackendMetadata>;
+  plan: ContextMutationPlan;
+  deferredOperationIds: string[];
+  fallbackUsed: boolean;
+}): ContextRewriteResult<CodexSharedBackendDetails> {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    mode: "response_chain_rebase",
+    planId: params.plan.planId,
+    applied: false,
+    changed: false,
+    previousRevision: params.snapshot.revision,
+    nextRevision: params.snapshot.revision,
+    appliedOperationIds: [],
+    deferredOperationIds: params.deferredOperationIds,
+    removedItemIds: [],
+    savedChars: 0,
+    fallbackUsed: params.fallbackUsed,
+  };
+}
+
+export const codexSharedContextRewriteBackend: CodexSharedContextRewriteBackend = {
+  hostId: CODEX_HOST_ID,
+  mode: "response_chain_rebase",
+
+  async readSnapshot({ sessionId, request }) {
+    return requestSnapshot(sessionId, request);
+  },
+
+  async validate({ snapshot, plan }) {
+    const structural = revalidateContextMutationPlan({ snapshot, plan });
+    if (!structural.valid) return structural;
+
+    const metadata = snapshot.adapterMetadata;
+    if (!metadata || metadata.effectiveHistory.revision !== snapshot.revision) {
+      return {
+        valid: false,
+        applicableOperationIds: [],
+        deferredOperationIds: [...new Set(plan.operations.map((operation) => operation.id))],
+        reasons: [...structural.reasons, "codex_snapshot_metadata_invalid"],
+      };
+    }
+
+    const reasons = [...structural.reasons];
+    const deferred = new Set(structural.deferredOperationIds);
+    const candidates = new Set(structural.applicableOperationIds);
+    const replayableItemIds = new Set(metadata.replayableItemIds);
+    const claimedItemIds = new Set<string>();
+
+    const defer = (operationId: string, reason: string): void => {
+      candidates.delete(operationId);
+      deferred.add(operationId);
+      reasons.push(`operation:${operationId || "<empty>"}:${reason}`);
+    };
+
+    if (metadata.effectiveHistory.incomplete) {
+      for (const operationId of [...candidates]) {
+        defer(operationId, "effective_history_incomplete");
+      }
+    }
+
+    for (const operation of plan.operations) {
+      if (!candidates.has(operation.id)) continue;
+      if (operation.type !== "remove") {
+        defer(operation.id, "unsupported_operation");
+        continue;
+      }
+      if (Array.isArray(operation.replacementItems)
+        && operation.replacementItems.length > 0) {
+        defer(operation.id, "native_replacement_unsupported");
+        continue;
+      }
+      if (operation.targetItemIds.some((itemId) => !replayableItemIds.has(itemId))) {
+        defer(operation.id, "target_not_replayable");
+        continue;
+      }
+      if (operation.targetItemIds.some((itemId) => claimedItemIds.has(itemId))) {
+        defer(operation.id, "target_overlap");
+        continue;
+      }
+      for (const itemId of operation.targetItemIds) claimedItemIds.add(itemId);
+    }
+
+    const closure = validateContextMutationProtocolClosure({
+      snapshot,
+      plan,
+      activeTaskIds: metadata.activeTaskIds,
+      evictableTaskIds: metadata.evictableTaskIds,
+      candidateOperationIds: orderedOperationIds(plan, candidates),
+    });
+    reasons.push(...closure.reasons);
+    for (const operationId of closure.deferredOperationIds) {
+      candidates.delete(operationId);
+      deferred.add(operationId);
+    }
+
+    if (candidates.size > 0) {
+      const codexValidation = validateCodexRebaseRequest({
+        baseRevision: snapshot.revision,
+        effectiveHistory: metadata.effectiveHistory,
+        currentInput: metadata.currentInput,
+        mutationPlan: codexMutationPlanFor(plan, candidates),
+      });
+      if (!codexValidation.valid) {
+        reasons.push(...codexValidation.reasons.map((reason) => `codex:${reason}`));
+        for (const operationId of [...candidates]) deferred.add(operationId);
+        candidates.clear();
+      }
+    }
+
+    return {
+      valid: true,
+      applicableOperationIds: orderedOperationIds(plan, candidates),
+      deferredOperationIds: orderedOperationIds(plan, deferred),
+      reasons: [...new Set(reasons)],
+    };
+  },
+
+  async apply({ snapshot, plan, request }) {
+    const validation = await this.validate({ snapshot, plan });
+    const allOperationIds = [...new Set(plan.operations.map((operation) => operation.id))];
+    if (!validation.valid || validation.applicableOperationIds.length === 0) {
+      return {
+        request,
+        result: unchangedResult({
+          snapshot,
+          plan,
+          deferredOperationIds: validation.valid
+            ? validation.deferredOperationIds
+            : allOperationIds,
+          fallbackUsed: false,
+        }),
+      };
+    }
+
+    try {
+      const currentSnapshot = requestSnapshot(request.sessionId, request);
+      if (!snapshotsMatch(snapshot, currentSnapshot)) {
+        return {
+          request,
+          result: unchangedResult({
+            snapshot,
+            plan,
+            deferredOperationIds: allOperationIds,
+            fallbackUsed: false,
+          }),
+        };
+      }
+
+      const applicable = new Set(validation.applicableOperationIds);
+      const mutationPlan = codexMutationPlanFor(plan, applicable);
+      const rebased = buildCodexRebaseRequest({
+        sessionId: snapshot.sessionId,
+        planId: plan.planId,
+        baseRevision: snapshot.revision,
+        originalPayload: request.payload,
+        effectiveHistory: request.effectiveHistory,
+        currentInput: request.currentInput ?? request.payload.input,
+        mutationPlan,
+      });
+      const removedItemIds = plan.operations
+        .filter((operation) => applicable.has(operation.id))
+        .flatMap((operation) => operation.targetItemIds);
+      return {
+        request: {
+          ...request,
+          payload: rebased.payload,
+        },
+        result: {
+          schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+          mode: "response_chain_rebase",
+          planId: plan.planId,
+          applied: validation.applicableOperationIds.length > 0,
+          changed: removedItemIds.length > 0,
+          previousRevision: snapshot.revision,
+          nextRevision: rebased.rebaseRevision,
+          appliedOperationIds: validation.applicableOperationIds,
+          deferredOperationIds: validation.deferredOperationIds,
+          removedItemIds,
+          savedChars: rebased.accounting.actuallyRemovedChars,
+          fallbackUsed: false,
+          details: {
+            rebasePrepared: true,
+            accounting: rebased.accounting,
+          },
+        },
+      };
+    } catch {
+      return {
+        request,
+        result: unchangedResult({
+          snapshot,
+          plan,
+          deferredOperationIds: allOperationIds,
+          fallbackUsed: true,
+        }),
+      };
+    }
+  },
+};
+
+export type CodexSharedGoldenItem = {
+  id: string;
+  kind: string;
+  role?: string;
+  content?: string;
+  tool_name?: string;
+  tool_call_id?: string;
+  arguments?: Record<string, unknown>;
+  result?: string;
+};
+
+export type CodexSharedGoldenTask = {
+  id: string;
+  status: "active" | "completed" | "unresolved";
+  current?: boolean;
+  items: CodexSharedGoldenItem[];
+};
+
+export type CodexSharedGoldenFixture = {
+  id: string;
+  tasks: CodexSharedGoldenTask[];
+};
+
+export type CodexSharedGoldenDecision = {
+  hostId: "codex";
+  fixtureId: string;
+  selectedTaskIds: string[];
+  keptTaskIds: string[];
+  selectedItemIds: string[];
+  keptItemIds: string[];
+  validation: ContextRewriteValidation;
+  result: ContextRewriteResult<CodexSharedBackendDetails>;
+};
+
+function fixtureItemPayload(item: CodexSharedGoldenItem): JsonObject {
+  if (item.kind === "tool_call") {
+    return {
+      type: "function_call",
+      call_id: item.tool_call_id,
+      name: item.tool_name ?? "fixture_tool",
+      arguments: JSON.stringify(item.arguments ?? {}),
+    };
+  }
+  if (item.kind === "tool_result") {
+    return {
+      type: "function_call_output",
+      call_id: item.tool_call_id,
+      output: item.result ?? "",
+    };
+  }
+  const role = item.role ?? "user";
+  return {
+    type: "message",
+    role,
+    content: [{
+      type: role === "assistant" ? "output_text" : "input_text",
+      text: item.content ?? "",
+    }],
+  };
+}
+
+export async function runCodexSharedGoldenFixture(
+  fixture: CodexSharedGoldenFixture,
+): Promise<CodexSharedGoldenDecision> {
+  const sessionId = `gua-02-${fixture.id}`;
+  const allItems = fixture.tasks.flatMap((task) => task.items);
+  const historyItems: CodexEffectiveHistoryItem[] = allItems.map((item) => ({
+    stableItemId: item.id,
+    nativeId: `fixture:${item.id}`,
+    callId: item.tool_call_id,
+    item: fixtureItemPayload(item),
+  }));
+  const taskIdsByItemId = Object.fromEntries(
+    fixture.tasks.flatMap((task) => task.items.map((item) => [item.id, [task.id]])),
+  );
+  const evictableTasks = fixture.tasks.filter((task) => (
+    task.status === "completed" && task.current !== true
+  ));
+  const activeTasks = fixture.tasks.filter((task) => (
+    task.status !== "completed" || task.current === true
+  ));
+  const request: CodexSharedBackendRequest = {
+    sessionId,
+    payload: {
+      model: "fixture-model",
+      previous_response_id: "fixture-parent",
+      input: [],
+    },
+    effectiveHistory: {
+      revision: `codex-gua-rev-${hashJson(fixture)}`,
+      replayableItems: historyItems,
+      observationOnlyItems: [],
+      deferredItems: [],
+      unresolvedCallIds: [],
+      source: "proxy_journal",
+      incomplete: false,
+    },
+    currentInput: [],
+    taskIdsByItemId,
+    activeTaskIds: activeTasks.map((task) => task.id),
+    evictableTaskIds: evictableTasks.map((task) => task.id),
+  };
+  const snapshot = await codexSharedContextRewriteBackend.readSnapshot({ sessionId, request });
+  const itemById = new Map(snapshot.items.map((item) => [item.stableId, item]));
+  const plan: ContextMutationPlan = {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: `gua-02-plan-${fixture.id}`,
+    hostId: CODEX_HOST_ID,
+    sessionId,
+    baseRevision: snapshot.revision,
+    sourceModuleId: "gua-02",
+    operations: evictableTasks.map((task) => {
+      const targetItemIds = task.items.map((item) => item.id);
+      return {
+        id: `gua-02-op-${task.id}`,
+        type: "remove",
+        targetItemIds,
+        targetItemFingerprints: Object.fromEntries(
+          targetItemIds.map((itemId) => [itemId, itemById.get(itemId)!.fingerprint]),
+        ),
+        taskIds: [task.id],
+        rationale: "evict completed fixture task",
+        estimatedSavedChars: targetItemIds.reduce(
+          (total, itemId) => total + (itemById.get(itemId)?.chars ?? 0),
+          0,
+        ),
+      };
+    }),
+    createdAt: "2026-08-09T00:00:00.000Z",
+  };
+  const validation = await codexSharedContextRewriteBackend.validate({ snapshot, plan });
+  const applied = await codexSharedContextRewriteBackend.apply({ snapshot, plan, request });
+  const appliedOperationIds = new Set(applied.result.appliedOperationIds);
+  const selectedTaskIds = evictableTasks
+    .filter((task) => appliedOperationIds.has(`gua-02-op-${task.id}`))
+    .map((task) => task.id);
+  const selectedItems = new Set(plan.operations
+    .filter((operation) => appliedOperationIds.has(operation.id))
+    .flatMap((operation) => operation.targetItemIds));
+  const selectedTasks = new Set(selectedTaskIds);
+  return {
+    hostId: "codex",
+    fixtureId: fixture.id,
+    selectedTaskIds,
+    keptTaskIds: fixture.tasks.map((task) => task.id).filter((taskId) => !selectedTasks.has(taskId)),
+    selectedItemIds: allItems.map((item) => item.id).filter((itemId) => selectedItems.has(itemId)),
+    keptItemIds: allItems.map((item) => item.id).filter((itemId) => !selectedItems.has(itemId)),
+    validation,
+    result: applied.result,
+  };
+}

--- a/components/adapters/codex/src/context-rewrite/fallback.ts
+++ b/components/adapters/codex/src/context-rewrite/fallback.ts
@@ -149,6 +149,7 @@ export async function executeCodexRebaseWithFallback(params: {
     return {
       response,
       outcome: isSuccessfulResponse(response) ? "bypassed" : "failed",
+      reason: notice?.reason ?? "rewrite_guard_busy",
       capability: notice,
     };
   }
@@ -213,6 +214,7 @@ export async function executeCodexRebaseWithFallback(params: {
       return {
         response,
         outcome: isSuccessfulResponse(response) ? "bypassed" : "failed",
+        reason: "cooldown_active",
         cooldown: codexRebaseCooldownNotice(activeCooldown),
       };
     }
@@ -345,6 +347,7 @@ export async function executeCodexRebaseWithFallback(params: {
     return {
       response: fallbackResponse,
       outcome: fallbackSucceeded ? "bypassed" : "failed",
+      reason,
       rebaseResponse,
       epoch,
       cooldown,
@@ -438,6 +441,7 @@ export async function executeCodexRebaseWithFallback(params: {
         return {
           response: rebaseResponse,
           outcome: "committed",
+          reason: "rebase_committed",
           newResponseId,
           rebaseResponse,
           epoch,

--- a/components/adapters/codex/src/context-rewrite/index.ts
+++ b/components/adapters/codex/src/context-rewrite/index.ts
@@ -6,6 +6,22 @@ export {
   resolveCodexProviderContinuationCompatibility,
 } from "./provider-continuation.js";
 export type { CodexProviderContinuationCompatibility } from "./provider-continuation.js";
+export { createCodexContextRewriteLifecycle } from "./lifecycle-events.js";
+export type { CodexContextRewriteLifecycle } from "./lifecycle-events.js";
+export {
+  codexSharedContextRewriteBackend,
+  runCodexSharedGoldenFixture,
+} from "./backend.js";
+export type {
+  CodexSharedBackendDetails,
+  CodexSharedBackendMetadata,
+  CodexSharedBackendRequest,
+  CodexSharedContextRewriteBackend,
+  CodexSharedGoldenDecision,
+  CodexSharedGoldenFixture,
+  CodexSharedGoldenItem,
+  CodexSharedGoldenTask,
+} from "./backend.js";
 export {
   buildCodexRebaseRequest,
   validateCodexRebaseRequest,

--- a/components/adapters/codex/src/context-rewrite/lifecycle-events.ts
+++ b/components/adapters/codex/src/context-rewrite/lifecycle-events.ts
@@ -1,0 +1,42 @@
+import {
+  appendContextRewriteEvent,
+  type ContextRewriteEventInput,
+} from "@lightmem2/host-adapter";
+
+type CodexContextRewriteEventInput = Omit<
+  ContextRewriteEventInput,
+  "hostId" | "sessionId" | "mode"
+>;
+
+type ContextRewriteEventAppender = typeof appendContextRewriteEvent;
+
+export type CodexContextRewriteLifecycle = {
+  append(input: CodexContextRewriteEventInput): Promise<void>;
+};
+
+/**
+ * Builds the Codex runtime bridge to the shared context-rewrite event schema.
+ * Event persistence is deliberately best effort: observability must never turn
+ * a valid provider request into a failure.
+ */
+export function createCodexContextRewriteLifecycle(params: {
+  stateDir: string;
+  sessionId: string;
+  appendEvent?: ContextRewriteEventAppender;
+}): CodexContextRewriteLifecycle {
+  const appendEvent = params.appendEvent ?? appendContextRewriteEvent;
+  return {
+    async append(input): Promise<void> {
+      try {
+        await appendEvent(params.stateDir, {
+          ...input,
+          hostId: "codex",
+          sessionId: params.sessionId,
+          mode: "response_chain_rebase",
+        });
+      } catch {
+        // Lifecycle traces are advisory and must not affect proxy availability.
+      }
+    },
+  };
+}

--- a/components/adapters/codex/src/context-rewrite/types.ts
+++ b/components/adapters/codex/src/context-rewrite/types.ts
@@ -86,6 +86,7 @@ export type CodexUpstreamResponse = {
 export type CodexRebaseFallbackResult = {
   response: CodexUpstreamResponse;
   outcome: "committed" | "bypassed" | "failed";
+  reason?: string;
   newResponseId?: string;
   rebaseResponse?: CodexUpstreamResponse;
   epoch?: CodexRebaseEpoch;

--- a/components/adapters/codex/src/index.ts
+++ b/components/adapters/codex/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./config.js";
+export * from "./context-rewrite/index.js";
 export * from "./daemon.js";
 export * from "./install.js";
 export * from "./logger.js";

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -9,6 +9,8 @@ import {
 import {
   countTextWithPreciseTokens,
   createStaticStatePathResolver,
+  type ContextRewriteEventInput,
+  type ContextRewriteEventName,
   type HostRequestEnvelope,
   prepareBeforeCallWithReductionSummary,
   recordUxEffect,
@@ -77,6 +79,7 @@ import {
   acquireCodexRebaseSessionLock,
   buildCodexRebaseRequest,
   codexRebaseEndpointIdentity,
+  createCodexContextRewriteLifecycle,
   executeCodexProviderContinuationWithReplay,
   executeCodexRebaseWithFallback,
   failPendingCodexRebaseEpochsAfterRestart,
@@ -165,6 +168,77 @@ function codexMutationPlanId(plan: CodexMutationPlan): string {
     baseRevision: plan.baseRevision ?? null,
     operations: plan.operations,
   })}`;
+}
+
+type CodexLifecyclePlan = {
+  planId: string;
+  operationIds?: string[];
+  itemIds?: string[];
+  previousRevision?: string;
+  nextRevision?: string;
+  estimatedSavedChars?: number;
+  savedChars?: number;
+};
+
+function codexMutationLifecyclePlan(plan: CodexMutationPlan): CodexLifecyclePlan {
+  return {
+    planId: codexMutationPlanId(plan),
+    operationIds: plan.operations.map((operation, index) => (
+      `op-${index + 1}-${hashJson({
+        type: operation.type,
+        stableItemId: operation.stableItemId ?? null,
+      })}`
+    )),
+    itemIds: plan.operations
+      .map((operation) => operation.stableItemId)
+      .filter((stableItemId): stableItemId is string => Boolean(stableItemId)),
+    previousRevision: plan.baseRevision,
+  };
+}
+
+function codexValidationReasonCodes(error: unknown): string[] {
+  const message = error instanceof Error ? error.message.toLowerCase() : "";
+  const reasons: string[] = [];
+  if (message.includes("revision_mismatch")) reasons.push("revision_drift");
+  if (message.includes("effective_history_incomplete")) reasons.push("effective_history_incomplete");
+  if (message.includes("tool_") || message.includes("program_")) reasons.push("tool_closure_unresolved");
+  if (message.includes("mutation_target")) reasons.push("mutation_target_unavailable");
+  if (message.includes("unsupported_operation")) reasons.push("unsupported_operation");
+  return reasons.length > 0 ? reasons : ["rewrite_validation_error"];
+}
+
+const SAFE_REWRITE_REASON_CODES = new Set([
+  "capability_check_error",
+  "capability_journal_untrusted",
+  "cooldown_active",
+  "encrypted_payload_rejected",
+  "epoch_store_error",
+  "fallback_original_request",
+  "fallback_upstream_error",
+  "feature_disabled",
+  "history_journal_write_failed",
+  "item_schema_unsupported",
+  "native_response_chain_used",
+  "provider_replay_probe_required",
+  "provider_replay_rejected",
+  "rebase_journal_error",
+  "rebase_response_failed",
+  "rebase_response_id_missing",
+  "rebase_response_incomplete",
+  "rebase_stream_failed",
+  "rebase_stream_incomplete",
+  "rebase_stream_malformed",
+  "rebase_upstream_error",
+  "rebase_upstream_rejected",
+  "request_journal_unavailable",
+  "response_chain_head_missing",
+  "rewrite_configuration_unsupported",
+  "rewrite_guard_busy",
+  "stateless_continuation_succeeded",
+]);
+
+function codexSafeRuntimeReason(reason: string | undefined, fallback: string): string {
+  return reason && SAFE_REWRITE_REASON_CODES.has(reason) ? reason : fallback;
 }
 
 function encodedRequestPayload(params: {
@@ -347,6 +421,40 @@ export async function startCodexResponsesProxy(params: {
         envelope = { ...envelope, model };
       }
       const sessionId = envelope.session.sessionId;
+      const contextRewriteLifecycle = createCodexContextRewriteLifecycle({
+        stateDir: config.stateDir,
+        sessionId,
+      });
+      const emittedContextRewriteStages = new Set<string>();
+      let activeLifecyclePlan: CodexLifecyclePlan | undefined;
+      const emitContextRewriteStage = async (
+        stage: ContextRewriteEventName,
+        details: Partial<Omit<
+          ContextRewriteEventInput,
+          "stage" | "hostId" | "sessionId" | "mode"
+        >> = {},
+        lifecyclePlan: CodexLifecyclePlan | undefined = activeLifecyclePlan,
+      ): Promise<void> => {
+        const planId = details.planId ?? lifecyclePlan?.planId;
+        const eventKey = `${planId ?? "request"}\0${stage}`;
+        if (emittedContextRewriteStages.has(eventKey)) return;
+        emittedContextRewriteStages.add(eventKey);
+        await contextRewriteLifecycle.append({
+          stage,
+          ...(lifecyclePlan?.planId ? { planId: lifecyclePlan.planId } : {}),
+          ...(lifecyclePlan?.previousRevision
+            ? { previousRevision: lifecyclePlan.previousRevision }
+            : {}),
+          ...(lifecyclePlan?.nextRevision ? { nextRevision: lifecyclePlan.nextRevision } : {}),
+          ...(lifecyclePlan?.operationIds ? { operationIds: lifecyclePlan.operationIds } : {}),
+          ...(lifecyclePlan?.itemIds ? { itemIds: lifecyclePlan.itemIds } : {}),
+          ...(lifecyclePlan?.estimatedSavedChars !== undefined
+            ? { estimatedSavedChars: lifecyclePlan.estimatedSavedChars }
+            : {}),
+          ...(lifecyclePlan?.savedChars !== undefined ? { savedChars: lifecyclePlan.savedChars } : {}),
+          ...details,
+        });
+      };
       await recoverSessionEpochsAfterRestart(sessionId);
       if (inboundPromptCacheKey) {
         if (
@@ -388,6 +496,38 @@ export async function startCodexResponsesProxy(params: {
       let continuationReplayRequest: CodexRebaseRequestResult | undefined;
       let rebaseAccounting = rebaseRequest?.accounting;
       const mutationPlan = activeMutationPlan(config);
+      if (mutationPlan) {
+        activeLifecyclePlan = codexMutationLifecyclePlan(mutationPlan);
+        await emitContextRewriteStage("context_rewrite_planned");
+        if (!config.contextRewrite.enabled) {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["feature_disabled"],
+            fallbackUsed: true,
+          });
+        } else if (!requestJournalEntry) {
+          await emitContextRewriteStage("context_rewrite_failed", {
+            reasonCodes: ["request_journal_unavailable"],
+            errorCategory: "history_journal_write_failed",
+            fallbackUsed: true,
+          });
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["fallback_original_request"],
+            fallbackUsed: true,
+          });
+        } else if (typeof originalPayload.previous_response_id !== "string"
+          || !originalPayload.previous_response_id) {
+          await emitContextRewriteStage("context_rewrite_deferred", {
+            reasonCodes: ["response_chain_head_missing"],
+          });
+        } else if (!config.contextRewrite.retryOriginalRequest
+          || config.contextRewrite.mode !== "response_chain_rebase"
+          || config.contextRewrite.failureMode !== "bypass") {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["rewrite_configuration_unsupported"],
+            fallbackUsed: true,
+          });
+        }
+      }
       let effectiveHistoryPromise: ReturnType<typeof buildCodexEffectiveHistory> | undefined;
       const effectiveHistoryForHead = (): ReturnType<typeof buildCodexEffectiveHistory> => {
         if (!requestJournalEntry || typeof originalPayload.previous_response_id !== "string") {
@@ -430,7 +570,7 @@ export async function startCodexResponsesProxy(params: {
       if (canAttemptCodexRebase({ config, payload: originalPayload, requestEntry: requestJournalEntry })
         && mutationPlan
         && requestJournalEntry) {
-        const planId = codexMutationPlanId(mutationPlan);
+        const planId = activeLifecyclePlan?.planId ?? codexMutationPlanId(mutationPlan);
         try {
           const effectiveHistory = await effectiveHistoryForHead();
           rebaseRequest = buildCodexRebaseRequest({
@@ -443,12 +583,23 @@ export async function startCodexResponsesProxy(params: {
             mutationPlan,
           });
           rebasePlanId = planId;
+          activeLifecyclePlan = {
+            ...(activeLifecyclePlan ?? { planId }),
+            previousRevision: rebaseRequest.oldRevision,
+            nextRevision: rebaseRequest.rebaseRevision,
+            estimatedSavedChars: rebaseRequest.accounting.plannedSavedChars,
+            savedChars: rebaseRequest.accounting.actuallyRemovedChars,
+          };
         } catch (err) {
           await appendTrace(config.stateDir, {
             stage: "context_rewrite_rebase_deferred",
             sessionId,
             model,
             reason: err instanceof Error ? err.message : String(err),
+          });
+          await emitContextRewriteStage("context_rewrite_deferred", {
+            reasonCodes: codexValidationReasonCodes(err),
+            deferredOperationIds: activeLifecyclePlan?.operationIds,
           });
         }
       }
@@ -457,7 +608,11 @@ export async function startCodexResponsesProxy(params: {
         && requestJournalEntry
         && typeof originalPayload.previous_response_id === "string"
         && config.contextRewrite.providerCompatibilityProbe !== "disabled";
+      let continuationLifecyclePlanned = false;
       if (canPrepareContinuationReplay) {
+        continuationLifecyclePlanned = true;
+        activeLifecyclePlan = { planId: "provider-continuation-replay" };
+        await emitContextRewriteStage("context_rewrite_planned");
         try {
           const effectiveHistory = await effectiveHistoryForHead();
           continuationReplayRequest = buildCodexRebaseRequest({
@@ -469,6 +624,13 @@ export async function startCodexResponsesProxy(params: {
             currentInput: originalPayload.input,
             mutationPlan: { baseRevision: effectiveHistory.revision, operations: [] },
           });
+          activeLifecyclePlan = {
+            planId: "provider-continuation-replay",
+            previousRevision: continuationReplayRequest.oldRevision,
+            nextRevision: continuationReplayRequest.rebaseRevision,
+            estimatedSavedChars: continuationReplayRequest.accounting.plannedSavedChars,
+            savedChars: continuationReplayRequest.accounting.actuallyRemovedChars,
+          };
         } catch (err) {
           await appendTrace(config.stateDir, {
             stage: "provider_continuation_replay_deferred",
@@ -476,7 +638,17 @@ export async function startCodexResponsesProxy(params: {
             model,
             reason: err instanceof Error ? err.message : String(err),
           });
+          await emitContextRewriteStage("context_rewrite_deferred", {
+            reasonCodes: codexValidationReasonCodes(err),
+          });
         }
+      }
+      if (!config.contextRewrite.enabled && !mutationPlan && !continuationLifecyclePlanned) {
+        activeLifecyclePlan = undefined;
+        await emitContextRewriteStage("context_rewrite_bypassed", {
+          reasonCodes: ["feature_disabled"],
+          fallbackUsed: true,
+        });
       }
 
       const payload = cloneJsonObject(rebaseRequest?.payload ?? originalPayload);
@@ -635,13 +807,128 @@ export async function startCodexResponsesProxy(params: {
           chainedPayload: payload,
           capabilityStore,
         }) === "verified_supported";
-      let contextRewriteOutcome: string | undefined;
+      let contextRewriteOutcome: string | undefined = nativeStreamChainVerified
+        ? "chained"
+        : undefined;
+      let contextRewriteValidationPassed = false;
+      let contextRewriteFailureReason: string | undefined;
+      let contextRewriteDeferredReason: string | undefined;
+      let contextRewriteBypassReason: string | undefined;
       let contextHistoryJournalPersisted = false;
+      if (nativeStreamChainVerified) contextRewriteValidationPassed = true;
       const committedContextInputItems = (): JsonObject[] | undefined => {
         const source = contextRewriteOutcome === "stateless_replay"
           ? continuationReplayPayload
           : payload;
         return Array.isArray(source?.input) ? source.input as JsonObject[] : undefined;
+      };
+
+      const finalizeContextRewriteLifecycle = async (
+        requestStatus: CodexJournalStatus,
+      ): Promise<void> => {
+        if (!activeLifecyclePlan || !contextRewriteOutcome) return;
+        const responseCompleted = requestStatus === "completed";
+        const journalReady = contextHistoryJournalPersisted;
+        if (contextRewriteOutcome === "committed" || contextRewriteOutcome === "stateless_replay") {
+          if (!responseCompleted || !journalReady) {
+            await emitContextRewriteStage("context_rewrite_failed", {
+              reasonCodes: [journalReady
+                ? "rebase_response_incomplete"
+                : "history_journal_write_failed"],
+              errorCategory: journalReady
+                ? "provider_response_incomplete"
+                : "history_journal_write_failed",
+              fallbackUsed: false,
+            });
+            return;
+          }
+          await emitContextRewriteStage("context_rewrite_validated", {
+            applicableOperationIds: activeLifecyclePlan.operationIds,
+          });
+          await emitContextRewriteStage("context_rewrite_applied", {
+            applicableOperationIds: activeLifecyclePlan.operationIds,
+            fallbackUsed: false,
+          });
+          return;
+        }
+        if (contextRewriteOutcome === "chained") {
+          if (!responseCompleted || !journalReady) {
+            await emitContextRewriteStage("context_rewrite_failed", {
+              reasonCodes: [journalReady
+                ? "rebase_response_incomplete"
+                : "history_journal_write_failed"],
+              errorCategory: journalReady
+                ? "provider_response_incomplete"
+                : "history_journal_write_failed",
+              fallbackUsed: false,
+            });
+            return;
+          }
+          await emitContextRewriteStage("context_rewrite_validated");
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["native_response_chain_used"],
+            fallbackUsed: false,
+          });
+          return;
+        }
+        if (contextRewriteOutcome === "bypassed") {
+          if (!responseCompleted || !journalReady) {
+            await emitContextRewriteStage("context_rewrite_failed", {
+              reasonCodes: [journalReady
+                ? "rebase_response_incomplete"
+                : "history_journal_write_failed"],
+              errorCategory: journalReady
+                ? "provider_response_incomplete"
+                : "history_journal_write_failed",
+              fallbackUsed: true,
+            });
+            return;
+          }
+          if (contextRewriteValidationPassed) {
+            await emitContextRewriteStage("context_rewrite_validated", {
+              applicableOperationIds: activeLifecyclePlan.operationIds,
+            });
+          }
+          if (contextRewriteFailureReason) {
+            await emitContextRewriteStage("context_rewrite_failed", {
+              reasonCodes: [codexSafeRuntimeReason(
+                contextRewriteFailureReason,
+                "rebase_upstream_rejected",
+              )],
+              errorCategory: "rewrite_apply_failed",
+              fallbackUsed: true,
+            });
+          } else if (contextRewriteDeferredReason) {
+            await emitContextRewriteStage("context_rewrite_deferred", {
+              reasonCodes: [codexSafeRuntimeReason(
+                contextRewriteDeferredReason,
+                "provider_replay_probe_required",
+              )],
+              deferredOperationIds: activeLifecyclePlan.operationIds,
+            });
+          }
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: [codexSafeRuntimeReason(
+              contextRewriteBypassReason,
+              "fallback_original_request",
+            )],
+            fallbackUsed: true,
+          });
+          return;
+        }
+        if (contextRewriteValidationPassed) {
+          await emitContextRewriteStage("context_rewrite_validated", {
+            applicableOperationIds: activeLifecyclePlan.operationIds,
+          });
+        }
+        await emitContextRewriteStage("context_rewrite_failed", {
+          reasonCodes: [codexSafeRuntimeReason(
+            contextRewriteFailureReason,
+            "rebase_upstream_error",
+          )],
+          errorCategory: "provider_request_failed",
+          fallbackUsed: contextRewriteValidationPassed,
+        });
       };
 
       const appendStreamContextHistory = async (paramsForJournal: {
@@ -680,6 +967,7 @@ export async function startCodexResponsesProxy(params: {
           status,
           error,
         });
+        contextHistoryJournalPersisted = true;
       };
 
       const appendNonStreamContextHistory = async (paramsForJournal: {
@@ -718,6 +1006,7 @@ export async function startCodexResponsesProxy(params: {
           status,
           error,
         });
+        contextHistoryJournalPersisted = true;
       };
 
       const persistAcceptedRebaseResponse = async (paramsForCommit: {
@@ -744,40 +1033,98 @@ export async function startCodexResponsesProxy(params: {
 
       const sendRebasedOrCurrentPayload = async () => {
         if (rebaseRequest && requestJournalEntry && rebasePlanId) {
-          const result = await executeCodexRebaseWithFallback({
-            sessionId,
-            planId: rebasePlanId,
-            epochId: `epoch-${requestJournalEntry.requestId}`,
-            originalPayload: fallbackPayload,
-            rebasedPayload: payload,
-            sendUpstream,
-            beforeCommit: persistAcceptedRebaseResponse,
-            accounting: rebaseAccounting,
-            epochStore: {
-              stateDir: config.stateDir,
-              oldPreviousResponseId: String(originalPayload.previous_response_id),
-              oldRevision: rebaseRequest.oldRevision,
-              newRevision: rebaseRequest.rebaseRevision,
-            },
-            cooldownStore: {
-              stateDir: config.stateDir,
-              cooldownMs: config.contextRewrite.cooldownMs,
-            },
-            capabilityStore,
-          });
-          contextRewriteOutcome = result.outcome;
-          if (result.outcome !== "committed") contextHistoryJournalPersisted = false;
-          return result.response;
+          try {
+            const result = await executeCodexRebaseWithFallback({
+              sessionId,
+              planId: rebasePlanId,
+              epochId: `epoch-${requestJournalEntry.requestId}`,
+              originalPayload: fallbackPayload,
+              rebasedPayload: payload,
+              sendUpstream,
+              beforeCommit: persistAcceptedRebaseResponse,
+              accounting: rebaseAccounting,
+              epochStore: {
+                stateDir: config.stateDir,
+                oldPreviousResponseId: String(originalPayload.previous_response_id),
+                oldRevision: rebaseRequest.oldRevision,
+                newRevision: rebaseRequest.rebaseRevision,
+              },
+              cooldownStore: {
+                stateDir: config.stateDir,
+                cooldownMs: config.contextRewrite.cooldownMs,
+              },
+              capabilityStore,
+            });
+            contextRewriteOutcome = result.outcome;
+            contextRewriteValidationPassed = Boolean(result.rebaseResponse)
+              || result.outcome === "committed";
+            if (result.outcome !== "committed") contextHistoryJournalPersisted = false;
+            if (result.outcome === "bypassed") {
+              if (result.rebaseResponse) {
+                contextRewriteFailureReason = result.reason
+                  ?? result.cooldown?.reason
+                  ?? result.capability?.reason
+                  ?? "rebase_upstream_rejected";
+                contextRewriteBypassReason = "fallback_original_request";
+              } else if (result.capability?.reason === "provider_replay_probe_required") {
+                contextRewriteDeferredReason = result.capability.reason;
+                contextRewriteBypassReason = "fallback_original_request";
+              } else if (result.capability?.reason) {
+                contextRewriteBypassReason = result.capability.reason;
+              } else if (result.reason === "cooldown_active") {
+                contextRewriteBypassReason = "cooldown_active";
+              } else if (result.reason === "rewrite_guard_busy") {
+                contextRewriteBypassReason = "rewrite_guard_busy";
+              } else if (result.reason) {
+                contextRewriteFailureReason = result.reason;
+                contextRewriteBypassReason = "fallback_original_request";
+              } else if (result.cooldown) {
+                contextRewriteBypassReason = "cooldown_active";
+              } else {
+                contextRewriteBypassReason = "rewrite_guard_busy";
+              }
+            } else if (result.outcome === "failed") {
+              contextRewriteFailureReason = result.reason
+                ?? result.cooldown?.reason
+                ?? result.capability?.reason
+                ?? "rebase_upstream_error";
+            }
+            return result.response;
+          } catch (error) {
+            contextRewriteOutcome = "failed";
+            contextRewriteFailureReason = "rebase_upstream_error";
+            await emitContextRewriteStage("context_rewrite_failed", {
+              reasonCodes: ["rebase_upstream_error"],
+              errorCategory: "provider_request_failed",
+              fallbackUsed: true,
+            });
+            throw error;
+          }
         }
         if (continuationReplayPayload) {
-          const result = await executeCodexProviderContinuationWithReplay({
-            chainedPayload: payload,
-            statelessReplayPayload: continuationReplayPayload,
-            sendUpstream,
-            capabilityStore,
-          });
-          contextRewriteOutcome = result.outcome;
-          return result.response;
+          try {
+            const result = await executeCodexProviderContinuationWithReplay({
+              chainedPayload: payload,
+              statelessReplayPayload: continuationReplayPayload,
+              sendUpstream,
+              capabilityStore,
+            });
+            contextRewriteOutcome = result.outcome;
+            contextRewriteValidationPassed = result.outcome !== "failed";
+            if (result.outcome === "failed") {
+              contextRewriteFailureReason = "rebase_upstream_error";
+            }
+            return result.response;
+          } catch (error) {
+            contextRewriteOutcome = "failed";
+            contextRewriteFailureReason = "rebase_upstream_error";
+            await emitContextRewriteStage("context_rewrite_failed", {
+              reasonCodes: ["rebase_upstream_error"],
+              errorCategory: "provider_request_failed",
+              fallbackUsed: false,
+            });
+            throw error;
+          }
         }
         return sendUpstream(payload);
       };
@@ -827,6 +1174,7 @@ export async function startCodexResponsesProxy(params: {
             });
           }
         }
+        await finalizeContextRewriteLifecycle(requestStatus);
         await appendTrace(config.stateDir, {
           stage: "proxy_after_call",
           sessionId,
@@ -981,6 +1329,10 @@ export async function startCodexResponsesProxy(params: {
           });
         }
       }
+      await finalizeContextRewriteLifecycle(nonStreamRequestStatus({
+        httpStatus: upstreamResp.status,
+        response: responseJson,
+      }));
       await recordCodexUxReduction({
         stateDir: config.stateDir,
         sessionId,

--- a/components/adapters/codex/tests/context-rebase-pipeline.test.ts
+++ b/components/adapters/codex/tests/context-rebase-pipeline.test.ts
@@ -244,6 +244,23 @@ function inputText(payload: JsonObject | undefined): string {
   return JSON.stringify(input);
 }
 
+const CONTEXT_REWRITE_LIFECYCLE_STAGES = new Set([
+  "context_rewrite_planned",
+  "context_rewrite_validated",
+  "context_rewrite_applied",
+  "context_rewrite_deferred",
+  "context_rewrite_failed",
+  "context_rewrite_bypassed",
+]);
+
+async function readContextRewriteLifecycleEvents(stateDir: string): Promise<JsonObject[]> {
+  const rows = (await readFile(join(stateDir, "event-trace.jsonl"), "utf8"))
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as JsonObject);
+  return rows.filter((row) => CONTEXT_REWRITE_LIFECYCLE_STAGES.has(String(row.stage)));
+}
+
 test("CDR-03 proxy startup recovers a pending epoch before serving its session", async () => {
   const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rebase-pending-restart-"));
   const upstream = await startSequencedResponsesUpstream();
@@ -439,6 +456,20 @@ test("CDR-06 proxy pipeline rebases a non-stream request from effective history"
     assert.equal("previous_response_id" in (upstream.requests[1] ?? {}), false);
     assert.doesNotMatch(inputText(upstream.requests[1]), /OLD_SENTINEL_PIPELINE/);
     assert.match(inputText(upstream.requests[1]), /CURRENT_SENTINEL_PIPELINE/);
+    const lifecycleEvents = (await readContextRewriteLifecycleEvents(stateDir))
+      .filter((event) => String(event.planId).startsWith("plan-"));
+    assert.deepEqual(
+      lifecycleEvents.map((event) => event.stage),
+      [
+        "context_rewrite_planned",
+        "context_rewrite_validated",
+        "context_rewrite_applied",
+      ],
+    );
+    assert.equal(lifecycleEvents[2]?.fallbackUsed, false);
+    const serializedLifecycle = JSON.stringify(lifecycleEvents);
+    assert.doesNotMatch(serializedLifecycle, /OLD_SENTINEL_PIPELINE|CURRENT_SENTINEL_PIPELINE/);
+    assert.doesNotMatch(serializedLifecycle, /responseId|previousResponseId|promptCacheKey|encrypted_content/);
   } finally {
     await runtime?.close();
     await upstream.close();
@@ -539,6 +570,23 @@ test("CDR-06 proxy automatically replaces an unsupported response chain with sta
       })),
       { latestResponseId: "resp-pipeline-4", previousResponseId: undefined },
     );
+    const continuationEvents = (await readContextRewriteLifecycleEvents(stateDir))
+      .filter((event) => event.planId === "provider-continuation-replay");
+    assert.deepEqual(
+      continuationEvents.slice(0, 3).map((event) => event.stage),
+      [
+        "context_rewrite_planned",
+        "context_rewrite_validated",
+        "context_rewrite_applied",
+      ],
+    );
+    const featureDisabled = (await readContextRewriteLifecycleEvents(stateDir)).find((event) => (
+      event.stage === "context_rewrite_bypassed"
+      && event.planId === undefined
+      && Array.isArray(event.reasonCodes)
+      && event.reasonCodes.includes("feature_disabled")
+    ));
+    assert.ok(featureDisabled);
   } finally {
     await runtime?.close();
     await upstream.close();
@@ -847,6 +895,24 @@ test("CDR-01 proxy pipeline defers stale mutation plans", async () => {
     assert.equal(upstream.requests.length, 2);
     assert.equal(upstream.requests[1]?.previous_response_id, "resp-pipeline-1");
     assert.match(inputText(upstream.requests[1]), /CURRENT_SENTINEL_STALE_PLAN/);
+    const lifecycleEvents = await readContextRewriteLifecycleEvents(stateDir);
+    const mutationEvents = lifecycleEvents.filter((event) => String(event.planId).startsWith("plan-"));
+    assert.deepEqual(
+      mutationEvents.map((event) => event.stage),
+      ["context_rewrite_planned", "context_rewrite_deferred"],
+    );
+    assert.deepEqual(mutationEvents[1]?.reasonCodes, ["revision_drift"]);
+    const continuationEvents = lifecycleEvents
+      .filter((event) => event.planId === "provider-continuation-replay");
+    assert.deepEqual(
+      continuationEvents.map((event) => event.stage),
+      [
+        "context_rewrite_planned",
+        "context_rewrite_validated",
+        "context_rewrite_bypassed",
+      ],
+    );
+    assert.deepEqual(continuationEvents[2]?.reasonCodes, ["native_response_chain_used"]);
   } finally {
     await runtime?.close();
     await upstream.close();
@@ -947,6 +1013,22 @@ test("CDR-06 proxy pipeline falls back and cools down rejected rebases", async (
     assert.equal(fourth.status, 200);
     assert.equal(upstream.requests.length, 5);
     assert.equal(upstream.requests[4]?.previous_response_id, "resp-pipeline-1");
+    const mutationEvents = (await readContextRewriteLifecycleEvents(stateDir))
+      .filter((event) => String(event.planId).startsWith("plan-"));
+    assert.deepEqual(
+      mutationEvents.slice(0, 4).map((event) => event.stage),
+      [
+        "context_rewrite_planned",
+        "context_rewrite_validated",
+        "context_rewrite_failed",
+        "context_rewrite_bypassed",
+      ],
+    );
+    assert.ok(mutationEvents.some((event) => (
+      event.stage === "context_rewrite_bypassed"
+      && Array.isArray(event.reasonCodes)
+      && event.reasonCodes.includes("cooldown_active")
+    )));
   } finally {
     await runtime?.close();
     await upstream.close();
@@ -1145,6 +1227,17 @@ test("CDR-06 proxy pipeline falls back and cools down rejected stream rebases", 
     await third.text();
     assert.equal(upstream.requests.length, 4);
     assert.equal(upstream.requests[3]?.previous_response_id, "resp-stream-pipeline-1");
+    const mutationEvents = (await readContextRewriteLifecycleEvents(stateDir))
+      .filter((event) => String(event.planId).startsWith("plan-"));
+    assert.deepEqual(
+      mutationEvents.slice(0, 4).map((event) => event.stage),
+      [
+        "context_rewrite_planned",
+        "context_rewrite_validated",
+        "context_rewrite_failed",
+        "context_rewrite_bypassed",
+      ],
+    );
   } finally {
     await runtime?.close();
     await upstream.close();

--- a/components/adapters/codex/tests/context-rebase-provider-smoke.test.ts
+++ b/components/adapters/codex/tests/context-rebase-provider-smoke.test.ts
@@ -28,7 +28,10 @@ async function requestBody(req: IncomingMessage): Promise<JsonObject> {
   });
 }
 
-async function startProviderFixture(options: { rejectWithSecret?: boolean } = {}): Promise<{
+async function startProviderFixture(options: {
+  rejectChainReferences?: boolean;
+  rejectWithSecret?: boolean;
+} = {}): Promise<{
   baseUrl: string;
   authorizationPresent(): boolean;
   close(): Promise<void>;
@@ -50,6 +53,17 @@ async function startProviderFixture(options: { rejectWithSecret?: boolean } = {}
       return;
     }
     const payload = await requestBody(req);
+    if (options.rejectChainReferences && typeof payload.previous_response_id === "string") {
+      res.statusCode = 400;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({
+        error: {
+          code: "invalid_request_error",
+          message: "previous_response_id is not supported by this provider",
+        },
+      }));
+      return;
+    }
     ordinal += 1;
     const id = `resp-provider-fixture-${ordinal}`;
     const previousId = typeof payload.previous_response_id === "string"
@@ -198,6 +212,35 @@ test("provider smoke emits sanitized real-chain, capability v2, matrix, and usag
     else process.env.OPENAI_API_KEY = previousKey;
     if (previousCli === undefined) delete process.env.CODEX_CLI_VERSION;
     else process.env.CODEX_CLI_VERSION = previousCli;
+    await provider.close();
+    await rm(outputDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+  }
+});
+
+test("provider smoke accepts journal-backed stateless continuation roots", async () => {
+  const provider = await startProviderFixture({ rejectChainReferences: true });
+  const outputDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-provider-stateless-smoke-test-"));
+  const previousKey = process.env.OPENAI_API_KEY;
+  process.env.OPENAI_API_KEY = "provider-smoke-test-key-not-secret";
+  try {
+    const result = await runCodexRebaseProviderSmoke({
+      baseUrl: provider.baseUrl,
+      model: "provider-fixture-model",
+      continuationTurns: 5,
+      outputDir,
+    });
+    const evidence = result.evidence;
+
+    assert.equal(evidence.rebase.committed, true);
+    assert.equal(evidence.rebase.responseChain.linksValid, true);
+    assert.equal(evidence.rebase.responseChain.restartPreserved, true);
+    assert.equal(evidence.rebase.responseChain.finalHistoryComplete, true);
+    assert.ok(evidence.capability.realProviderRejectedItemTypes.includes("previous_response_id"));
+    assert.ok(evidence.capability.realProviderVerifiedItemTypes.includes("reasoning"));
+    assert.ok(evidence.usage.observedSavedInputTokens > 0);
+  } finally {
+    if (previousKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = previousKey;
     await provider.close();
     await rm(outputDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }

--- a/components/adapters/codex/tests/context-rewrite-backend.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-backend.test.ts
@@ -1,0 +1,256 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextMutationPlan,
+} from "@lightmem2/host-adapter";
+
+import type { CodexEffectiveHistoryItem, JsonObject } from "../src/context-history/types.js";
+import {
+  codexSharedContextRewriteBackend,
+  runCodexSharedGoldenFixture,
+  type CodexSharedBackendRequest,
+} from "../src/context-rewrite/index.js";
+
+const SESSION_ID = "codex-shared-backend-session";
+
+function message(stableItemId: string, role: string, text: string): CodexEffectiveHistoryItem {
+  return {
+    stableItemId,
+    item: {
+      type: "message",
+      role,
+      content: [{ type: role === "assistant" ? "output_text" : "input_text", text }],
+    },
+  };
+}
+
+function requestFor(items: CodexEffectiveHistoryItem[]): CodexSharedBackendRequest {
+  return {
+    sessionId: SESSION_ID,
+    payload: {
+      model: "fixture-model",
+      previous_response_id: "fixture-parent",
+      input: [],
+    },
+    currentInput: [],
+    effectiveHistory: {
+      revision: "codex-shared-rev-1",
+      replayableItems: items,
+      observationOnlyItems: [],
+      deferredItems: [],
+      unresolvedCallIds: [],
+      source: "proxy_journal",
+      incomplete: false,
+    },
+    taskIdsByItemId: {
+      "old-user": ["task-completed"],
+      "old-call": ["task-completed"],
+      "old-result": ["task-completed"],
+      "active-user": ["task-active"],
+    },
+    activeTaskIds: ["task-active"],
+    evictableTaskIds: ["task-completed"],
+  };
+}
+
+function planFor(params: {
+  revision: string;
+  targetItemIds: string[];
+  fingerprints: Record<string, string>;
+  taskId?: string;
+}): ContextMutationPlan {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: "codex-shared-plan-1",
+    hostId: "codex",
+    sessionId: SESSION_ID,
+    baseRevision: params.revision,
+    sourceModuleId: "test",
+    operations: [{
+      id: "codex-shared-op-1",
+      type: "remove",
+      targetItemIds: params.targetItemIds,
+      targetItemFingerprints: params.fingerprints,
+      taskIds: [params.taskId ?? "task-completed"],
+      rationale: "remove completed task",
+      estimatedSavedChars: 100,
+    }],
+    createdAt: "2026-08-09T00:00:00.000Z",
+  };
+}
+
+test("Codex shared backend maps effective history and prepares a standard rebase result", async () => {
+  const items: CodexEffectiveHistoryItem[] = [
+    message("old-user", "user", "old request"),
+    {
+      stableItemId: "old-call",
+      callId: "call-old",
+      item: { type: "function_call", call_id: "call-old", name: "read", arguments: "{}" },
+    },
+    {
+      stableItemId: "old-result",
+      callId: "call-old",
+      item: { type: "function_call_output", call_id: "call-old", output: "old result" },
+    },
+    message("active-user", "user", "keep current work"),
+  ];
+  const request = requestFor(items);
+  const snapshot = await codexSharedContextRewriteBackend.readSnapshot({
+    sessionId: SESSION_ID,
+    request,
+  });
+  assert.deepEqual(
+    snapshot.items.map((item) => [item.stableId, item.kind, item.taskIds]),
+    [
+      ["old-user", "user", ["task-completed"]],
+      ["old-call", "tool_call", ["task-completed"]],
+      ["old-result", "tool_result", ["task-completed"]],
+      ["active-user", "user", ["task-active"]],
+    ],
+  );
+  const targets = ["old-user", "old-call", "old-result"];
+  const plan = planFor({
+    revision: snapshot.revision,
+    targetItemIds: targets,
+    fingerprints: Object.fromEntries(
+      snapshot.items.filter((item) => targets.includes(item.stableId))
+        .map((item) => [item.stableId, item.fingerprint]),
+    ),
+  });
+
+  const validation = await codexSharedContextRewriteBackend.validate({ snapshot, plan });
+  assert.deepEqual(validation.applicableOperationIds, ["codex-shared-op-1"]);
+  assert.deepEqual(validation.deferredOperationIds, []);
+
+  const applied = await codexSharedContextRewriteBackend.apply({ snapshot, plan, request });
+  assert.equal(applied.result.mode, "response_chain_rebase");
+  assert.equal(applied.result.applied, true);
+  assert.equal(applied.result.changed, true);
+  assert.deepEqual(applied.result.appliedOperationIds, ["codex-shared-op-1"]);
+  assert.deepEqual(applied.result.removedItemIds, targets);
+  assert.equal(applied.result.fallbackUsed, false);
+  assert.equal(applied.result.details?.rebasePrepared, true);
+  assert.equal("previous_response_id" in applied.request.payload, false);
+  const replayInput = JSON.stringify(applied.request.payload.input);
+  assert.doesNotMatch(replayInput, /old request|old result|call-old/);
+  assert.match(replayInput, /keep current work/);
+});
+
+test("Codex shared backend defers partial tool closure and active task targets", async () => {
+  const items: CodexEffectiveHistoryItem[] = [
+    {
+      stableItemId: "old-call",
+      callId: "call-old",
+      item: { type: "function_call", call_id: "call-old", name: "read", arguments: "{}" },
+    },
+    {
+      stableItemId: "old-result",
+      callId: "call-old",
+      item: { type: "function_call_output", call_id: "call-old", output: "old result" },
+    },
+    message("active-user", "user", "keep current work"),
+  ];
+  const request = requestFor(items);
+  const snapshot = await codexSharedContextRewriteBackend.readSnapshot({ sessionId: SESSION_ID, request });
+
+  const partial = planFor({
+    revision: snapshot.revision,
+    targetItemIds: ["old-call"],
+    fingerprints: { "old-call": snapshot.items.find((item) => item.stableId === "old-call")!.fingerprint },
+  });
+  const partialValidation = await codexSharedContextRewriteBackend.validate({ snapshot, plan: partial });
+  assert.deepEqual(partialValidation.applicableOperationIds, []);
+  assert.deepEqual(partialValidation.deferredOperationIds, ["codex-shared-op-1"]);
+  assert.ok(partialValidation.reasons.some((reason) => reason.includes("protocol_pair_partial")));
+
+  const active = planFor({
+    revision: snapshot.revision,
+    targetItemIds: ["active-user"],
+    fingerprints: {
+      "active-user": snapshot.items.find((item) => item.stableId === "active-user")!.fingerprint,
+    },
+    taskId: "task-active",
+  });
+  const activeValidation = await codexSharedContextRewriteBackend.validate({ snapshot, plan: active });
+  assert.deepEqual(activeValidation.applicableOperationIds, []);
+  assert.deepEqual(activeValidation.deferredOperationIds, ["codex-shared-op-1"]);
+  assert.ok(activeValidation.reasons.some((reason) => reason.includes("active_task_targeted")));
+});
+
+test("Codex shared backend revalidates a stale revision only with exact target fingerprints", async () => {
+  const request = requestFor([
+    message("old-user", "user", "old request"),
+    message("active-user", "user", "keep current work"),
+  ]);
+  const snapshot = await codexSharedContextRewriteBackend.readSnapshot({ sessionId: SESSION_ID, request });
+  const fingerprint = snapshot.items.find((item) => item.stableId === "old-user")!.fingerprint;
+  const plan = planFor({
+    revision: "codex-stale-revision",
+    targetItemIds: ["old-user"],
+    fingerprints: { "old-user": fingerprint },
+  });
+  const validation = await codexSharedContextRewriteBackend.validate({ snapshot, plan });
+  assert.deepEqual(validation.applicableOperationIds, ["codex-shared-op-1"]);
+  assert.ok(validation.reasons.includes("revision_mismatch"));
+  const applied = await codexSharedContextRewriteBackend.apply({ snapshot, plan, request });
+  assert.equal(applied.result.applied, true);
+
+  plan.operations[0]!.targetItemFingerprints = { "old-user": "changed-fingerprint" };
+  const drifted = await codexSharedContextRewriteBackend.validate({ snapshot, plan });
+  assert.deepEqual(drifted.applicableOperationIds, []);
+  assert.deepEqual(drifted.deferredOperationIds, ["codex-shared-op-1"]);
+});
+
+test("Codex GUA-02 fixture API returns deterministic logical target sets", async () => {
+  const fixture = {
+    id: "codex-fixture-api",
+    tasks: [
+      {
+        id: "task-completed",
+        status: "completed" as const,
+        items: [
+          { id: "item-old", kind: "message", role: "user", content: "old task" },
+        ],
+      },
+      {
+        id: "task-active",
+        status: "active" as const,
+        current: true,
+        items: [
+          { id: "item-current", kind: "message", role: "user", content: "current task" },
+        ],
+      },
+    ],
+  };
+  const first = await runCodexSharedGoldenFixture(fixture);
+  const second = await runCodexSharedGoldenFixture(structuredClone(fixture));
+  assert.deepEqual(first, second);
+  assert.deepEqual(first.selectedTaskIds, ["task-completed"]);
+  assert.deepEqual(first.keptTaskIds, ["task-active"]);
+  assert.deepEqual(first.selectedItemIds, ["item-old"]);
+  assert.deepEqual(first.keptItemIds, ["item-current"]);
+  assert.equal(first.result.applied, true);
+});
+
+test("Codex shared backend defers incomplete effective history without mutating the request", async () => {
+  const request = requestFor([
+    message("old-user", "user", "old request"),
+    message("active-user", "user", "keep current work"),
+  ]);
+  request.effectiveHistory.incomplete = true;
+  const snapshot = await codexSharedContextRewriteBackend.readSnapshot({ sessionId: SESSION_ID, request });
+  const oldItem = snapshot.items.find((item) => item.stableId === "old-user")!;
+  const plan = planFor({
+    revision: snapshot.revision,
+    targetItemIds: ["old-user"],
+    fingerprints: { "old-user": oldItem.fingerprint },
+  });
+  const applied = await codexSharedContextRewriteBackend.apply({ snapshot, plan, request });
+  assert.equal(applied.result.applied, false);
+  assert.equal(applied.result.changed, false);
+  assert.deepEqual(applied.result.deferredOperationIds, ["codex-shared-op-1"]);
+  assert.equal(applied.request, request);
+  assert.deepEqual(applied.request.payload as JsonObject, request.payload);
+});

--- a/components/adapters/codex/tests/context-rewrite-lifecycle-events.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-lifecycle-events.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { createCodexContextRewriteLifecycle } from "../src/context-rewrite/index.js";
+
+test("Codex lifecycle events use the shared sanitized schema", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-rewrite-lifecycle-"));
+  const secret = "sk-proj-abcdefghijklmnopqrstuvwxyz012345";
+  try {
+    const lifecycle = createCodexContextRewriteLifecycle({
+      stateDir,
+      sessionId: `session:${secret}`,
+    });
+    await lifecycle.append({
+      stage: "context_rewrite_applied",
+      planId: `plan:${secret}`,
+      operationIds: [`operation:${secret}`],
+      itemIds: [`item:${secret}`],
+      reasonCodes: [`reason:${secret}`],
+      errorCategory: `error:${secret}`,
+      savedChars: 42,
+    });
+
+    const raw = await readFile(join(stateDir, "event-trace.jsonl"), "utf8");
+    assert.doesNotMatch(raw, new RegExp(secret));
+    const event = JSON.parse(raw.trim()) as Record<string, unknown>;
+    assert.equal(event.stage, "context_rewrite_applied");
+    assert.equal(event.hostId, "codex");
+    assert.equal(event.mode, "response_chain_rebase");
+    assert.equal(event.savedChars, 42);
+    assert.match(String(event.sessionId), /^redacted:sha256:/);
+    assert.match(String(event.planId), /^redacted:sha256:/);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex lifecycle event persistence is best effort", async () => {
+  let appendCalls = 0;
+  const lifecycle = createCodexContextRewriteLifecycle({
+    stateDir: "unused",
+    sessionId: "session-best-effort",
+    async appendEvent() {
+      appendCalls += 1;
+      throw new Error("simulated trace-store failure");
+    },
+  });
+
+  await assert.doesNotReject(lifecycle.append({
+    stage: "context_rewrite_failed",
+    errorCategory: "trace_store_failure",
+  }));
+  assert.equal(appendCalls, 1);
+});

--- a/components/adapters/openclaw/src/context-rewrite/cross-host-backends.test.ts
+++ b/components/adapters/openclaw/src/context-rewrite/cross-host-backends.test.ts
@@ -1,0 +1,433 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextMutationPlan,
+  type ContextRewriteResult,
+  type ContextRewriteValidation,
+  type ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+import type { RuntimeMessage } from "@lightmem2/kernel";
+
+import {
+  claudeContextRewriteBackend,
+  type ClaudeOverlayRequest,
+} from "../../../claude-code/src/context-rewrite/backend.js";
+import {
+  runCodexSharedGoldenFixture,
+  type CodexSharedGoldenFixture,
+} from "../../../codex/src/context-rewrite/backend.js";
+import {
+  createOpenClawReferenceBackend,
+  type OpenClawReferenceBackendRequest,
+} from "./reference-backend.js";
+
+type GoldenItem = {
+  id: string;
+  kind: string;
+  role?: string;
+  content?: string;
+  tool_name?: string;
+  tool_call_id?: string;
+  arguments?: Record<string, unknown>;
+  result?: string;
+};
+
+type GoldenTask = {
+  id: string;
+  status: "active" | "completed" | "unresolved";
+  current?: boolean;
+  items: GoldenItem[];
+};
+
+type GoldenFixture = CodexSharedGoldenFixture & {
+  schema: string;
+  description: string;
+  tasks: GoldenTask[];
+  expected: {
+    evict_task_ids: string[];
+    keep_task_ids: string[];
+    evict_item_ids: string[];
+    keep_item_ids: string[];
+  };
+};
+
+type BackendDecision = {
+  hostId: "openclaw" | "claude-code" | "codex";
+  mode: string;
+  selectedTaskIds: string[];
+  keptTaskIds: string[];
+  selectedItemIds: string[];
+  keptItemIds: string[];
+  validation: ContextRewriteValidation;
+  result: ContextRewriteResult<unknown>;
+};
+
+const fixtureDirectory = path.join(__dirname, "fixtures");
+const fixtureFiles = [
+  "active-turn.json",
+  "completed-task.json",
+  "tool-closure.json",
+  "unresolved-task.json",
+];
+
+function readFixture(fileName: string): GoldenFixture {
+  return JSON.parse(
+    fs.readFileSync(path.join(fixtureDirectory, fileName), "utf8"),
+  ) as GoldenFixture;
+}
+
+function sorted(values: readonly string[]): string[] {
+  return [...values].sort();
+}
+
+function completedTasks(fixture: GoldenFixture): GoldenTask[] {
+  return fixture.tasks.filter((task) => task.status === "completed" && task.current !== true);
+}
+
+function buildPlan(params: {
+  fixture: GoldenFixture;
+  hostId: string;
+  sessionId: string;
+  snapshot: ModelContextSnapshot<unknown>;
+  stableIdByLogicalId: Map<string, string>;
+  operationType: "remove" | "replace";
+}): ContextMutationPlan {
+  const snapshotItemById = new Map(params.snapshot.items.map((item) => [item.stableId, item]));
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: `gua-02-${params.hostId}-${params.fixture.id}`,
+    hostId: params.hostId,
+    sessionId: params.sessionId,
+    baseRevision: params.snapshot.revision,
+    sourceModuleId: "gua-02",
+    operations: completedTasks(params.fixture).map((task) => {
+      const targetItemIds = task.items.map((item) => params.stableIdByLogicalId.get(item.id)!);
+      return {
+        id: `gua-02-op-${task.id}`,
+        type: params.operationType,
+        targetItemIds,
+        targetItemFingerprints: Object.fromEntries(
+          targetItemIds.map((itemId) => [itemId, snapshotItemById.get(itemId)!.fingerprint]),
+        ),
+        taskIds: [task.id],
+        rationale: "evict completed golden task",
+        estimatedSavedChars: targetItemIds.reduce(
+          (total, itemId) => total + (snapshotItemById.get(itemId)?.chars ?? 0),
+          0,
+        ),
+      };
+    }),
+    createdAt: "2026-08-09T00:00:00.000Z",
+  };
+}
+
+function normalizeDecision(params: {
+  fixture: GoldenFixture;
+  hostId: BackendDecision["hostId"];
+  mode: string;
+  plan: ContextMutationPlan;
+  logicalIdByStableId: Map<string, string>;
+  validation: ContextRewriteValidation;
+  result: ContextRewriteResult<unknown>;
+}): BackendDecision {
+  const appliedOperationIds = new Set(params.result.appliedOperationIds);
+  const selectedTaskIds = completedTasks(params.fixture)
+    .filter((task) => appliedOperationIds.has(`gua-02-op-${task.id}`))
+    .map((task) => task.id);
+  const selectedStableIds = new Set(params.plan.operations
+    .filter((operation) => appliedOperationIds.has(operation.id))
+    .flatMap((operation) => operation.targetItemIds));
+  const selectedItemIds = params.fixture.tasks.flatMap((task) => task.items)
+    .map((item) => item.id)
+    .filter((logicalId) => {
+      const stableId = [...params.logicalIdByStableId.entries()]
+        .find(([, candidateLogicalId]) => candidateLogicalId === logicalId)?.[0];
+      return stableId ? selectedStableIds.has(stableId) : false;
+    });
+  const selectedTasks = new Set(selectedTaskIds);
+  const selectedItems = new Set(selectedItemIds);
+  return {
+    hostId: params.hostId,
+    mode: params.mode,
+    selectedTaskIds,
+    keptTaskIds: params.fixture.tasks.map((task) => task.id)
+      .filter((taskId) => !selectedTasks.has(taskId)),
+    selectedItemIds,
+    keptItemIds: params.fixture.tasks.flatMap((task) => task.items.map((item) => item.id))
+      .filter((itemId) => !selectedItems.has(itemId)),
+    validation: params.validation,
+    result: params.result,
+  };
+}
+
+function claudeMessage(item: GoldenItem): RuntimeMessage {
+  if (item.kind === "tool_call") {
+    return {
+      role: "assistant",
+      content: [{
+        type: "tool_use",
+        id: item.tool_call_id,
+        name: item.tool_name ?? "fixture_tool",
+        input: item.arguments ?? {},
+      }],
+    } as unknown as RuntimeMessage;
+  }
+  if (item.kind === "tool_result") {
+    return {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: item.tool_call_id,
+        content: item.result ?? "",
+      }],
+    } as unknown as RuntimeMessage;
+  }
+  return {
+    role: item.role ?? "user",
+    content: [{ type: "text", text: item.content ?? "" }],
+  } as RuntimeMessage;
+}
+
+async function runClaudeFixture(fixture: GoldenFixture): Promise<BackendDecision> {
+  const sessionId = `gua-02-claude-${fixture.id}`;
+  const logicalItems = fixture.tasks.flatMap((task) => task.items);
+  const request: ClaudeOverlayRequest = {
+    sessionId,
+    revision: `claude-gua-rev-${fixture.id}`,
+    messages: logicalItems.map(claudeMessage),
+  };
+  const snapshot = await claudeContextRewriteBackend.readSnapshot({ sessionId, request });
+  assert.equal(snapshot.items.length, logicalItems.length);
+  const stableIdByLogicalId = new Map(
+    logicalItems.map((item, index) => [item.id, snapshot.items[index]!.stableId]),
+  );
+  const logicalIdByStableId = new Map(
+    [...stableIdByLogicalId].map(([logicalId, stableId]) => [stableId, logicalId]),
+  );
+  const plan = buildPlan({
+    fixture,
+    hostId: "claude-code",
+    sessionId,
+    snapshot,
+    stableIdByLogicalId,
+    operationType: "replace",
+  });
+  const validation = await claudeContextRewriteBackend.validate({ snapshot, plan });
+  const applied = await claudeContextRewriteBackend.apply({ snapshot, plan, request });
+  return normalizeDecision({
+    fixture,
+    hostId: "claude-code",
+    mode: claudeContextRewriteBackend.mode,
+    plan,
+    logicalIdByStableId,
+    validation,
+    result: applied.result,
+  });
+}
+
+function contentToText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return "";
+  return value.map((block) => (
+    block && typeof block === "object" && "text" in block
+      ? String((block as Record<string, unknown>).text ?? "")
+      : ""
+  )).join("");
+}
+
+function openClawTaskIds(message: Record<string, unknown>): string[] {
+  const details = message.details as { contextSafe?: { taskIds?: string[] } } | undefined;
+  return details?.contextSafe?.taskIds ?? [];
+}
+
+function openClawMessage(item: GoldenItem, taskId: string): Record<string, unknown> {
+  const details = { contextSafe: { taskIds: [taskId] } };
+  if (item.kind === "tool_call") {
+    return {
+      messageId: item.id,
+      role: "assistant",
+      content: [{
+        type: "toolCall",
+        id: item.tool_call_id,
+        name: item.tool_name ?? "fixture_tool",
+        arguments: item.arguments ?? {},
+      }],
+      details,
+    };
+  }
+  if (item.kind === "tool_result") {
+    return {
+      messageId: item.id,
+      role: "toolResult",
+      toolCallId: item.tool_call_id,
+      toolName: item.tool_name ?? "fixture_tool",
+      content: [{ type: "text", text: item.result ?? "" }],
+      details,
+    };
+  }
+  return {
+    messageId: item.id,
+    role: item.role ?? "user",
+    content: item.content ?? "",
+    details,
+  };
+}
+
+function openClawRequest(fixture: GoldenFixture): OpenClawReferenceBackendRequest {
+  const messages = fixture.tasks.flatMap((task) => (
+    task.items.map((item) => openClawMessage(item, task.id))
+  ));
+  return {
+    stateDir: "fixture-state",
+    sessionId: `gua-02-openclaw-${fixture.id}`,
+    state: {
+      version: 1,
+      sessionId: `gua-02-openclaw-${fixture.id}`,
+      messages,
+      seenMessageIds: messages.map((message) => String(message.messageId)),
+      updatedAt: "2026-08-09T00:00:00.000Z",
+    },
+    evictionEnabled: true,
+    evictionPolicy: "model_scored",
+    evictionMinBlockChars: 1,
+    evictionReplacementMode: "drop",
+    helpers: {
+      appendTaskStateTrace: async () => undefined,
+      appendEvictionVisualSnapshot: async () => undefined,
+      asRecord: (value) => value && typeof value === "object" && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : undefined,
+      canonicalMessageTaskIds: openClawTaskIds,
+      contentToText,
+      dedupeStrings: (values) => [...new Set(values)],
+      ensureContextSafeDetails: (_details, patch) => ({ contextSafe: patch }),
+      extractPathLike: () => undefined,
+      extractToolMessageText: (message) => contentToText(message.content),
+      isToolResultLikeMessage: (message) => ["tool", "toolresult"].includes(
+        String(message.role ?? "").toLowerCase(),
+      ),
+      logger: { info: () => undefined },
+      messageToolCallId: (message) => typeof message.toolCallId === "string"
+        ? message.toolCallId
+        : typeof message.tool_call_id === "string"
+          ? message.tool_call_id
+          : undefined,
+      safeId: (value) => value,
+    },
+  };
+}
+
+async function runOpenClawFixture(fixture: GoldenFixture): Promise<BackendDecision> {
+  const request = openClawRequest(fixture);
+  const backend = createOpenClawReferenceBackend({
+    async rewriteCanonicalState(params) {
+      const requestedTaskIds = new Set(params.evictionTaskIds);
+      const appliedTaskIds = [...requestedTaskIds].filter((taskId) => (
+        params.state.messages.some((rawMessage) => {
+          const message = rawMessage as Record<string, unknown>;
+          return openClawTaskIds(message).includes(taskId);
+        })
+      ));
+      const nextMessages = params.state.messages.filter((rawMessage) => {
+        const message = rawMessage as Record<string, unknown>;
+        return !openClawTaskIds(message).some((taskId) => requestedTaskIds.has(taskId));
+      });
+      return {
+        state: {
+          ...params.state,
+          messages: nextMessages,
+          updatedAt: "2026-08-09T00:01:00.000Z",
+        },
+        changed: nextMessages.length !== params.state.messages.length,
+        appliedEvictionTaskIds: appliedTaskIds,
+      };
+    },
+  });
+  const snapshot = await backend.readSnapshot({ sessionId: request.sessionId, request });
+  const stableIdByLogicalId = new Map(snapshot.items.map((item) => [item.stableId, item.stableId]));
+  const logicalIdByStableId = new Map(snapshot.items.map((item) => [item.stableId, item.stableId]));
+  const plan = buildPlan({
+    fixture,
+    hostId: "openclaw",
+    sessionId: request.sessionId,
+    snapshot,
+    stableIdByLogicalId,
+    operationType: "remove",
+  });
+  const validation = await backend.validate({ snapshot, plan });
+  const applied = await backend.apply({ snapshot, plan, request });
+  return normalizeDecision({
+    fixture,
+    hostId: "openclaw",
+    mode: backend.mode,
+    plan,
+    logicalIdByStableId,
+    validation,
+    result: applied.result,
+  });
+}
+
+test("GUA-02 runs all three independent backends against the same logical target sets", async () => {
+  for (const fixtureFile of fixtureFiles) {
+    const fixture = readFixture(fixtureFile);
+    const openclaw = await runOpenClawFixture(fixture);
+    const claude = await runClaudeFixture(fixture);
+    const codexRaw = await runCodexSharedGoldenFixture(fixture);
+    const codex: BackendDecision = {
+      hostId: "codex",
+      mode: codexRaw.result.mode,
+      selectedTaskIds: codexRaw.selectedTaskIds,
+      keptTaskIds: codexRaw.keptTaskIds,
+      selectedItemIds: codexRaw.selectedItemIds,
+      keptItemIds: codexRaw.keptItemIds,
+      validation: codexRaw.validation,
+      result: codexRaw.result,
+    };
+    const decisions = [openclaw, claude, codex];
+
+    for (const decision of decisions) {
+      assert.equal(decision.validation.valid, true, `${fixture.id}/${decision.hostId} validation`);
+      assert.deepEqual(
+        sorted(decision.selectedTaskIds),
+        sorted(fixture.expected.evict_task_ids),
+        `${fixture.id}/${decision.hostId} selected tasks`,
+      );
+      assert.deepEqual(
+        sorted(decision.keptTaskIds),
+        sorted(fixture.expected.keep_task_ids),
+        `${fixture.id}/${decision.hostId} kept tasks`,
+      );
+      assert.deepEqual(
+        sorted(decision.selectedItemIds),
+        sorted(fixture.expected.evict_item_ids),
+        `${fixture.id}/${decision.hostId} selected items`,
+      );
+      assert.deepEqual(
+        sorted(decision.keptItemIds),
+        sorted(fixture.expected.keep_item_ids),
+        `${fixture.id}/${decision.hostId} kept items`,
+      );
+      assert.equal(
+        decision.result.applied,
+        fixture.expected.evict_task_ids.length > 0,
+        `${fixture.id}/${decision.hostId} apply outcome`,
+      );
+      assert.equal(decision.result.fallbackUsed, false);
+    }
+
+    assert.deepEqual(
+      decisions.map((decision) => sorted(decision.selectedTaskIds)),
+      decisions.map(() => sorted(fixture.expected.evict_task_ids)),
+      `${fixture.id} cross-host task targets`,
+    );
+    assert.deepEqual(
+      decisions.map((decision) => sorted(decision.selectedItemIds)),
+      decisions.map(() => sorted(fixture.expected.evict_item_ids)),
+      `${fixture.id} cross-host item targets`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- wire all six shared context-rewrite lifecycle events into the Codex runtime
- add a Codex `ModelContextRewriteBackend` backed by effective-history snapshots
- export a deterministic Codex golden-fixture API
- complete GUA-02 by running the OpenClaw, Claude, and Codex backends against the same logical target sets
- update provider smoke validation to support stateless continuation roots

## Codex lifecycle events

The Codex runtime now emits:

- `context_rewrite_planned`
- `context_rewrite_validated`
- `context_rewrite_applied`
- `context_rewrite_deferred`
- `context_rewrite_failed`
- `context_rewrite_bypassed`

`applied` is emitted only after the provider succeeds, the context-history journal is persisted, and the rebase epoch is committed. Event persistence remains best-effort and does not change the proxy response.

## Shared backend

The new Codex backend:

- maps `CodexEffectiveHistory` to shared stable item references and revisions
- reuses shared revision revalidation and protocol-closure validation
- reuses the existing Codex rebase request builder
- safely defers active tasks, incomplete history, partial tool pairs, non-replayable items, and unsafe revision drift
- returns the standard `ContextRewriteResult`
- does not duplicate provider, fallback, cooldown, journal, or epoch behavior

## GUA-02

The cross-host acceptance test now actually invokes the OpenClaw, Claude, and Codex backends for:

- completed tasks
- unresolved tasks
- tool-call closure
- active/current turns

It compares normalized selected/kept task and item IDs across all three implementations instead of validating only static expected JSON.

## Validation

- Codex backend tests: 5/5
- GUA-02/reference/shared-closure tests: 22/22
- Claude backend focused tests: 15/15
- Codex full suite: 271/271
- Codex and OpenClaw typecheck: passed
- Codex and OpenClaw build: passed
- package boundary validation: passed
- `git diff --check`: passed

OpenClaw full-suite status is 106/108 on Windows. The two remaining failures are existing platform-specific assertions involving path separators and CRLF parsing in `pack_release.sh`; the focused GUA-02 suite passes.