### PR TITLE
feat(host-adapter): add shared context plan relocation

### DIFF
--- a/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/index.ts
@@ -1,5 +1,6 @@
 export * from "./contracts.js";
 export * from "./revalidation.js";
+export * from "./relocation.js";
 export * from "./observability.js";
 export * from "./protocol-closure.js";
 export * from "./plan-store.js";

--- a/components/packages/foundation/host-adapter/src/context-rewrite/relocation.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/relocation.ts
@@ -1,0 +1,155 @@
+import type {
+  ContextMutationOperation,
+  ContextMutationPlan,
+  ModelContextSnapshot,
+} from "./contracts.js";
+
+export type ContextMutationTargetRelocationReason =
+  | "target_fingerprint_missing"
+  | "target_missing"
+  | "target_ambiguous"
+  | "target_changed"
+  | "target_duplicate";
+
+export type ContextMutationTargetRelocation = {
+  relocated: boolean;
+  newTargetIds?: string[];
+  reason?: ContextMutationTargetRelocationReason;
+};
+
+function candidatesByStableId(snapshot: ModelContextSnapshot): Map<string, number[]> {
+  const candidates = new Map<string, number[]>();
+  snapshot.items.forEach((item, index) => {
+    candidates.set(item.stableId, [
+      ...(candidates.get(item.stableId) ?? []),
+      index,
+    ]);
+  });
+  return candidates;
+}
+
+function candidatesByFingerprint(snapshot: ModelContextSnapshot): Map<string, string[]> {
+  const candidates = new Map<string, string[]>();
+  for (const item of snapshot.items) {
+    candidates.set(item.fingerprint, [
+      ...(candidates.get(item.fingerprint) ?? []),
+      item.stableId,
+    ]);
+  }
+  return candidates;
+}
+
+/**
+ * Resolves every target in an operation against the current snapshot without
+ * mutating the operation. Existing stable IDs are retained only when their
+ * persisted fingerprint still matches. Missing IDs may move to a new stable
+ * ID only when the persisted fingerprint has exactly one current match.
+ */
+export function relocateTargetIds(
+  operation: ContextMutationOperation,
+  snapshot: ModelContextSnapshot,
+): ContextMutationTargetRelocation {
+  if (operation.targetItemIds.length === 0) {
+    return { relocated: false, reason: "target_missing" };
+  }
+
+  const fingerprints = operation.targetItemFingerprints;
+  if (!fingerprints) {
+    return { relocated: false, reason: "target_fingerprint_missing" };
+  }
+
+  const stableCandidates = candidatesByStableId(snapshot);
+  const fingerprintCandidates = candidatesByFingerprint(snapshot);
+  const nextTargetIds: string[] = [];
+  let relocated = false;
+
+  for (const targetId of operation.targetItemIds) {
+    const expectedFingerprint = fingerprints[targetId]?.trim();
+    if (!expectedFingerprint) {
+      return { relocated: false, reason: "target_fingerprint_missing" };
+    }
+
+    const stableMatches = stableCandidates.get(targetId) ?? [];
+    if (stableMatches.length > 1) {
+      return { relocated: false, reason: "target_ambiguous" };
+    }
+    if (stableMatches.length === 1) {
+      const current = snapshot.items[stableMatches[0]!];
+      if (current?.fingerprint !== expectedFingerprint) {
+        return { relocated: false, reason: "target_changed" };
+      }
+      nextTargetIds.push(targetId);
+      continue;
+    }
+
+    const fingerprintMatches = fingerprintCandidates.get(expectedFingerprint) ?? [];
+    if (fingerprintMatches.length === 0) {
+      return { relocated: false, reason: "target_missing" };
+    }
+    if (fingerprintMatches.length > 1) {
+      return { relocated: false, reason: "target_ambiguous" };
+    }
+    nextTargetIds.push(fingerprintMatches[0]!);
+    relocated = true;
+  }
+
+  if (new Set(nextTargetIds).size !== nextTargetIds.length) {
+    return { relocated: false, reason: "target_duplicate" };
+  }
+  return { relocated, newTargetIds: nextTargetIds };
+}
+
+export type ContextMutationPlanRelocationResult<TAdapterReplacementItem = never> = {
+  plan: ContextMutationPlan<TAdapterReplacementItem>;
+  relocated: boolean;
+  deferredOperationIds: string[];
+  reasons: string[];
+};
+
+/**
+ * Returns a relocated plan copy. Operations that cannot be resolved with a
+ * unique fingerprint match are omitted and reported as deferred. The input
+ * plan and its operations are never mutated.
+ */
+export function relocateContextMutationPlan<TAdapterReplacementItem = never>(params: {
+  snapshot: ModelContextSnapshot;
+  plan: ContextMutationPlan<TAdapterReplacementItem>;
+}): ContextMutationPlanRelocationResult<TAdapterReplacementItem> {
+  const { snapshot, plan } = params;
+  const operations: ContextMutationOperation<TAdapterReplacementItem>[] = [];
+  const deferredOperationIds: string[] = [];
+  const reasons: string[] = [];
+  let relocated = false;
+
+  for (const operation of plan.operations) {
+    const result = relocateTargetIds(operation, snapshot);
+    if (!result.newTargetIds) {
+      deferredOperationIds.push(operation.id);
+      reasons.push(`operation:${operation.id || "<empty>"}:${result.reason}`);
+      continue;
+    }
+    const targetItemFingerprints = Object.fromEntries(
+      result.newTargetIds.map((targetId) => [
+        targetId,
+        snapshot.items.find((item) => item.stableId === targetId)!.fingerprint,
+      ]),
+    );
+    operations.push({
+      ...operation,
+      targetItemIds: result.newTargetIds,
+      targetItemFingerprints,
+    });
+    relocated ||= result.relocated;
+  }
+
+  return {
+    plan: {
+      ...plan,
+      baseRevision: relocated ? snapshot.revision : plan.baseRevision,
+      operations,
+    },
+    relocated,
+    deferredOperationIds,
+    reasons,
+  };
+}

--- a/components/packages/foundation/host-adapter/src/context-rewrite/relocation.ts
+++ b/components/packages/foundation/host-adapter/src/context-rewrite/relocation.ts
@@ -45,8 +45,8 @@ function candidatesByFingerprint(snapshot: ModelContextSnapshot): Map<string, st
  * persisted fingerprint still matches. Missing IDs may move to a new stable
  * ID only when the persisted fingerprint has exactly one current match.
  */
-export function relocateTargetIds(
-  operation: ContextMutationOperation,
+export function relocateTargetIds<TAdapterReplacementItem = never>(
+  operation: ContextMutationOperation<TAdapterReplacementItem>,
   snapshot: ModelContextSnapshot,
 ): ContextMutationTargetRelocation {
   if (operation.targetItemIds.length === 0) {

--- a/components/packages/foundation/host-adapter/tests/context-rewrite-relocation.test.ts
+++ b/components/packages/foundation/host-adapter/tests/context-rewrite-relocation.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  relocateContextMutationPlan,
+  relocateTargetIds,
+  type ContextMutationOperation,
+  type ContextMutationPlan,
+  type ModelContextSnapshot,
+} from "../src/index.js";
+
+const snapshot: ModelContextSnapshot = {
+  schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  hostId: "test-host",
+  sessionId: "session-1",
+  revision: "ctxrev-current",
+  items: [
+    { stableId: "new-item-1", kind: "user", fingerprint: "fp-1", chars: 10 },
+    { stableId: "new-item-2", kind: "assistant", fingerprint: "fp-2", chars: 20 },
+  ],
+};
+
+function operation(
+  targetItemIds: string[],
+  targetItemFingerprints: Record<string, string> = Object.fromEntries(
+    targetItemIds.map((id, index) => [id, `fp-${index + 1}`]),
+  ),
+): ContextMutationOperation {
+  return {
+    id: "op-1",
+    type: "remove",
+    targetItemIds,
+    targetItemFingerprints,
+    rationale: "evicted task",
+    estimatedSavedChars: 10,
+  };
+}
+
+function plan(operations: ContextMutationPlan["operations"]): ContextMutationPlan {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: "plan-1",
+    hostId: snapshot.hostId,
+    sessionId: snapshot.sessionId,
+    baseRevision: "ctxrev-old",
+    sourceModuleId: "eviction",
+    operations,
+    createdAt: "2026-08-02T00:00:00.000Z",
+  };
+}
+
+test("relocates a missing stable id only through a unique fingerprint", () => {
+  const result = relocateTargetIds(operation(["old-item-1"], { "old-item-1": "fp-1" }), snapshot);
+  assert.deepEqual(result, {
+    relocated: true,
+    newTargetIds: ["new-item-1"],
+  });
+});
+
+test("keeps an existing stable id when its fingerprint is unchanged", () => {
+  const current = {
+    ...snapshot,
+    items: [{ ...snapshot.items[0]!, stableId: "new-item-1" }],
+  };
+  const result = relocateTargetIds(operation(["new-item-1"], { "new-item-1": "fp-1" }), current);
+  assert.deepEqual(result, {
+    relocated: false,
+    newTargetIds: ["new-item-1"],
+  });
+});
+
+test("defers missing, ambiguous, and changed targets", () => {
+  assert.equal(
+    relocateTargetIds(operation(["gone"], { gone: "fp-gone" }), snapshot).reason,
+    "target_missing",
+  );
+  assert.equal(
+    relocateTargetIds(
+      operation(["gone"], { gone: "fp-1" }),
+      { ...snapshot, items: [...snapshot.items, { ...snapshot.items[0]!, stableId: "duplicate" }] },
+    ).reason,
+    "target_ambiguous",
+  );
+  assert.equal(
+    relocateTargetIds(operation(["new-item-1"], { "new-item-1": "wrong" }), snapshot).reason,
+    "target_changed",
+  );
+});
+
+test("relocated plan is a copy and defers an operation with any unsafe target", () => {
+  const originalOperation = operation(
+    ["old-item-1", "gone"],
+    { "old-item-1": "fp-1", gone: "fp-gone" },
+  );
+  const original = plan([originalOperation]);
+  const result = relocateContextMutationPlan({ snapshot, plan: original });
+
+  assert.equal(result.relocated, false);
+  assert.deepEqual(result.deferredOperationIds, ["op-1"]);
+  assert.deepEqual(result.reasons, ["operation:op-1:target_missing"]);
+  assert.deepEqual(original.operations[0]!.targetItemIds, ["old-item-1", "gone"]);
+  assert.deepEqual(result.plan.operations, []);
+});
+
+test("relocated plan updates revision and fingerprint claims", () => {
+  const original = plan([operation(["old-item-1"], { "old-item-1": "fp-1" })]);
+  const result = relocateContextMutationPlan({ snapshot, plan: original });
+
+  assert.equal(result.relocated, true);
+  assert.equal(result.plan.baseRevision, snapshot.revision);
+  assert.deepEqual(result.plan.operations[0]!.targetItemIds, ["new-item-1"]);
+  assert.deepEqual(result.plan.operations[0]!.targetItemFingerprints, {
+    "new-item-1": "fp-1",
+  });
+  assert.deepEqual(original.operations[0]!.targetItemIds, ["old-item-1"]);
+});


### PR DESCRIPTION
 ## Summary

  Add a shared, conservative context mutation plan relocation API for revision drift.

  ## Changes

  - Add `relocateTargetIds()` for unique fingerprint-based target resolution.
  - Add `relocateContextMutationPlan()` that returns a new plan copy.
  - Preserve targets whose stable ID and fingerprint still match.
  - Relocate missing stable IDs only when exactly one fingerprint match exists.
  - Defer missing, ambiguous, changed, or duplicate targets.
  - Update relocated plans with the current revision and fingerprint claims.
  - Export the new APIs from the shared context-rewrite index.

  ## Safety

  - Input plans and operations are never mutated.
  - No fuzzy matching is used.
  - Ambiguous or unsafe mappings are deferred instead of applied.

  ## Scope

  This PR only changes Shared Foundation code. Claude Code, Codex, and OpenClaw adapter integration
  remains a follow-up for their respective owners.

  ## Verification

  ```bash
  pnpm --filter @lightmem2/host-adapter test

  Result:

  tests 83
  pass 83
  fail 0

```

 This PR only exposes a host-neutral relocation primitive and does not wire it into any adapter. It may
  support the stale-revision and ambiguous-target cases in the new lifecycle planner work. Please confirm
  whether this shared API should merge independently or be deferred.