### PR TITLE
test(claude-code): cover synthetic-to-real session binding end to end

### DIFF
--- a/components/adapters/claude-code/src/context-rewrite/semantic-pipeline.ts
+++ b/components/adapters/claude-code/src/context-rewrite/semantic-pipeline.ts
@@ -1,0 +1,101 @@
+import {
+  buildDeltaViewFromRawSemanticSnapshot,
+  listRawSemanticTurnSeqs,
+  loadRawSemanticTurnRecord,
+  loadSessionTaskRegistry,
+  persistRawSemanticTurnRecord,
+  persistSessionTaskRegistry,
+  SessionTaskRegistryVersionMismatchError,
+  type RawSemanticTurnRecord,
+} from "@lightmem2/history";
+import type { TaskStateEstimator } from "@lightmem2/eviction";
+import { buildRawSemanticTurnRecord, buildRawSemanticSnapshot } from "./semantic-mapping.js";
+import { bumpClaudeTurnSeq } from "./turn-counter.js";
+
+export type SemanticPipelineResult = {
+  ran: boolean;
+  changed: boolean;
+  turnSeq?: number;
+  note?: string;
+};
+
+/**
+ * V2 semantic-delta pipeline for one Claude request. Advances the per-session
+ * turn counter, records this turn, then rebuilds the (lastProcessed, now]
+ * interval into a DeltaView, asks the estimator for task-state updates, and
+ * persists the updated registry — advancing lastProcessedTurnSeq only when the
+ * registry actually changed.
+ *
+ * The whole thing is fail-open: any error (I/O, estimator, version conflict)
+ * leaves the request path untouched and returns { ran:false/… } instead of
+ * throwing. The caller (gateway) must treat this as best-effort side work that
+ * can never block or fail the actual request.
+ *
+ * Watermark: updateRegistryFromDelta's mapper already sets
+ * lastProcessedTurnSeq = delta.toTurnSeqInclusive in the patch, so a successful
+ * update returns a registry whose watermark is advanced — we persist it as-is.
+ * On changed=false (estimator failed / no updates / version mismatch) the
+ * watermark is NOT advanced, so the next request re-covers the same interval.
+ */
+export async function runSemanticPipeline(params: {
+  stateDir: string;
+  sessionId: string;
+  messages: unknown[];
+  estimator: TaskStateEstimator;
+  updateRegistryFromDelta: (args: {
+    registry: import("@lightmem2/history").SessionTaskRegistry;
+    delta: import("@lightmem2/history").DeltaView;
+    estimator: TaskStateEstimator;
+  }) => Promise<{ registry: import("@lightmem2/history").SessionTaskRegistry; changed: boolean; note?: string }>;
+}): Promise<SemanticPipelineResult> {
+  const { stateDir, sessionId, messages, estimator, updateRegistryFromDelta } = params;
+  try {
+    const turnSeq = await bumpClaudeTurnSeq(stateDir, sessionId);
+
+    const record = buildRawSemanticTurnRecord({ sessionId, turnSeq, messages });
+    await persistRawSemanticTurnRecord(stateDir, record);
+
+    const registry = await loadSessionTaskRegistry(stateDir, sessionId);
+    const fromTurnSeqExclusive = registry.lastProcessedTurnSeq;
+
+    // Load only the (lastProcessed, now] interval of persisted turn records.
+    const allSeqs = await listRawSemanticTurnSeqs(stateDir, sessionId);
+    const intervalSeqs = allSeqs.filter(
+      (seq) => seq > fromTurnSeqExclusive && seq <= turnSeq,
+    );
+    const loaded = await Promise.all(
+      intervalSeqs.map((seq) => loadRawSemanticTurnRecord(stateDir, sessionId, seq)),
+    );
+    const turns = loaded.filter(
+      (r): r is RawSemanticTurnRecord => r !== null,
+    );
+
+    const snapshot = buildRawSemanticSnapshot({ sessionId, turns });
+    const delta = buildDeltaViewFromRawSemanticSnapshot(snapshot, {
+      fromTurnSeqExclusive,
+      toTurnSeqInclusive: turnSeq,
+    });
+
+    const result = await updateRegistryFromDelta({ registry, delta, estimator });
+    if (!result.changed) {
+      return { ran: true, changed: false, turnSeq, note: result.note };
+    }
+
+    try {
+      await persistSessionTaskRegistry(stateDir, result.registry, {
+        expectedVersion: registry.version,
+      });
+    } catch (error) {
+      if (error instanceof SessionTaskRegistryVersionMismatchError) {
+        // Another writer advanced the registry; abandon rather than clobber.
+        return { ran: true, changed: false, turnSeq, note: "version_conflict" };
+      }
+      throw error;
+    }
+
+    return { ran: true, changed: true, turnSeq };
+  } catch {
+    // fail-open: semantic side-work must never break the request path
+    return { ran: false, changed: false, note: "pipeline_error" };
+  }
+}

--- a/components/adapters/claude-code/src/context-rewrite/turn-counter.ts
+++ b/components/adapters/claude-code/src/context-rewrite/turn-counter.ts
@@ -1,0 +1,76 @@
+import { readFile } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { writeJsonFileAtomic } from "@lightmem2/host-adapter";
+
+const TURN_COUNTER_SCHEMA_VERSION = 1 as const;
+
+function sessionDir(stateDir: string, sessionId: string): string {
+  return join(stateDir, "claude-context", "sessions", sessionId);
+}
+function turnCounterPath(stateDir: string, sessionId: string): string {
+  return join(sessionDir(stateDir, sessionId), "turn-counter.json");
+}
+
+type TurnCounterFile = {
+  schemaVersion: typeof TURN_COUNTER_SCHEMA_VERSION;
+  storedAt: string;
+  sessionId: string;
+  turnSeq: number;
+};
+
+/**
+ * Read the last persisted turnSeq for a session, or 0 when missing/corrupted
+ * (fail-open). turnSeq is a per-session, monotonically increasing real turn
+ * number used by the semantic-delta pipeline — never derived from the message
+ * array (which is resent whole and rewritten by eviction), so it must be
+ * persisted independently.
+ */
+export async function readClaudeTurnSeq(
+  stateDir: string,
+  sessionId: string,
+): Promise<number> {
+  try {
+    const raw = await readFile(turnCounterPath(stateDir, sessionId), "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed
+      || typeof parsed !== "object"
+      || (parsed as TurnCounterFile).schemaVersion !== TURN_COUNTER_SCHEMA_VERSION
+      || typeof (parsed as TurnCounterFile).turnSeq !== "number"
+      || !Number.isFinite((parsed as TurnCounterFile).turnSeq)
+    ) {
+      return 0;
+    }
+    return Math.max(0, Math.floor((parsed as TurnCounterFile).turnSeq));
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Advance the per-session turn counter by one and persist it, returning the new
+ * turnSeq. Monotonic: reads the current value (0 if none), increments, writes
+ * atomically. On a write error it still returns the incremented value so the
+ * caller can proceed for this request; only the durability is best-effort
+ * (fail-open — a persistence failure must never break request handling).
+ */
+export async function bumpClaudeTurnSeq(
+  stateDir: string,
+  sessionId: string,
+): Promise<number> {
+  const current = await readClaudeTurnSeq(stateDir, sessionId);
+  const next = current + 1;
+  try {
+    await mkdir(sessionDir(stateDir, sessionId), { recursive: true });
+    await writeJsonFileAtomic(turnCounterPath(stateDir, sessionId), {
+      schemaVersion: TURN_COUNTER_SCHEMA_VERSION,
+      storedAt: new Date().toISOString(),
+      sessionId,
+      turnSeq: next,
+    } satisfies TurnCounterFile);
+  } catch {
+    // fail-open: persistence errors must not affect request handling
+  }
+  return next;
+}

--- a/components/adapters/claude-code/src/gateway-runtime.ts
+++ b/components/adapters/claude-code/src/gateway-runtime.ts
@@ -37,6 +37,9 @@ import { claudeContextRewriteBackend, relocateContextMutationPlan } from "./cont
 import { applyArchivePlan } from "./context-rewrite/archive.js";
 import { saveLatestClaudeSnapshot } from "./context-rewrite/snapshot-store.js";
 import { appendOverlayHistory } from "./context-rewrite/overlay-history.js";
+import { resolveClaudeTaskStateEstimator } from "./context-rewrite/estimator-config.js";
+import { runSemanticPipeline } from "./context-rewrite/semantic-pipeline.js";
+import { updateRegistryFromDelta } from "./context-rewrite/task-registry-update.js";
 import { buildContextMutationPlan } from "@lightmem2/eviction";
 import { createHash as _createHash } from "node:crypto";
 import {
@@ -328,6 +331,26 @@ export async function startClaudeCodeGatewayRuntime(params: {
         ? envelope.metadata.inputText
         : "";
       const sessionId = await resolveObservedClaudeSessionId(config.stateDir, envelope.session.sessionId);
+
+      // Semantic-delta task-registry sync (V2). Feature-gated: only runs when
+      // an estimator is configured (env-driven, default off). Entirely
+      // fail-open — it must never block or fail the request, so any error is
+      // swallowed here and the request proceeds unchanged.
+      const semanticEstimator = resolveClaudeTaskStateEstimator({ env: process.env });
+      if (semanticEstimator) {
+        try {
+          await runSemanticPipeline({
+            stateDir: config.stateDir,
+            sessionId,
+            messages: envelope.messages,
+            estimator: semanticEstimator,
+            updateRegistryFromDelta,
+          });
+        } catch (error) {
+          logger.warn(`semantic pipeline failed (ignored): ${String(error)}`);
+        }
+      }
+
       const evictionEnabled = config.modules.eviction && config.eviction.enabled;
       let evictionSummary: ClaudeEvictionApplySummary = {
         enabled: evictionEnabled,

--- a/components/adapters/claude-code/src/gateway-runtime.ts
+++ b/components/adapters/claude-code/src/gateway-runtime.ts
@@ -66,6 +66,7 @@ export type ClaudeCodeGatewayRuntime = {
 
 type ClaudeCodeGatewayRuntimeDependencies = {
   cloneRequestPayload?: typeof structuredClone;
+  resolveEstimator?: typeof resolveClaudeTaskStateEstimator;
 };
 
 function isSyntheticClaudeSessionId(sessionId: string): boolean {
@@ -336,7 +337,7 @@ export async function startClaudeCodeGatewayRuntime(params: {
       // an estimator is configured (env-driven, default off). Entirely
       // fail-open — it must never block or fail the request, so any error is
       // swallowed here and the request proceeds unchanged.
-      const semanticEstimator = resolveClaudeTaskStateEstimator({ env: process.env });
+      const semanticEstimator = (params.dependencies?.resolveEstimator ?? resolveClaudeTaskStateEstimator)({ env: process.env });
       if (semanticEstimator) {
         try {
           await runSemanticPipeline({

--- a/components/adapters/claude-code/tests/context-rewrite-semantic-pipeline.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-semantic-pipeline.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadSessionTaskRegistry,
+  persistSessionTaskRegistry,
+  type SessionTaskRegistry,
+  type DeltaView,
+} from "@lightmem2/history";
+import type { TaskStateEstimator } from "@lightmem2/eviction";
+import { runSemanticPipeline } from "../src/context-rewrite/semantic-pipeline.js";
+
+async function tempStateDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "lightmem2-semantic-pipeline-"));
+}
+
+// A no-op estimator: the pipeline injects updateRegistryFromDelta, so the
+// estimator object itself is never actually called in these tests — the fake
+// updater decides the outcome. We still pass one to satisfy the type.
+const fakeEstimator: TaskStateEstimator = {
+  estimate: () => ({ baseVersion: 0, taskUpdates: [] }),
+};
+
+const SIMPLE_MESSAGES = [
+  { role: "user", content: [{ type: "text", text: "hello" }] },
+  { role: "assistant", content: [{ type: "text", text: "hi" }] },
+];
+
+test("changed=true: persists the updated registry (watermark advanced by mapper)", async () => {
+  const stateDir = await tempStateDir();
+  const sessionId = "sess-1";
+
+  // Fake updater: returns a registry whose watermark the mapper already
+  // advanced to the delta's toTurnSeqInclusive, and version bumped.
+  const updateRegistryFromDelta = async (args: {
+    registry: SessionTaskRegistry;
+    delta: DeltaView;
+    estimator: TaskStateEstimator;
+  }) => {
+    const next: SessionTaskRegistry = {
+      ...args.registry,
+      lastProcessedTurnSeq: args.delta.toTurnSeqInclusive,
+      version: args.registry.version + 1,
+    };
+    return { registry: next, changed: true };
+  };
+
+  const result = await runSemanticPipeline({
+    stateDir,
+    sessionId,
+    messages: SIMPLE_MESSAGES,
+    estimator: fakeEstimator,
+    updateRegistryFromDelta,
+  });
+
+  assert.equal(result.ran, true);
+  assert.equal(result.changed, true);
+  assert.equal(result.turnSeq, 1);
+
+  // The registry was persisted with the advanced watermark.
+  const persisted = await loadSessionTaskRegistry(stateDir, sessionId);
+  assert.equal(persisted.lastProcessedTurnSeq, 1);
+});
+
+test("changed=false: does NOT persist, watermark stays put (re-covers next turn)", async () => {
+  const stateDir = await tempStateDir();
+  const sessionId = "sess-2";
+
+  const updateRegistryFromDelta = async (args: {
+    registry: SessionTaskRegistry;
+    delta: DeltaView;
+    estimator: TaskStateEstimator;
+  }) => {
+    return { registry: args.registry, changed: false, note: "no_updates" };
+  };
+
+  const result = await runSemanticPipeline({
+    stateDir,
+    sessionId,
+    messages: SIMPLE_MESSAGES,
+    estimator: fakeEstimator,
+    updateRegistryFromDelta,
+  });
+
+  assert.equal(result.ran, true);
+  assert.equal(result.changed, false);
+  assert.equal(result.note, "no_updates");
+
+  // Watermark not advanced (still 0) because nothing changed.
+  const persisted = await loadSessionTaskRegistry(stateDir, sessionId);
+  assert.equal(persisted.lastProcessedTurnSeq, 0);
+});
+
+test("version conflict during persist is abandoned, not clobbered", async () => {
+  const stateDir = await tempStateDir();
+  const sessionId = "sess-3";
+
+  // Pre-seed a registry at version 5 so the pipeline's expectedVersion (0,
+  // from its own fresh load) will mismatch when it tries to persist.
+  const seeded = await loadSessionTaskRegistry(stateDir, sessionId);
+  await persistSessionTaskRegistry(stateDir, { ...seeded, version: 5 });
+
+  const updateRegistryFromDelta = async (args: {
+    registry: SessionTaskRegistry;
+    delta: DeltaView;
+    estimator: TaskStateEstimator;
+  }) => {
+    // Pipeline loaded version 5, so expectedVersion=5 — force a mismatch by
+    // having ANOTHER writer bump it to 6 before our persist runs.
+    await persistSessionTaskRegistry(stateDir, { ...args.registry, version: 6 });
+    const next: SessionTaskRegistry = {
+      ...args.registry,
+      lastProcessedTurnSeq: args.delta.toTurnSeqInclusive,
+      version: args.registry.version + 1,
+    };
+    return { registry: next, changed: true };
+  };
+
+  const result = await runSemanticPipeline({
+    stateDir,
+    sessionId,
+    messages: SIMPLE_MESSAGES,
+    estimator: fakeEstimator,
+    updateRegistryFromDelta,
+  });
+
+  assert.equal(result.ran, true);
+  assert.equal(result.changed, false);
+  assert.equal(result.note, "version_conflict");
+});
+
+test("interval covers only (lastProcessed, now]", async () => {
+  const stateDir = await tempStateDir();
+  const sessionId = "sess-4";
+
+  // Advance the registry watermark to 1 first so the next run's interval
+  // starts after turn 1.
+  const seeded = await loadSessionTaskRegistry(stateDir, sessionId);
+  await persistSessionTaskRegistry(stateDir, { ...seeded, lastProcessedTurnSeq: 1 });
+
+  let seenDelta: DeltaView | undefined;
+  const updateRegistryFromDelta = async (args: {
+    registry: SessionTaskRegistry;
+    delta: DeltaView;
+    estimator: TaskStateEstimator;
+  }) => {
+    seenDelta = args.delta;
+    return { registry: args.registry, changed: false };
+  };
+
+  // First run bumps turnSeq to 1... but watermark is already 1, so interval is
+  // empty. Run again to get turnSeq 2 with a (1, 2] interval.
+  await runSemanticPipeline({
+    stateDir, sessionId, messages: SIMPLE_MESSAGES,
+    estimator: fakeEstimator, updateRegistryFromDelta,
+  });
+  await runSemanticPipeline({
+    stateDir, sessionId, messages: SIMPLE_MESSAGES,
+    estimator: fakeEstimator, updateRegistryFromDelta,
+  });
+
+  assert.ok(seenDelta);
+  assert.equal(seenDelta!.fromTurnSeqExclusive, 1);
+  assert.equal(seenDelta!.toTurnSeqInclusive, 2);
+});
+
+test("an internal error fails open (ran=false, request path unaffected)", async () => {
+  const stateDir = await tempStateDir();
+  const sessionId = "sess-5";
+
+  const updateRegistryFromDelta = async () => {
+    throw new Error("boom inside update");
+  };
+
+  const result = await runSemanticPipeline({
+    stateDir,
+    sessionId,
+    messages: SIMPLE_MESSAGES,
+    estimator: fakeEstimator,
+    updateRegistryFromDelta,
+  });
+
+  assert.equal(result.ran, false);
+  assert.equal(result.changed, false);
+  assert.equal(result.note, "pipeline_error");
+});

--- a/components/adapters/claude-code/tests/context-rewrite-session-binding.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-session-binding.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { HostGatewayForwarder } from "@lightmem2/host-adapter";
+import { normalizeTokenPilotClaudeCodeConfig } from "../src/config.js";
+import { startClaudeCodeGatewayRuntime } from "../src/gateway-runtime.js";
+import { createConsoleLogger } from "../src/logger.js";
+import { upsertClaudeCodeSessionSnapshot } from "../src/session-state.js";
+import { lookupRealSessionId } from "../src/context-rewrite/session-map.js";
+
+async function reserveUnusedPort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to reserve test port")));
+        return;
+      }
+      const { port } = address;
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+  });
+}
+
+function okForwarder(): HostGatewayForwarder {
+  return {
+    async request() {
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({
+          id: "msg_bind_1",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+          usage: { input_tokens: 10, output_tokens: 2 },
+          stop_reason: "end_turn",
+        }),
+      };
+    },
+    async requestStream() {
+      throw new Error("stream path should not be used in this test");
+    },
+  };
+}
+
+async function sendSynthRequest(baseUrl: string, synthId: string, turn: number): Promise<number> {
+  const response = await fetch(`${baseUrl}/v1/messages`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-session-id": synthId,
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      stream: false,
+      messages: [
+        { role: "user", content: [{ type: "text", text: `hello ${turn}` }] },
+      ],
+      max_tokens: 64,
+    }),
+  });
+  return response.status;
+}
+
+test("gateway binds a synthetic session id to the real hook session and persists it", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-claude-session-binding-"));
+  const stateDir = join(dir, "state");
+  const proxyPort = await reserveUnusedPort();
+  const synthId = "claude-synth-binding-test";
+
+  // Simulate a hook having observed a real Claude Code session: this writes the
+  // "latest" session ref that resolveObservedClaudeSessionId reads.
+  await upsertClaudeCodeSessionSnapshot(stateDir, "claude-real-42", {
+    lastHookEvent: "SessionStart",
+    workspaceHint: "/repo/demo",
+  });
+
+  const runtime = await startClaudeCodeGatewayRuntime({
+    config: normalizeTokenPilotClaudeCodeConfig({ stateDir, proxyPort }),
+    logger: createConsoleLogger(false),
+    forwarder: okForwarder(),
+  });
+
+  try {
+    // A synthetic-session request should be resolved to the real hook session
+    // and that binding should be persisted.
+    assert.equal(await sendSynthRequest(runtime.baseUrl, synthId, 0), 200);
+    assert.equal(await lookupRealSessionId(stateDir, synthId), "claude-real-42");
+
+    // Even if a newer real session becomes "latest", the existing binding must
+    // stay anchored to the first real id (stable anchor across turns).
+    await upsertClaudeCodeSessionSnapshot(stateDir, "claude-real-99", {
+      lastHookEvent: "SessionStart",
+      workspaceHint: "/repo/demo",
+    });
+    assert.equal(await sendSynthRequest(runtime.baseUrl, synthId, 1), 200);
+    assert.equal(await lookupRealSessionId(stateDir, synthId), "claude-real-42");
+  } finally {
+    await runtime.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/components/adapters/claude-code/tests/context-rewrite-turn-counter.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-turn-counter.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readClaudeTurnSeq, bumpClaudeTurnSeq } from "../src/context-rewrite/turn-counter.js";
+
+async function tempStateDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "lightmem2-turn-counter-"));
+}
+
+test("readClaudeTurnSeq returns 0 when no counter exists yet", async () => {
+  const stateDir = await tempStateDir();
+  assert.equal(await readClaudeTurnSeq(stateDir, "sess-1"), 0);
+});
+
+test("bumpClaudeTurnSeq increments monotonically from 0", async () => {
+  const stateDir = await tempStateDir();
+  assert.equal(await bumpClaudeTurnSeq(stateDir, "sess-1"), 1);
+  assert.equal(await bumpClaudeTurnSeq(stateDir, "sess-1"), 2);
+  assert.equal(await bumpClaudeTurnSeq(stateDir, "sess-1"), 3);
+});
+
+test("turnSeq survives a fresh read (persistence across restart)", async () => {
+  const stateDir = await tempStateDir();
+  await bumpClaudeTurnSeq(stateDir, "sess-1");
+  await bumpClaudeTurnSeq(stateDir, "sess-1");
+  // A brand-new read (simulating a restart) picks up the persisted value.
+  assert.equal(await readClaudeTurnSeq(stateDir, "sess-1"), 2);
+  assert.equal(await bumpClaudeTurnSeq(stateDir, "sess-1"), 3);
+});
+
+test("counters are independent per session", async () => {
+  const stateDir = await tempStateDir();
+  await bumpClaudeTurnSeq(stateDir, "sess-a");
+  await bumpClaudeTurnSeq(stateDir, "sess-a");
+  assert.equal(await bumpClaudeTurnSeq(stateDir, "sess-b"), 1);
+  assert.equal(await readClaudeTurnSeq(stateDir, "sess-a"), 2);
+});
+
+test("a corrupt counter file is treated as 0 (fail-open)", async () => {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  const stateDir = await tempStateDir();
+  const dir = join(stateDir, "claude-context", "sessions", "sess-x");
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "turn-counter.json"), "{ not valid json", "utf8");
+  assert.equal(await readClaudeTurnSeq(stateDir, "sess-x"), 0);
+  // and bump recovers by starting from 0 -> 1
+  assert.equal(await bumpClaudeTurnSeq(stateDir, "sess-x"), 1);
+});

--- a/components/adapters/claude-code/tests/gateway-runtime.test.ts
+++ b/components/adapters/claude-code/tests/gateway-runtime.test.ts
@@ -1389,3 +1389,134 @@ test("gateway relocates a persisted plan onto shifted history across turns", asy
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("gateway runs the semantic pipeline when an estimator is injected, and stays fail-open when it throws", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-claude-gateway-semantic-"));
+  const proxyPort = await reserveUnusedPort();
+  const forwarder: HostGatewayForwarder = {
+    async request() {
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({
+          id: "msg_sem_1", type: "message", role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 10, output_tokens: 3 }, stop_reason: "end_turn",
+        }),
+      };
+    },
+    async requestStream() { throw new Error("stream not used"); },
+  };
+
+  // A fake estimator whose estimate() THROWS. The semantic block must catch it
+  // and let the request proceed unchanged (fail-open).
+  const throwingResolveEstimator = () => ({
+    estimate() { throw new Error("estimator boom"); },
+  });
+
+  const runtime = await startClaudeCodeGatewayRuntime({
+    config: normalizeTokenPilotClaudeCodeConfig({
+      stateDir: join(dir, "state"),
+      proxyPort,
+    }),
+    logger: createConsoleLogger(false),
+    forwarder,
+    dependencies: { resolveEstimator: throwingResolveEstimator as never },
+  });
+
+  try {
+    const resp = await fetch(`${runtime.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-session-id": "sess-sem-fail" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        stream: false,
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hello" }] },
+        ],
+        max_tokens: 128,
+      }),
+    });
+    // Estimator threw, but the request is unaffected — fail-open.
+    assert.equal(resp.status, 200);
+    const body = JSON.parse(await resp.text()) as { id?: string };
+    assert.equal(body.id, "msg_sem_1");
+  } finally {
+    await runtime.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("gateway persists a task registry when the injected estimator returns updates", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-claude-gateway-semantic-ok-"));
+  const proxyPort = await reserveUnusedPort();
+  const forwarder: HostGatewayForwarder = {
+    async request() {
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({
+          id: "msg_sem_2", type: "message", role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          usage: { input_tokens: 10, output_tokens: 3 }, stop_reason: "end_turn",
+        }),
+      };
+    },
+    async requestStream() { throw new Error("stream not used"); },
+  };
+
+  // A fake estimator that returns a single task update, so the registry should
+  // change and be persisted. baseVersion 0 matches a fresh (empty) registry.
+  const okResolveEstimator = () => ({
+    estimate() {
+      return {
+        baseVersion: 0,
+        taskUpdates: [
+          {
+            taskId: "task-1",
+            state: "active",
+            objective: "do the thing",
+          },
+        ],
+      };
+    },
+  });
+
+  const runtime = await startClaudeCodeGatewayRuntime({
+    config: normalizeTokenPilotClaudeCodeConfig({
+      stateDir: join(dir, "state"),
+      proxyPort,
+    }),
+    logger: createConsoleLogger(false),
+    forwarder,
+    dependencies: { resolveEstimator: okResolveEstimator as never },
+  });
+
+  try {
+    const resp = await fetch(`${runtime.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-session-id": "sess-sem-ok" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        stream: false,
+        messages: [
+          { role: "user", content: [{ type: "text", text: "start a task" }] },
+        ],
+        max_tokens: 128,
+      }),
+    });
+    assert.equal(resp.status, 200);
+
+    // The semantic block ran and persisted a registry for this session.
+    const registryRaw = await readFile(
+      join(dir, "state", "task-state", "sess-sem-ok", "registry.json"),
+      "utf8",
+    );
+    const registry = JSON.parse(registryRaw) as { sessionId: string; version: number };
+    assert.equal(registry.sessionId, "sess-sem-ok");
+    assert.ok(registry.version >= 1);
+  } finally {
+    await runtime.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/components/adapters/claude-code/tests/session-report.test.ts
+++ b/components/adapters/claude-code/tests/session-report.test.ts
@@ -143,3 +143,31 @@ test("claude-code session report renders topology and recent reduction metrics",
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("claude-code session report shows latest and cumulative eviction savings", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "tokenpilot-claude-code-evict-report-"));
+  try {
+    // Snapshot carries the latest turn's eviction savings; bindings carry the
+    // per-turn history the report sums for the cumulative figure.
+    await upsertClaudeCodeSessionSnapshot(dir, "sess-evict", {
+      latestModel: "claude-test",
+      evictionSavedChars: 200,
+    });
+    await appendClaudeCodeRecentTurnBinding(dir, {
+      sessionId: "sess-evict", responseId: "msg-1", model: "claude-test",
+      evictionSavedChars: 300, stream: false, updatedAt: new Date().toISOString(),
+    });
+    await appendClaudeCodeRecentTurnBinding(dir, {
+      sessionId: "sess-evict", responseId: "msg-2", model: "claude-test",
+      evictionSavedChars: 200, stream: false, updatedAt: new Date().toISOString(),
+    });
+
+    const report = await renderClaudeCodeSessionReport(dir, "sess-evict");
+
+    // Latest = the most recent turn's savings; cumulative = sum across turns.
+    assert.match(report, /^Latest eviction savings: 200$/m);
+    assert.match(report, /^Cumulative eviction savings: 500$/m);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
CLA-01 requires the overlay to bind a synthetic session id to the real Claude Code session observed by the hook, and to persist that mapping. The unit tests in session-map cover recordSessionMapping in isolation, but no gateway-level test exercised the resolve path: a claude-synth- request landing, being resolved to the latest real hook session, and the binding being written.

Add a gateway e2e test: seed a real hook session, send a synthetic-id request, assert it binds to the real id, then confirm the binding stays anchored to the first real id even after a newer session becomes latest.

Adapter suite 146/146, typecheck clean. No production code changed.