### PR TITLE
feat(eviction): add shared lifecycle planner

### DIFF
--- a/components/packages/features/eviction/src/index.ts
+++ b/components/packages/features/eviction/src/index.ts
@@ -6,4 +6,5 @@ export * from "./task-state-estimator.js";
 export * from "./task-update-mapper.js";
 export * from "./history-apply.js";
 export * from "./lifecycle-policy-context.js";
+export * from "./lifecycle-planner.js";
 export * from "./context-mutation-plan.js";

--- a/components/packages/features/eviction/src/lifecycle-planner.ts
+++ b/components/packages/features/eviction/src/lifecycle-planner.ts
@@ -1,0 +1,329 @@
+import {
+  applySessionTaskRegistryPatch,
+  type DeltaView,
+  type HistoryBlock,
+  type SessionTaskRegistry,
+} from "@lightmem2/history";
+import type {
+  ContextMutationPlan,
+  ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+
+import { buildContextMutationPlanFromEviction } from "./context-mutation-plan.js";
+import { analyzeEvictionFromTaskRegistry } from "./planning/analyzer.js";
+import {
+  mapTaskUpdatesToRegistryPatch,
+  type RejectedTaskUpdate,
+} from "./task-update-mapper.js";
+import type {
+  EvictionDecision,
+  EvictionPolicy,
+  TaskStateEstimator,
+  TaskStateEstimatorOutput,
+  TaskStateTransition,
+} from "./types.js";
+
+export type LifecyclePlannerStatus = "applied" | "deferred" | "bypassed";
+
+export type LifecyclePlannerReasonCode =
+  | "planner_disabled"
+  | "estimator_missing"
+  | "insufficient_pending_turns"
+  | "duplicate_estimator_window"
+  | "empty_delta_window"
+  | "planner_input_invalid"
+  | "session_mismatch"
+  | "estimator_failed"
+  | "estimator_output_invalid"
+  | "base_version_mismatch"
+  | "task_update_turn_out_of_scope"
+  | "task_updates_rejected"
+  | "registry_updated"
+  | "registry_watermark_advanced"
+  | "no_eviction_candidates"
+  | "mutation_plan_deferred"
+  | "mutation_plan_created";
+
+export type LifecyclePlannerConfig = {
+  enabled: boolean;
+  batchTurns: number;
+  evictionEnabled: boolean;
+  evictionPolicy: EvictionPolicy;
+  evictionMinBlockChars?: number;
+};
+
+export type LifecyclePlannerInput<TAdapterMetadata = never> = {
+  registry: SessionTaskRegistry;
+  delta: DeltaView;
+  pendingTurnCount: number;
+  duplicateWindow?: boolean;
+  estimator?: TaskStateEstimator | null;
+  historyBlocks: HistoryBlock[];
+  snapshot: ModelContextSnapshot<TAdapterMetadata>;
+  stableItemIdsByMessageId?: Readonly<Record<string, readonly string[]>>;
+  activeTaskIds?: string[];
+  currentTaskIds?: string[];
+  currentTurnAbsId?: string;
+  closureDeferredTaskIds?: string[];
+  config: LifecyclePlannerConfig;
+  createdAt: string;
+  sourcePresetId?: string;
+};
+
+export type LifecyclePlannerResult = {
+  status: LifecyclePlannerStatus;
+  reasonCodes: LifecyclePlannerReasonCode[];
+  registry: SessionTaskRegistry;
+  expectedRegistryVersion: number;
+  registryChanged: boolean;
+  registryUpdateRequired: boolean;
+  attemptedEstimator: boolean;
+  transitions: TaskStateTransition[];
+  rejectedUpdates: RejectedTaskUpdate[];
+  decision?: EvictionDecision;
+  plan?: ContextMutationPlan;
+  deferredBlockIds: string[];
+  estimatorUsage?: TaskStateEstimatorOutput["usage"];
+};
+
+function uniqueStrings(values: Iterable<string | undefined>): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const normalized = value?.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function baseResult(
+  input: LifecyclePlannerInput<unknown>,
+  status: LifecyclePlannerStatus,
+  reasonCodes: LifecyclePlannerReasonCode[],
+  attemptedEstimator = false,
+): LifecyclePlannerResult {
+  return {
+    status,
+    reasonCodes,
+    registry: input.registry,
+    expectedRegistryVersion: input.registry.version,
+    registryChanged: false,
+    registryUpdateRequired: false,
+    attemptedEstimator,
+    transitions: [],
+    rejectedUpdates: [],
+    deferredBlockIds: [],
+  };
+}
+
+function validEstimatorOutput(value: unknown): value is TaskStateEstimatorOutput {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const output = value as Partial<TaskStateEstimatorOutput>;
+  if (!Number.isInteger(output.baseVersion) || !Array.isArray(output.taskUpdates)) return false;
+  const optionalStringArray = (value: unknown): boolean =>
+    value === undefined
+    || (Array.isArray(value) && value.every((entry) => typeof entry === "string"));
+  return output.taskUpdates.every((update) => {
+    if (!update || typeof update !== "object" || Array.isArray(update)) return false;
+    return typeof update.taskId === "string"
+      && typeof update.objective === "string"
+      && ["active", "blocked", "completed", "evictable"].includes(update.lifecycle)
+      && optionalStringArray(update.coveredTurnAbsIds)
+      && optionalStringArray(update.completionEvidence)
+      && optionalStringArray(update.unresolvedQuestions);
+  });
+}
+
+function blockTaskIds(block: HistoryBlock, registry: SessionTaskRegistry): string[] {
+  const direct = uniqueStrings(block.taskIds ?? []);
+  if (direct.length > 0) return direct;
+  const byTurns = uniqueStrings(
+    (block.turnAbsIds ?? []).flatMap((turnId) => registry.turnToTaskIds[turnId] ?? []),
+  );
+  if (byTurns.length > 0) return byTurns;
+  return uniqueStrings([
+    ...(registry.blockToTaskIds[block.blockId] ?? []),
+    ...block.segmentIds.flatMap((segmentId) => registry.blockToTaskIds[segmentId] ?? []),
+  ]);
+}
+
+function protectedTaskIds(input: LifecyclePlannerInput<unknown>, registry: SessionTaskRegistry): Set<string> {
+  return new Set(uniqueStrings([
+    ...input.registry.activeTaskIds,
+    ...registry.activeTaskIds,
+    ...Object.values(registry.tasks)
+      .filter((task) => task.lifecycle === "blocked" || task.unresolvedQuestions.length > 0)
+      .map((task) => task.taskId),
+    ...(input.activeTaskIds ?? []),
+    ...(input.currentTaskIds ?? []),
+    ...(input.closureDeferredTaskIds ?? []),
+  ]));
+}
+
+function safeHistoryBlocks(
+  input: LifecyclePlannerInput<unknown>,
+  registry: SessionTaskRegistry,
+): HistoryBlock[] {
+  const protectedIds = protectedTaskIds(input, registry);
+  const currentTurnAbsId = input.currentTurnAbsId?.trim();
+  return input.historyBlocks.filter(
+    (block) => !(currentTurnAbsId && block.turnAbsIds?.includes(currentTurnAbsId))
+      && !blockTaskIds(block, registry).some((taskId) => protectedIds.has(taskId)),
+  );
+}
+
+function taskStateChanged(
+  before: SessionTaskRegistry,
+  after: SessionTaskRegistry,
+): boolean {
+  return JSON.stringify({
+    tasks: before.tasks,
+    activeTaskIds: before.activeTaskIds,
+    completedTaskIds: before.completedTaskIds,
+    evictableTaskIds: before.evictableTaskIds,
+    turnToTaskIds: before.turnToTaskIds,
+  }) !== JSON.stringify({
+    tasks: after.tasks,
+    activeTaskIds: after.activeTaskIds,
+    completedTaskIds: after.completedTaskIds,
+    evictableTaskIds: after.evictableTaskIds,
+    turnToTaskIds: after.turnToTaskIds,
+  });
+}
+
+/**
+ * Runs the Host-neutral estimator-to-plan lifecycle. The caller owns history
+ * loading, duplicate-window persistence, registry CAS, tracing, and mutation
+ * execution. This function performs no I/O and fails closed to no plan.
+ */
+export async function planLifecycleEviction<TAdapterMetadata = never>(
+  input: LifecyclePlannerInput<TAdapterMetadata>,
+): Promise<LifecyclePlannerResult> {
+  if (!input.config.enabled) {
+    return baseResult(input, "bypassed", ["planner_disabled"]);
+  }
+  if (!input.estimator) {
+    return baseResult(input, "bypassed", ["estimator_missing"]);
+  }
+  if (
+    !Number.isFinite(input.config.batchTurns)
+    || input.config.batchTurns < 1
+    || !Number.isInteger(input.pendingTurnCount)
+    || input.pendingTurnCount < 0
+    || !input.createdAt.trim()
+  ) {
+    return baseResult(input, "bypassed", ["planner_input_invalid"]);
+  }
+  const batchTurns = Math.floor(input.config.batchTurns);
+  if (input.pendingTurnCount < batchTurns) {
+    return baseResult(input, "deferred", ["insufficient_pending_turns"]);
+  }
+  if (input.duplicateWindow) {
+    return baseResult(input, "deferred", ["duplicate_estimator_window"]);
+  }
+  if (input.delta.coveredTurnAbsIds.length === 0) {
+    return baseResult(input, "deferred", ["empty_delta_window"]);
+  }
+  if (
+    input.registry.sessionId !== input.snapshot.sessionId
+    || input.delta.coveredTurnAbsIds.some(
+      (turnId) => !turnId.startsWith(`${input.registry.sessionId}:`),
+    )
+  ) {
+    return baseResult(input, "bypassed", ["session_mismatch"]);
+  }
+
+  let output: unknown;
+  try {
+    output = await input.estimator.estimate({
+      registry: input.registry,
+      delta: input.delta,
+    });
+  } catch {
+    return baseResult(input, "bypassed", ["estimator_failed"], true);
+  }
+  if (!validEstimatorOutput(output)) {
+    return baseResult(input, "bypassed", ["estimator_output_invalid"], true);
+  }
+  if (output.baseVersion !== input.registry.version) {
+    const result = baseResult(input, "deferred", ["base_version_mismatch"], true);
+    return { ...result, estimatorUsage: output.usage };
+  }
+
+  const coveredTurnAbsIds = new Set(input.delta.coveredTurnAbsIds);
+  if (output.taskUpdates.some((update) =>
+    (update.coveredTurnAbsIds ?? []).some(
+      (turnAbsId) => !coveredTurnAbsIds.has(turnAbsId),
+    ))) {
+    const result = baseResult(
+      input,
+      "deferred",
+      ["task_update_turn_out_of_scope"],
+      true,
+    );
+    return { ...result, estimatorUsage: output.usage };
+  }
+
+  const mapped = mapTaskUpdatesToRegistryPatch({
+    registry: input.registry,
+    updates: output.taskUpdates,
+    coveredTurnAbsIds: input.delta.coveredTurnAbsIds,
+    toTurnSeqInclusive: input.delta.toTurnSeqInclusive,
+  });
+  if (mapped.rejectedUpdates.length > 0) {
+    const result = baseResult(input, "deferred", ["task_updates_rejected"], true);
+    return {
+      ...result,
+      rejectedUpdates: mapped.rejectedUpdates,
+      estimatorUsage: output.usage,
+    };
+  }
+
+  const registry = applySessionTaskRegistryPatch(input.registry, mapped.patch);
+  const registryChanged = taskStateChanged(input.registry, registry);
+  const reasonCodes: LifecyclePlannerReasonCode[] = [
+    registryChanged ? "registry_updated" : "registry_watermark_advanced",
+  ];
+  const decision = analyzeEvictionFromTaskRegistry(
+    safeHistoryBlocks(input, registry),
+    registry,
+    {
+      enabled: input.config.evictionEnabled,
+      policy: input.config.evictionPolicy,
+      minBlockChars: input.config.evictionMinBlockChars,
+    },
+  );
+  const built = buildContextMutationPlanFromEviction({
+    decision,
+    registry,
+    snapshot: input.snapshot,
+    stableItemIdsByMessageId: input.stableItemIdsByMessageId,
+    createdAt: input.createdAt,
+    sourcePresetId: input.sourcePresetId,
+  });
+  if (built.plan) {
+    reasonCodes.push("mutation_plan_created");
+  } else if (built.deferredBlockIds.length > 0) {
+    reasonCodes.push("mutation_plan_deferred");
+  } else {
+    reasonCodes.push("no_eviction_candidates");
+  }
+
+  return {
+    status: "applied",
+    reasonCodes,
+    registry,
+    expectedRegistryVersion: input.registry.version,
+    registryChanged,
+    registryUpdateRequired: true,
+    attemptedEstimator: true,
+    transitions: mapped.transitions,
+    rejectedUpdates: [],
+    decision,
+    plan: built.plan,
+    deferredBlockIds: built.deferredBlockIds,
+    estimatorUsage: output.usage,
+  };
+}

--- a/components/packages/features/eviction/tests/lifecycle-planner.test.ts
+++ b/components/packages/features/eviction/tests/lifecycle-planner.test.ts
@@ -1,0 +1,449 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createEmptySessionTaskRegistry,
+  type DeltaView,
+  type HistoryBlock,
+  type SessionTaskRegistry,
+} from "@lightmem2/history";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+
+import {
+  planLifecycleEviction,
+  type LifecyclePlannerInput,
+  type TaskStateEstimator,
+} from "../src/index.js";
+
+const SESSION = "session-1";
+
+function registry(): SessionTaskRegistry {
+  return createEmptySessionTaskRegistry(SESSION);
+}
+
+function delta(toTurnSeqInclusive = 1): DeltaView {
+  return {
+    fromTurnSeqExclusive: 0,
+    toTurnSeqInclusive,
+    coveredTurnAbsIds: [`${SESSION}:t${toTurnSeqInclusive}`],
+    messages: [],
+    toolCalls: [],
+    toolResults: [],
+    filesRead: [],
+    filesWritten: [],
+  };
+}
+
+function block(taskIds: string[]): HistoryBlock {
+  return {
+    blockId: "block-1",
+    blockType: "other",
+    lifecycleState: "EVICTABLE",
+    segmentIds: ["message-1"],
+    taskIds,
+    text: "evictable task block",
+    charCount: 1200,
+    approxTokens: 300,
+  };
+}
+
+function snapshot(): ModelContextSnapshot {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    hostId: "test-host",
+    sessionId: SESSION,
+    revision: "ctxrev-1",
+    items: [{
+      stableId: "item-1",
+      kind: "user",
+      taskIds: ["task-1"],
+      fingerprint: "fp-1",
+      chars: 1200,
+    }],
+  };
+}
+
+function estimator(output: unknown): TaskStateEstimator {
+  return {
+    estimate: async () => output as Awaited<ReturnType<TaskStateEstimator["estimate"]>>,
+  };
+}
+
+function input(overrides: Partial<LifecyclePlannerInput> = {}): LifecyclePlannerInput {
+  return {
+    registry: registry(),
+    delta: delta(),
+    pendingTurnCount: 1,
+    estimator: estimator({ baseVersion: 0, taskUpdates: [] }),
+    historyBlocks: [],
+    snapshot: snapshot(),
+    stableItemIdsByMessageId: { "message-1": ["item-1"] },
+    config: {
+      enabled: true,
+      batchTurns: 1,
+      evictionEnabled: true,
+      evictionPolicy: "model_scored",
+      evictionMinBlockChars: 256,
+    },
+    createdAt: "2026-08-13T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("disabled and missing estimator bypass without registry updates", async () => {
+  const disabled = await planLifecycleEviction(input({
+    config: {
+      enabled: false,
+      batchTurns: 1,
+      evictionEnabled: true,
+      evictionPolicy: "model_scored",
+    },
+  }));
+  const missing = await planLifecycleEviction(input({ estimator: null }));
+
+  assert.deepEqual(disabled.reasonCodes, ["planner_disabled"]);
+  assert.deepEqual(missing.reasonCodes, ["estimator_missing"]);
+  assert.equal(disabled.registryUpdateRequired, false);
+  assert.equal(missing.attemptedEstimator, false);
+});
+
+test("batch and duplicate gates do not call the estimator", async () => {
+  let calls = 0;
+  const countingEstimator: TaskStateEstimator = {
+    estimate: async () => {
+      calls += 1;
+      return { baseVersion: 0, taskUpdates: [] };
+    },
+  };
+  const batched = await planLifecycleEviction(input({
+    estimator: countingEstimator,
+    pendingTurnCount: 1,
+    config: {
+      enabled: true,
+      batchTurns: 2,
+      evictionEnabled: true,
+      evictionPolicy: "model_scored",
+    },
+  }));
+  const duplicate = await planLifecycleEviction(input({
+    estimator: countingEstimator,
+    duplicateWindow: true,
+  }));
+
+  assert.deepEqual(batched.reasonCodes, ["insufficient_pending_turns"]);
+  assert.deepEqual(duplicate.reasonCodes, ["duplicate_estimator_window"]);
+  assert.equal(calls, 0);
+});
+
+test("invalid planner inputs bypass before calling the estimator", async () => {
+  let calls = 0;
+  const countingEstimator: TaskStateEstimator = {
+    estimate: async () => {
+      calls += 1;
+      return { baseVersion: 0, taskUpdates: [] };
+    },
+  };
+  const invalidBatch = await planLifecycleEviction(input({
+    estimator: countingEstimator,
+    config: {
+      enabled: true,
+      batchTurns: Number.NaN,
+      evictionEnabled: true,
+      evictionPolicy: "model_scored",
+    },
+  }));
+  const missingTimestamp = await planLifecycleEviction(input({
+    estimator: countingEstimator,
+    createdAt: " ",
+  }));
+
+  assert.deepEqual(invalidBatch.reasonCodes, ["planner_input_invalid"]);
+  assert.deepEqual(missingTimestamp.reasonCodes, ["planner_input_invalid"]);
+  assert.equal(calls, 0);
+});
+
+test("estimator failures, invalid output, and stale versions fail open", async () => {
+  const failed = await planLifecycleEviction(input({
+    estimator: { estimate: async () => { throw new Error("secret provider error"); } },
+  }));
+  const invalid = await planLifecycleEviction(input({
+    estimator: estimator({ baseVersion: 0, taskUpdates: "invalid" }),
+  }));
+  const invalidNested = await planLifecycleEviction(input({
+    estimator: estimator({
+      baseVersion: 0,
+      taskUpdates: [{
+        taskId: "task-1",
+        objective: "invalid nested output",
+        lifecycle: "active",
+        coveredTurnAbsIds: [1],
+      }],
+    }),
+  }));
+  const staleRegistry = registry();
+  staleRegistry.version = 4;
+  const stale = await planLifecycleEviction(input({
+    registry: staleRegistry,
+    estimator: estimator({ baseVersion: 3, taskUpdates: [] }),
+  }));
+
+  assert.deepEqual(failed.reasonCodes, ["estimator_failed"]);
+  assert.deepEqual(invalid.reasonCodes, ["estimator_output_invalid"]);
+  assert.deepEqual(invalidNested.reasonCodes, ["estimator_output_invalid"]);
+  assert.deepEqual(stale.reasonCodes, ["base_version_mismatch"]);
+  assert.equal(failed.plan, undefined);
+  assert.equal(invalid.registryUpdateRequired, false);
+  assert.equal(stale.registry.version, 4);
+});
+
+test("estimator cannot claim turn ownership outside the delta", async () => {
+  const result = await planLifecycleEviction(input({
+    estimator: estimator({
+      baseVersion: 0,
+      taskUpdates: [{
+        taskId: "task-1",
+        objective: "out of scope task",
+        lifecycle: "active",
+        coveredTurnAbsIds: [`${SESSION}:t99`],
+      }],
+    }),
+  }));
+
+  assert.equal(result.status, "deferred");
+  assert.deepEqual(result.reasonCodes, ["task_update_turn_out_of_scope"]);
+  assert.equal(result.registryUpdateRequired, false);
+  assert.equal(result.registry.lastProcessedTurnSeq, 0);
+});
+
+test("successful no-op advances the watermark without reporting task changes", async () => {
+  const result = await planLifecycleEviction(input({
+    delta: delta(3),
+    pendingTurnCount: 3,
+    estimator: estimator({ baseVersion: 0, taskUpdates: [] }),
+  }));
+
+  assert.equal(result.status, "applied");
+  assert.equal(result.registry.lastProcessedTurnSeq, 3);
+  assert.equal(result.registry.version, 1);
+  assert.equal(result.registryUpdateRequired, true);
+  assert.equal(result.registryChanged, false);
+  assert.deepEqual(result.reasonCodes, [
+    "registry_watermark_advanced",
+    "no_eviction_candidates",
+  ]);
+});
+
+test("completed task update produces a deterministic mutation plan", async () => {
+  const completed = registry();
+  completed.version = 2;
+  completed.tasks["task-1"] = {
+    taskId: "task-1",
+    title: "Task 1",
+    objective: "finish work",
+    lifecycle: "completed",
+    completionEvidence: ["delivered result"],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${SESSION}:t1`,
+      lastTurnAbsId: `${SESSION}:t1`,
+      supportingTurnAbsIds: [`${SESSION}:t1`],
+      lastEstimatorTurnAbsId: `${SESSION}:t1`,
+    },
+  };
+  completed.completedTaskIds = ["task-1"];
+  completed.blockToTaskIds = { "block-1": ["task-1"] };
+
+  const params = input({
+    registry: completed,
+    historyBlocks: [block(["task-1"])],
+    estimator: estimator({
+      baseVersion: 2,
+      taskUpdates: [{
+        taskId: "task-1",
+        objective: "finish work",
+        lifecycle: "evictable",
+        completionEvidence: ["delivered result"],
+        evictableReason: "session moved on",
+      }],
+    }),
+  });
+  const first = await planLifecycleEviction(params);
+  const second = await planLifecycleEviction(params);
+
+  assert.equal(first.registry.evictableTaskIds.includes("task-1"), true);
+  assert.equal(first.plan?.operations.length, 1);
+  assert.deepEqual(first.plan?.operations[0]?.targetItemIds, ["item-1"]);
+  assert.equal(first.plan?.planId, second.plan?.planId);
+  assert.deepEqual(first.reasonCodes, ["registry_updated", "mutation_plan_created"]);
+});
+
+test("a task active before estimation cannot be evicted in the same run", async () => {
+  const activeRegistry = registry();
+  activeRegistry.tasks["task-1"] = {
+    taskId: "task-1",
+    title: "Active task",
+    objective: "finish work",
+    lifecycle: "active",
+    completionEvidence: [],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${SESSION}:t1`,
+      lastTurnAbsId: `${SESSION}:t1`,
+      supportingTurnAbsIds: [`${SESSION}:t1`],
+      lastEstimatorTurnAbsId: `${SESSION}:t1`,
+    },
+  };
+  activeRegistry.activeTaskIds = ["task-1"];
+
+  const result = await planLifecycleEviction(input({
+    registry: activeRegistry,
+    historyBlocks: [block(["task-1"])],
+    estimator: estimator({
+      baseVersion: 0,
+      taskUpdates: [{
+        taskId: "task-1",
+        objective: "finish work",
+        lifecycle: "evictable",
+        completionEvidence: ["delivered result"],
+        evictableReason: "session moved on",
+      }],
+    }),
+  }));
+
+  assert.equal(result.registry.evictableTaskIds.includes("task-1"), true);
+  assert.equal(result.plan, undefined);
+  assert.equal(result.decision?.instructions.length, 0);
+});
+
+test("active, current, and unresolved task ownership protects mixed blocks", async () => {
+  const protectedRegistry = registry();
+  protectedRegistry.tasks["task-1"] = {
+    taskId: "task-1",
+    title: "Old task",
+    objective: "old work",
+    lifecycle: "evictable",
+    completionEvidence: ["done"],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${SESSION}:t1`,
+      lastTurnAbsId: `${SESSION}:t1`,
+      supportingTurnAbsIds: [`${SESSION}:t1`],
+      lastEstimatorTurnAbsId: `${SESSION}:t1`,
+    },
+  };
+  protectedRegistry.tasks["task-current"] = {
+    taskId: "task-current",
+    title: "Current task",
+    objective: "current work",
+    lifecycle: "active",
+    completionEvidence: [],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${SESSION}:t2`,
+      lastTurnAbsId: `${SESSION}:t2`,
+      supportingTurnAbsIds: [`${SESSION}:t2`],
+      lastEstimatorTurnAbsId: `${SESSION}:t2`,
+    },
+  };
+  protectedRegistry.evictableTaskIds = ["task-1"];
+  protectedRegistry.activeTaskIds = ["task-current"];
+
+  const result = await planLifecycleEviction(input({
+    registry: protectedRegistry,
+    historyBlocks: [block(["task-1", "task-current"])],
+    currentTaskIds: ["task-current"],
+    estimator: estimator({ baseVersion: 0, taskUpdates: [] }),
+  }));
+
+  assert.equal(result.plan, undefined);
+  assert.equal(result.decision?.instructions.length, 0);
+  assert.deepEqual(result.reasonCodes, [
+    "registry_watermark_advanced",
+    "no_eviction_candidates",
+  ]);
+});
+
+test("current turn protects a block before task ownership is available", async () => {
+  const currentBlock = {
+    ...block(["task-1"]),
+    turnAbsIds: [`${SESSION}:t1`],
+  };
+  const currentRegistry = registry();
+  currentRegistry.tasks["task-1"] = {
+    taskId: "task-1",
+    title: "Task 1",
+    objective: "finished task",
+    lifecycle: "evictable",
+    completionEvidence: ["done"],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${SESSION}:t1`,
+      lastTurnAbsId: `${SESSION}:t1`,
+      supportingTurnAbsIds: [`${SESSION}:t1`],
+      lastEstimatorTurnAbsId: `${SESSION}:t1`,
+    },
+  };
+  currentRegistry.evictableTaskIds = ["task-1"];
+
+  const result = await planLifecycleEviction(input({
+    registry: currentRegistry,
+    historyBlocks: [currentBlock],
+    currentTurnAbsId: `${SESSION}:t1`,
+    estimator: estimator({ baseVersion: 0, taskUpdates: [] }),
+  }));
+
+  assert.equal(result.plan, undefined);
+  assert.equal(result.decision?.instructions.length, 0);
+});
+
+test("tool closure deferral protects an otherwise evictable task", async () => {
+  const closureRegistry = registry();
+  closureRegistry.tasks["task-1"] = {
+    taskId: "task-1",
+    title: "Tool task",
+    objective: "complete tool work",
+    lifecycle: "evictable",
+    completionEvidence: ["tool returned"],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${SESSION}:t1`,
+      lastTurnAbsId: `${SESSION}:t1`,
+      supportingTurnAbsIds: [`${SESSION}:t1`],
+      lastEstimatorTurnAbsId: `${SESSION}:t1`,
+    },
+  };
+  closureRegistry.evictableTaskIds = ["task-1"];
+
+  const result = await planLifecycleEviction(input({
+    registry: closureRegistry,
+    historyBlocks: [block(["task-1"])],
+    closureDeferredTaskIds: ["task-1"],
+    estimator: estimator({ baseVersion: 0, taskUpdates: [] }),
+  }));
+
+  assert.equal(result.plan, undefined);
+  assert.equal(result.decision?.instructions.length, 0);
+});
+
+test("rejected task updates do not advance the registry watermark", async () => {
+  const result = await planLifecycleEviction(input({
+    estimator: estimator({
+      baseVersion: 0,
+      taskUpdates: [{
+        taskId: "task-1",
+        objective: "unfinished",
+        lifecycle: "evictable",
+        coveredTurnAbsIds: [`${SESSION}:t1`],
+        unresolvedQuestions: ["still open"],
+      }],
+    }),
+  }));
+
+  assert.equal(result.status, "deferred");
+  assert.deepEqual(result.reasonCodes, ["task_updates_rejected"]);
+  assert.equal(result.registry.lastProcessedTurnSeq, 0);
+  assert.equal(result.rejectedUpdates.length, 1);
+});


### PR DESCRIPTION
## Summary

  Add a Host-neutral shared lifecycle planner for estimator-driven eviction.

  The planner connects canonical semantic turns, task registry updates, eviction decisions, and canonical
  `ContextMutationPlan` generation without depending on any Host payload or filesystem.

  ## Changes

  - Add `planLifecycleEviction()` shared API.
  - Add lifecycle planner input/output contracts.
  - Add estimator trigger gates:
    - disabled planner;
    - missing estimator;
    - insufficient pending turns;
    - duplicate estimator window;
    - invalid planner input.
  - Add fail-open handling for:
    - estimator failures;
    - invalid estimator output;
    - registry base-version mismatch;
    - out-of-scope turn ownership;
    - rejected task updates.
  - Support no-op watermark advancement without reporting task-state changes.
  - Reuse shared task update mapping, registry patching, eviction analysis, and mutation plan construction.
  - Protect active, current, unresolved, current-turn, and tool-closure-deferred tasks.
  - Prevent a task that was active before estimation from being evicted in the same run.
  - Export the planner from the eviction package.
  - Add pure contract tests covering normal and failure paths.

  ## Scope

  This PR only changes:

  - `components/packages/features/eviction/src/`
  - `components/packages/features/eviction/tests/`

  It does not modify:

  - Claude Code adapter;
  - Codex adapter;
  - OpenClaw adapter;
  - TokenPilot preset;
  - CLI;
  - archive/recovery;
  - provider protocols;
  - gateway/proxy runtime.

  Claude and Codex runtime integration, plus OpenClaw regression comparison, are follow-up adapter/fixture tasks.

  ## Verification

  ```bash
  pnpm --filter @lightmem2/eviction typecheck
  pnpm --filter @lightmem2/eviction test
  pnpm --filter @lightmem2/eviction build
  pnpm -r typecheck

  Results:

  eviction tests: 37 passed, 0 failed
  workspace typecheck: passed
  eviction build: passed

  ## Known Test Environment Issue

  pnpm -r test still has three unrelated CLI visual test failures because the test environment cannot resolve:

  components/products/cli/dist/cli.js

  No CLI files were modified in this PR.