### PR TITLE
feat(codex): add estimator history bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.13.0
           cache: pnpm
 
       - name: Install dependencies

--- a/components/adapters/codex/README.md
+++ b/components/adapters/codex/README.md
@@ -137,6 +137,45 @@ Once installed, Codex can use the real internal recovery tool named
 `memory_fault_recover` through the registered MCP server. Recovery hints in
 trimmed payloads are no longer just protocol text.
 
+### Task-state estimator bridge (PR-B)
+
+The task-state estimator bridge is default-disabled. A conservative
+`~/.codex/tokenpilot.json` example is:
+
+```json
+{
+  "taskStateEstimator": {
+    "enabled": false,
+    "baseUrl": "https://estimator.example/v1",
+    "model": "estimator-model",
+    "requestTimeoutMs": 60000,
+    "batchTurns": 5,
+    "evictionLookaheadTurns": 3,
+    "inputMode": "sliding_window",
+    "lifecycleMode": "coupled",
+    "evidenceMode": "three_state"
+  }
+}
+```
+
+Keep API keys out of checked-in configuration. The resolver accepts
+`LIGHTMEM2_TASK_STATE_ESTIMATOR_API_KEY` from the environment, with
+`TOKENPILOT_TASK_STATE_ESTIMATOR_API_KEY` as a compatibility fallback. The
+same prefixes support `ENABLED`, `BASE_URL`, `MODEL`, `TIMEOUT_MS`,
+`BATCH_TURNS`, `EVICTION_LOOKAHEAD_TURNS`, `INPUT_MODE`, `LIFECYCLE_MODE`, and
+`EVIDENCE_MODE`; explicit JSON fields take precedence over environment values.
+
+If the bridge is enabled without `baseUrl`, `apiKey`, or `model`, diagnostics
+report `incomplete` and fail closed. Status and doctor output expose only safe
+configuration state and numeric parameters, never the API key or an
+Authorization header.
+
+PR-B only provides configuration resolution, effective-history semantic input,
+and the canonical context snapshot. It does not invoke the estimator or shared
+planner in the production proxy, and it cannot trigger an automatic rebase.
+`contextRewrite.mutationPlan` remains a test/smoke override and does not gain
+runtime priority from this bridge.
+
 ### Offline context-rebase smoke
 
 The response-chain rebase path has a credential-free smoke command for local

--- a/components/adapters/codex/package.json
+++ b/components/adapters/codex/package.json
@@ -21,13 +21,15 @@
   },
   "dependencies": {
     "@lightmem2/artifact-store": "workspace:*",
-    "@lightmem2/tokenpilot": "workspace:*",
+    "@lightmem2/eviction": "workspace:*",
+    "@lightmem2/history": "workspace:*",
     "@lightmem2/host-adapter": "workspace:*",
     "@lightmem2/kernel": "workspace:*",
     "@lightmem2/mcp": "workspace:*",
     "@lightmem2/product-surface": "workspace:*",
     "@lightmem2/reduction": "workspace:*",
-    "@lightmem2/stabilizer": "workspace:*"
+    "@lightmem2/stabilizer": "workspace:*",
+    "@lightmem2/tokenpilot": "workspace:*"
   },
   "scripts": {
     "build": "tsx build.ts",

--- a/components/adapters/codex/package.json
+++ b/components/adapters/codex/package.json
@@ -17,7 +17,7 @@
     "directory": "components/adapters/codex"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.13.0"
   },
   "dependencies": {
     "@lightmem2/artifact-store": "workspace:*",

--- a/components/adapters/codex/scripts/doctor-codex.ts
+++ b/components/adapters/codex/scripts/doctor-codex.ts
@@ -8,7 +8,11 @@ import {
   resolveUpstreamProvider,
 } from "../src/config.js";
 import { readDaemonStatus } from "../src/daemon.js";
-import { inspectCodexDoctor } from "../src/doctor.js";
+import {
+  codexMcpServerDiagnostic,
+  codexProviderDiagnostic,
+  inspectCodexDoctor,
+} from "../src/doctor.js";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 
@@ -25,16 +29,16 @@ async function main() {
   });
   const tokenpilotProvider = await readCodexProviderFromToml(config.providerName, codexConfigPath);
   const recoveryMcp = await readCodexMcpServerFromToml("tokenpilot_memory_fault_recover", codexConfigPath);
-  const upstream = await resolveUpstreamProvider(config, codexConfigPath).catch((err) => ({ error: err instanceof Error ? err.message : String(err) }));
+  const upstream = await resolveUpstreamProvider(config, codexConfigPath).catch(() => undefined);
   const daemon = await readDaemonStatus(config);
   const hooksText = existsSync(hooksConfigPath) ? await readFile(hooksConfigPath, "utf8").catch(() => "") : "";
   const hookHandlerCount = (hooksText.match(/hooks-handler\.js/g) ?? []).length;
   console.log(JSON.stringify({
-    ok: Boolean(tokenpilotProvider) && !("error" in upstream),
+    ok: Boolean(tokenpilotProvider) && Boolean(upstream),
     codexConfigPath,
     hooksConfigPath,
     tokenPilotConfigPath,
-    tokenpilotProvider: tokenpilotProvider ?? null,
+    tokenpilotProvider: codexProviderDiagnostic(tokenpilotProvider),
     hooks: {
       installed: doctor.hooksInstalled,
       handlerCount: hookHandlerCount,
@@ -42,8 +46,8 @@ async function main() {
         ? "multiple TokenPilot hooks are registered; rerun install to dedupe hooks.json"
         : undefined,
     },
-    recoveryMcp,
-    upstream,
+    recoveryMcp: codexMcpServerDiagnostic(recoveryMcp),
+    upstream: codexProviderDiagnostic(upstream),
     proxy: {
       baseUrl: doctor.proxyBaseUrl,
       healthOk: doctor.proxyHealthy,
@@ -51,6 +55,7 @@ async function main() {
     },
     daemon,
     modules: config.modules,
+    taskStateEstimator: doctor.taskStateEstimator,
   }, null, 2));
 }
 

--- a/components/adapters/codex/src/cli.ts
+++ b/components/adapters/codex/src/cli.ts
@@ -10,6 +10,10 @@ import {
 } from "./daemon.js";
 import { createConsoleLogger } from "./logger.js";
 import { startCodexResponsesProxy } from "./proxy-runtime.js";
+import {
+  codexEstimatorStatusView,
+  resolveCodexTaskStateEstimator,
+} from "./context-rewrite/estimator-config.js";
 
 function usage(): string {
   return [
@@ -70,6 +74,10 @@ async function main() {
 
   if (command === "status") {
     const daemon = await readDaemonStatus(config);
+    const taskStateEstimator = codexEstimatorStatusView(resolveCodexTaskStateEstimator({
+      config: config.taskStateEstimator,
+      env: process.env,
+    }));
     console.log(JSON.stringify({
       enabled: config.enabled,
       stateDir: config.stateDir,
@@ -79,6 +87,7 @@ async function main() {
       modules: config.modules,
       reduction: config.reduction,
       proxyMode: config.proxyMode,
+      taskStateEstimator,
     }, null, 2));
     return;
   }

--- a/components/adapters/codex/src/config.ts
+++ b/components/adapters/codex/src/config.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import type { TaskStateEstimatorApiConfig } from "@lightmem2/eviction";
 import type { CodexContextRewriteConfig, CodexMutationPlan } from "./context-rewrite/types.js";
 
 export type CodexProviderConfig = {
@@ -32,7 +33,9 @@ export type TokenPilotCodexConfig = {
     stabilizer: boolean;
     reduction: boolean;
   };
+  taskStateEstimator: TaskStateEstimatorApiConfig;
   contextRewrite: CodexContextRewriteConfig & {
+    // Test/smoke override only. Production rewrite planning must derive this at runtime.
     mutationPlan?: CodexMutationPlan;
   };
   reduction: {
@@ -112,6 +115,15 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function optionalNumberValue(
+  value: unknown,
+  fallback: number,
+  min: number,
+  max: number,
+): number | undefined {
+  return value === undefined ? undefined : numberValue(value, fallback, min, max);
+}
+
 function sanitizeCodexReductionPassOptions(raw: unknown): Record<string, Record<string, unknown>> {
   const input = asRecord(raw);
   const output: Record<string, Record<string, unknown>> = {};
@@ -156,6 +168,7 @@ export function normalizeTokenPilotCodexConfig(
   const proxyMode = asRecord(obj.proxyMode);
   const hooks = asRecord(obj.hooks);
   const modules = asRecord(obj.modules);
+  const taskStateEstimator = asRecord(obj.taskStateEstimator);
   const contextRewrite = asRecord(obj.contextRewrite);
   const reduction = asRecord(obj.reduction);
   const passes = asRecord(reduction.passes);
@@ -190,6 +203,28 @@ export function normalizeTokenPilotCodexConfig(
     modules: {
       stabilizer: boolValue(modules.stabilizer, true),
       reduction: boolValue(modules.reduction, true),
+    },
+    taskStateEstimator: {
+      enabled: taskStateEstimator.enabled === undefined
+        ? undefined
+        : boolValue(taskStateEstimator.enabled, false),
+      baseUrl: stringValue(taskStateEstimator.baseUrl)?.replace(/\/+$/, ""),
+      apiKey: stringValue(taskStateEstimator.apiKey),
+      model: stringValue(taskStateEstimator.model),
+      requestTimeoutMs: optionalNumberValue(taskStateEstimator.requestTimeoutMs, 60_000, 1_000, 300_000),
+      batchTurns: optionalNumberValue(taskStateEstimator.batchTurns, 5, 1, 100),
+      evictionLookaheadTurns: optionalNumberValue(taskStateEstimator.evictionLookaheadTurns, 3, 1, 100),
+      inputMode: taskStateEstimator.inputMode === undefined
+        ? undefined
+        : taskStateEstimator.inputMode === "completed_summary_plus_active_turns"
+          ? "completed_summary_plus_active_turns"
+          : "sliding_window",
+      lifecycleMode: taskStateEstimator.lifecycleMode === undefined
+        ? undefined
+        : taskStateEstimator.lifecycleMode === "decoupled" ? "decoupled" : "coupled",
+      evidenceMode: taskStateEstimator.evidenceMode === undefined
+        ? undefined
+        : taskStateEstimator.evidenceMode === "two_state" ? "two_state" : "three_state",
     },
     contextRewrite: {
       enabled: boolValue(contextRewrite.enabled, false),

--- a/components/adapters/codex/src/context-history/effective-history.ts
+++ b/components/adapters/codex/src/context-history/effective-history.ts
@@ -1,3 +1,4 @@
+import { buildTurnAbsId } from "@lightmem2/history";
 import { readCodexContextHistoryJournalRecoveringTail } from "./journal-append.js";
 import { codexReplayabilityForItem, codexReplayPairRef } from "./replayability.js";
 import { cloneJson, hashJson } from "./shared.js";
@@ -5,6 +6,9 @@ import type {
   CodexContextHistoryJournalEntry,
   CodexEffectiveHistory,
   CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryReasonCode,
+  CodexEffectiveHistoryTurn,
+  CodexEffectiveHistoryView,
   CodexRequestJournalEntry,
   CodexResponseJournalEntry,
   JsonObject,
@@ -23,6 +27,11 @@ type IndexedResponse = {
 type CommittedTurn = {
   request: IndexedRequest;
   response: IndexedResponse;
+};
+
+type EffectiveItemRecord = {
+  stableItemId: string;
+  item: JsonObject;
 };
 
 function findLastResponse(
@@ -84,6 +93,10 @@ function previousResponseId(turn: CommittedTurn): string | undefined {
   return turn.request.entry.previousResponseId;
 }
 
+function semanticPreviousResponseId(turn: CommittedTurn): string | undefined {
+  return previousResponseId(turn) ?? turn.request.entry.previousResponseId;
+}
+
 function committedInputItems(turn: CommittedTurn): JsonObject[] {
   return turn.request.entry.committedInputItems ?? turn.request.entry.inputItems;
 }
@@ -92,6 +105,7 @@ function buildCommittedChain(params: {
   headResponseId?: string;
   requests: Map<string, IndexedRequest>;
   responses: Map<string, IndexedResponse[]>;
+  parentResponseId?: (turn: CommittedTurn) => string | undefined;
 }): { chain: CommittedTurn[]; complete: boolean } {
   const committed = committedResponses(params.responses, params.requests);
   const head = params.headResponseId
@@ -120,7 +134,7 @@ function buildCommittedChain(params: {
     const turn = { request, response: cursor };
     chain.unshift(turn);
 
-    const previousId = previousResponseId(turn);
+    const previousId = (params.parentResponseId ?? previousResponseId)(turn);
     if (!previousId) break;
     cursor = findLastResponse(committed, (candidate) => (
       candidate.entry.responseId === previousId
@@ -165,9 +179,10 @@ function appendEffectiveItem(params: {
   replayableItems: CodexEffectiveHistoryItem[];
   observationOnlyItems: CodexEffectiveHistoryItem[];
   deferredItems: CodexEffectiveHistoryItem[];
-}): void {
+  effectiveItemRecords?: EffectiveItemRecord[];
+}): string | undefined {
   const nativeId = itemIdentity(params);
-  if (params.seen.has(nativeId)) return;
+  if (params.seen.has(nativeId)) return undefined;
   params.seen.add(nativeId);
   const effectiveItem: CodexEffectiveHistoryItem = {
     stableItemId: `codex-${hashJson(nativeId)}`,
@@ -179,6 +194,164 @@ function appendEffectiveItem(params: {
   if (replayability.mode === "replayable") params.replayableItems.push(effectiveItem);
   else if (replayability.mode === "observation_only") params.observationOnlyItems.push(effectiveItem);
   else params.deferredItems.push(effectiveItem);
+  params.effectiveItemRecords?.push({
+    stableItemId: effectiveItem.stableItemId,
+    item: effectiveItem.item,
+  });
+  return effectiveItem.stableItemId;
+}
+
+function turnAttributionKey(item: JsonObject): string {
+  const normalized = cloneJson(item);
+  delete normalized.id;
+  if (!["program_output", "tool_search_call", "tool_search_output"].includes(
+    String(normalized.type ?? "").toLowerCase(),
+  )) delete normalized.status;
+  delete normalized.created_at;
+  return hashJson(normalized);
+}
+
+function buildAttributedTurns(params: {
+  chain: CommittedTurn[];
+  effectiveItemRecords: EffectiveItemRecord[];
+  sessionId: string;
+}): { turns: CodexEffectiveHistoryTurn[]; complete: boolean; ambiguousDuplicate: boolean } {
+  const candidates = params.effectiveItemRecords.map((entry) => ({
+    ...entry,
+    key: turnAttributionKey(entry.item),
+    matched: false,
+  }));
+  const sourceBuckets = new Map<string, Set<string>>();
+  const sourceCounts = new Map<string, number>();
+  const finalCounts = new Map<string, number>();
+  for (const candidate of candidates) {
+    finalCounts.set(candidate.key, (finalCounts.get(candidate.key) ?? 0) + 1);
+  }
+
+  const turns = params.chain.map((turn) => {
+    const sidecar: CodexEffectiveHistoryTurn = {
+      turnSeq: turn.request.entry.turnOrdinal,
+      turnAbsId: buildTurnAbsId(params.sessionId, turn.request.entry.turnOrdinal),
+      inputItemIds: [],
+      outputItemIds: [],
+    };
+    const attribute = (item: JsonObject, phase: "input" | "output") => {
+      const key = turnAttributionKey(item);
+      const bucket = `${turn.request.entry.turnOrdinal}:${phase}`;
+      const buckets = sourceBuckets.get(key) ?? new Set<string>();
+      buckets.add(bucket);
+      sourceBuckets.set(key, buckets);
+      sourceCounts.set(key, (sourceCounts.get(key) ?? 0) + 1);
+      const candidate = candidates.find((entry) => !entry.matched && entry.key === key);
+      if (!candidate) return;
+      candidate.matched = true;
+      appendUnique(
+        phase === "input" ? sidecar.inputItemIds : sidecar.outputItemIds,
+        candidate.stableItemId,
+      );
+    };
+    turn.request.entry.inputItems.forEach((item) => attribute(item, "input"));
+    turn.response.entry.outputItems.forEach((item) => attribute(item, "output"));
+    return sidecar;
+  });
+  const ambiguousDuplicate = Array.from(sourceCounts).some(([key, sourceCount]) => (
+    (finalCounts.get(key) ?? 0) > 0
+    && sourceCount > (finalCounts.get(key) ?? 0)
+    && (sourceBuckets.get(key)?.size ?? 0) > 1
+  ));
+  return {
+    turns,
+    complete: !ambiguousDuplicate && candidates.every((entry) => entry.matched),
+    ambiguousDuplicate,
+  };
+}
+
+function appendUnique(values: string[], value: string | undefined): void {
+  if (value && !values.includes(value)) values.push(value);
+}
+
+function mergeTurns(
+  turns: CodexEffectiveHistoryTurn[],
+  validItemIds?: Set<string>,
+): CodexEffectiveHistoryTurn[] {
+  const byTurnSeq = new Map<number, CodexEffectiveHistoryTurn>();
+  for (const turn of turns) {
+    const inputItemIds = turn.inputItemIds.filter((itemId) => !validItemIds || validItemIds.has(itemId));
+    const outputItemIds = turn.outputItemIds.filter((itemId) => !validItemIds || validItemIds.has(itemId));
+    const existing = byTurnSeq.get(turn.turnSeq);
+    if (!existing) {
+      byTurnSeq.set(turn.turnSeq, {
+        turnSeq: turn.turnSeq,
+        turnAbsId: turn.turnAbsId,
+        inputItemIds: Array.from(new Set(inputItemIds)),
+        outputItemIds: Array.from(new Set(outputItemIds)),
+      });
+      continue;
+    }
+    inputItemIds.forEach((itemId) => appendUnique(existing.inputItemIds, itemId));
+    outputItemIds.forEach((itemId) => appendUnique(existing.outputItemIds, itemId));
+  }
+  const attributedItemIds = new Set<string>();
+  return Array.from(byTurnSeq.values())
+    .sort((left, right) => left.turnSeq - right.turnSeq)
+    .map((turn) => ({
+      ...turn,
+      inputItemIds: turn.inputItemIds.filter((itemId) => {
+        if (attributedItemIds.has(itemId)) return false;
+        attributedItemIds.add(itemId);
+        return true;
+      }),
+      outputItemIds: turn.outputItemIds.filter((itemId) => {
+        if (attributedItemIds.has(itemId)) return false;
+        attributedItemIds.add(itemId);
+        return true;
+      }),
+    }));
+}
+
+function alignProxyTurnsAfterRollout(params: {
+  sessionId: string;
+  rolloutTurns: CodexEffectiveHistoryTurn[];
+  proxyTurns: CodexEffectiveHistoryTurn[];
+}): CodexEffectiveHistoryTurn[] {
+  if (params.rolloutTurns.length === 0 || params.proxyTurns.length === 0) {
+    return params.proxyTurns;
+  }
+  // A fresh proxy journal starts its local ordinal at 1 even when the Codex
+  // rollout already contains session-global turns. Empty rollout sidecars do
+  // not prove a boundary, so only advance after the last turn owning an item.
+  const evidencedRolloutTurns = params.rolloutTurns.filter((turn) =>
+    turn.inputItemIds.length > 0 || turn.outputItemIds.length > 0
+  );
+  if (evidencedRolloutTurns.length === 0) return params.proxyTurns;
+  const lastRolloutTurnSeq = Math.max(...evidencedRolloutTurns.map((turn) => turn.turnSeq));
+  const firstProxyTurnSeq = Math.min(...params.proxyTurns.map((turn) => turn.turnSeq));
+  const offset = firstProxyTurnSeq <= lastRolloutTurnSeq
+    ? lastRolloutTurnSeq - firstProxyTurnSeq + 1
+    : 0;
+  if (offset === 0) return params.proxyTurns;
+  return params.proxyTurns.map((turn) => {
+    const turnSeq = turn.turnSeq + offset;
+    return {
+      ...turn,
+      turnSeq,
+      turnAbsId: buildTurnAbsId(params.sessionId, turnSeq),
+    };
+  });
+}
+
+function historyItemIds(history: CodexEffectiveHistory): Set<string> {
+  return new Set([
+    ...history.replayableItems,
+    ...history.observationOnlyItems,
+    ...history.deferredItems,
+  ].map((entry) => entry.stableItemId));
+}
+
+function uniqueReasonCodes(
+  values: CodexEffectiveHistoryReasonCode[],
+): CodexEffectiveHistoryReasonCode[] {
+  return Array.from(new Set(values));
 }
 
 function unresolvedCallIds(items: CodexEffectiveHistoryItem[]): string[] {
@@ -226,6 +399,18 @@ function hasUncommittedResponseWork(params: {
 
 function hasMalformedStreamEvents(chain: CommittedTurn[]): boolean {
   return chain.some((turn) => (turn.response.entry.malformedEventCount ?? 0) > 0);
+}
+
+function hasTurnSequenceConflict(chain: CommittedTurn[]): boolean {
+  let previous = 0;
+  const seen = new Set<number>();
+  for (const turn of chain) {
+    const turnSeq = turn.request.entry.turnOrdinal;
+    if (seen.has(turnSeq) || turnSeq <= previous) return true;
+    seen.add(turnSeq);
+    previous = turnSeq;
+  }
+  return false;
 }
 
 function effectiveItemKeys(entry: CodexEffectiveHistoryItem): string[] {
@@ -283,29 +468,32 @@ function historyRevision(params: {
 }
 
 function mergeRolloutBootstrapWithProxyJournal(params: {
-  bootstrapped: CodexEffectiveHistory;
+  sessionId: string;
+  bootstrapped: CodexEffectiveHistoryView;
+  proxyTurns: CodexEffectiveHistoryTurn[];
   proxyReplayableItems: CodexEffectiveHistoryItem[];
   proxyObservationOnlyItems: CodexEffectiveHistoryItem[];
   proxyDeferredItems: CodexEffectiveHistoryItem[];
   proxyIncomplete: boolean;
-}): CodexEffectiveHistory {
+  proxyReasonCodes: CodexEffectiveHistoryReasonCode[];
+}): CodexEffectiveHistoryView {
   const seen = new Set<string>();
   const replayableItems: CodexEffectiveHistoryItem[] = [];
   const observationOnlyItems: CodexEffectiveHistoryItem[] = [];
   const deferredItems: CodexEffectiveHistoryItem[] = [];
   appendMergedEffectiveItems({
     target: replayableItems,
-    entries: params.bootstrapped.replayableItems,
+    entries: params.bootstrapped.history.replayableItems,
     seen,
   });
   appendMergedEffectiveItems({
     target: observationOnlyItems,
-    entries: params.bootstrapped.observationOnlyItems,
+    entries: params.bootstrapped.history.observationOnlyItems,
     seen,
   });
   appendMergedEffectiveItems({
     target: deferredItems,
-    entries: params.bootstrapped.deferredItems,
+    entries: params.bootstrapped.history.deferredItems,
     seen,
   });
   appendMergedEffectiveItems({
@@ -324,16 +512,16 @@ function mergeRolloutBootstrapWithProxyJournal(params: {
     seen,
   });
   const unresolved = Array.from(new Set([
-    ...params.bootstrapped.unresolvedCallIds,
+    ...params.bootstrapped.history.unresolvedCallIds,
     ...unresolvedCallIds(replayableItems),
   ])).sort();
   const incomplete = Boolean(
-    params.bootstrapped.incomplete
+    params.bootstrapped.history.incomplete
     || params.proxyIncomplete
     || deferredItems.length > 0
     || unresolved.length > 0
   );
-  return {
+  const history: CodexEffectiveHistory = {
     revision: historyRevision({
       replayableItems,
       observationOnlyItems,
@@ -348,15 +536,44 @@ function mergeRolloutBootstrapWithProxyJournal(params: {
     source: "rollout_proxy_merge",
     incomplete,
   };
+  const alignedProxyTurns = alignProxyTurnsAfterRollout({
+    sessionId: params.sessionId,
+    rolloutTurns: params.bootstrapped.turns,
+    proxyTurns: params.proxyTurns,
+  });
+  const turns = mergeTurns(
+    [...params.bootstrapped.turns, ...alignedProxyTurns],
+    historyItemIds(history),
+  );
+  const reasonCodes = uniqueReasonCodes([
+    ...params.bootstrapped.reasonCodes,
+    ...params.proxyReasonCodes,
+    ...(incomplete ? ["history_replay_incomplete" as const] : []),
+    ...(deferredItems.length > 0 ? ["history_deferred_items" as const] : []),
+    ...(unresolved.length > 0 ? ["history_unresolved_tool_calls" as const] : []),
+  ]);
+  return {
+    history,
+    turns,
+    semanticComplete: params.bootstrapped.semanticComplete
+      && !params.proxyIncomplete
+      && reasonCodes.length === 0,
+    reasonCodes,
+  };
 }
 
-export async function buildCodexEffectiveHistory(params: {
+export type BuildCodexEffectiveHistoryParams = {
   stateDir: string;
   sessionId: string;
   headResponseId?: string;
   currentRequestId?: string;
   rolloutParserBootstrap?: () => Promise<CodexEffectiveHistory | null>;
-}): Promise<CodexEffectiveHistory> {
+  rolloutViewBootstrap?: () => Promise<CodexEffectiveHistoryView | null>;
+};
+
+export async function buildCodexEffectiveHistoryView(
+  params: BuildCodexEffectiveHistoryParams,
+): Promise<CodexEffectiveHistoryView> {
   const journalRead = await readCodexContextHistoryJournalRecoveringTail(params.stateDir, params.sessionId);
   const requests = latestRequests(journalRead.entries);
   const responses = responsesById(journalRead.entries);
@@ -365,7 +582,14 @@ export async function buildCodexEffectiveHistory(params: {
     requests,
     responses,
   });
+  const semanticChain = buildCommittedChain({
+    headResponseId: params.headResponseId,
+    requests,
+    responses,
+    parentResponseId: semanticPreviousResponseId,
+  });
   const malformedStreams = hasMalformedStreamEvents(committedChain.chain);
+  const turnSequenceConflict = hasTurnSequenceConflict(committedChain.chain);
   const emptyChainWithJournal = Boolean(
     committedChain.chain.length === 0
     && journalRead.entries.some((entry) => (
@@ -394,9 +618,21 @@ export async function buildCodexEffectiveHistory(params: {
     || uncommittedActiveWork
     || uncommittedResponseWork,
   );
+  const journalReasonCodes: CodexEffectiveHistoryReasonCode[] = [
+    ...(journalRead.readError ? ["journal_read_error" as const] : []),
+    ...(journalRead.malformedLineCount > 0 ? ["journal_malformed_lines" as const] : []),
+    ...(malformedStreams ? ["journal_malformed_stream" as const] : []),
+    ...(!committedChain.complete ? ["journal_committed_chain_incomplete" as const] : []),
+    ...(emptyChainWithJournal ? ["journal_history_without_committed_chain" as const] : []),
+    ...(uncommittedActiveWork ? ["journal_uncommitted_request" as const] : []),
+    ...(uncommittedResponseWork ? ["journal_uncommitted_response" as const] : []),
+    ...(params.currentRequestId ? ["journal_current_request_uncommitted" as const] : []),
+    ...(turnSequenceConflict ? ["journal_turn_sequence_conflict" as const] : []),
+  ];
   const replayableItems: CodexEffectiveHistoryItem[] = [];
   const observationOnlyItems: CodexEffectiveHistoryItem[] = [];
   const deferredItems: CodexEffectiveHistoryItem[] = [];
+  const effectiveItemRecords: EffectiveItemRecord[] = [];
   const seen = new Set<string>();
   for (const turn of committedChain.chain) {
     committedInputItems(turn).forEach((item, itemOrdinal) => {
@@ -410,6 +646,7 @@ export async function buildCodexEffectiveHistory(params: {
         replayableItems,
         observationOnlyItems,
         deferredItems,
+        effectiveItemRecords,
       });
     });
     turn.response.entry.outputItems.forEach((item, itemOrdinal) => {
@@ -423,18 +660,70 @@ export async function buildCodexEffectiveHistory(params: {
         replayableItems,
         observationOnlyItems,
         deferredItems,
+        effectiveItemRecords,
       });
     });
   }
+  const attribution = buildAttributedTurns({
+    chain: semanticChain.chain,
+    effectiveItemRecords,
+    sessionId: params.sessionId,
+  });
+  const attributionIncomplete = !semanticChain.complete || !attribution.complete;
+  if (attributionIncomplete) journalReasonCodes.push("journal_turn_attribution_incomplete");
+  const turns = attribution.turns;
 
   const unresolved = unresolvedCallIds(replayableItems);
   const effectiveIncomplete = journalIncomplete || deferredItems.length > 0 || unresolved.length > 0;
-  if ((journalRead.entries.length === 0 || effectiveIncomplete) && params.rolloutParserBootstrap) {
-    const bootstrapped = await params.rolloutParserBootstrap();
+  const bootstrapRequested = journalRead.entries.length === 0
+    || effectiveIncomplete
+    || (attributionIncomplete && Boolean(params.rolloutViewBootstrap));
+  if (bootstrapRequested && (params.rolloutViewBootstrap || params.rolloutParserBootstrap)) {
+    const bootstrapped = params.rolloutViewBootstrap
+      ? await params.rolloutViewBootstrap()
+      : await params.rolloutParserBootstrap!().then((history) => history
+        ? {
+            history,
+            turns: [],
+            semanticComplete: false,
+            reasonCodes: ["rollout_turn_boundary_unavailable" as const],
+          }
+        : null);
     if (bootstrapped) {
-      if (committedChain.chain.length === 0) return bootstrapped;
+      const normalizedBootstrap: CodexEffectiveHistoryView = {
+        ...bootstrapped,
+        turns: mergeTurns(bootstrapped.turns.map((turn) => ({
+          ...turn,
+          turnAbsId: buildTurnAbsId(params.sessionId, turn.turnSeq),
+        })), historyItemIds(bootstrapped.history)),
+        reasonCodes: uniqueReasonCodes(bootstrapped.reasonCodes),
+      };
+      const proxyReasonCodes = journalReasonCodes.filter((reason) =>
+        reason !== "journal_committed_chain_incomplete"
+        && reason !== "journal_history_without_committed_chain"
+        && !(
+          reason === "journal_turn_attribution_incomplete"
+          && !semanticChain.complete
+          && attribution.complete
+          && !attribution.ambiguousDuplicate
+          && normalizedBootstrap.semanticComplete
+        )
+      );
+      if (committedChain.chain.length === 0) {
+        const reasonCodes = uniqueReasonCodes([
+          ...normalizedBootstrap.reasonCodes,
+          ...proxyReasonCodes,
+        ]);
+        return {
+          ...normalizedBootstrap,
+          semanticComplete: normalizedBootstrap.semanticComplete && reasonCodes.length === 0,
+          reasonCodes,
+        };
+      }
       return mergeRolloutBootstrapWithProxyJournal({
-        bootstrapped,
+        sessionId: params.sessionId,
+        bootstrapped: normalizedBootstrap,
+        proxyTurns: turns,
         proxyReplayableItems: replayableItems,
         proxyObservationOnlyItems: observationOnlyItems,
         proxyDeferredItems: deferredItems,
@@ -446,6 +735,7 @@ export async function buildCodexEffectiveHistory(params: {
           || uncommittedActiveWork
           || uncommittedResponseWork
         ),
+        proxyReasonCodes,
       });
     }
   }
@@ -457,7 +747,7 @@ export async function buildCodexEffectiveHistory(params: {
     incomplete: effectiveIncomplete,
   });
 
-  return {
+  const history: CodexEffectiveHistory = {
     revision,
     replayableItems,
     observationOnlyItems,
@@ -466,4 +756,22 @@ export async function buildCodexEffectiveHistory(params: {
     source: journalRead.entries.length > 0 ? "proxy_journal" : "empty",
     incomplete: effectiveIncomplete,
   };
+  const reasonCodes = uniqueReasonCodes([
+    ...journalReasonCodes,
+    ...(effectiveIncomplete ? ["history_replay_incomplete" as const] : []),
+    ...(deferredItems.length > 0 ? ["history_deferred_items" as const] : []),
+    ...(unresolved.length > 0 ? ["history_unresolved_tool_calls" as const] : []),
+  ]);
+  return {
+    history,
+    turns: mergeTurns(turns, historyItemIds(history)),
+    semanticComplete: reasonCodes.length === 0,
+    reasonCodes,
+  };
+}
+
+export async function buildCodexEffectiveHistory(
+  params: BuildCodexEffectiveHistoryParams,
+): Promise<CodexEffectiveHistory> {
+  return (await buildCodexEffectiveHistoryView(params)).history;
 }

--- a/components/adapters/codex/src/context-history/index.ts
+++ b/components/adapters/codex/src/context-history/index.ts
@@ -27,7 +27,10 @@ export type {
   CodexReplayabilityMode,
   CodexReplayabilityReason,
 } from "./replayability.js";
-export { buildCodexEffectiveHistory } from "./effective-history.js";
+export {
+  buildCodexEffectiveHistory,
+  buildCodexEffectiveHistoryView,
+} from "./effective-history.js";
 export { validateCodexRolloutBootstrap } from "./rollout-bootstrap.js";
 export type {
   CodexRolloutBootstrapRejectionReason,

--- a/components/adapters/codex/src/context-history/rollout-bootstrap.ts
+++ b/components/adapters/codex/src/context-history/rollout-bootstrap.ts
@@ -1,5 +1,6 @@
 import type {
   CodexEffectiveHistory,
+  CodexEffectiveHistoryView,
   CodexRolloutSnapshot,
 } from "./types.js";
 
@@ -17,8 +18,19 @@ export type CodexRolloutBootstrapRejectionReason =
 
 export type CodexRolloutBootstrapValidation = {
   history: CodexEffectiveHistory | null;
+  view: CodexEffectiveHistoryView | null;
   rejectionReason?: CodexRolloutBootstrapRejectionReason;
 };
+
+function accepted(rollout: CodexRolloutSnapshot): CodexRolloutBootstrapValidation {
+  return { history: rollout.history, view: rollout.view };
+}
+
+function rejected(
+  rejectionReason: CodexRolloutBootstrapRejectionReason,
+): CodexRolloutBootstrapValidation {
+  return { history: null, view: null, rejectionReason };
+}
 
 function normalizeSessionIdentity(value: string | undefined): string | undefined {
   const normalized = value?.trim();
@@ -53,48 +65,48 @@ export function validateCodexRolloutBootstrap(params: {
   const snapshotSessionId = normalizeSessionIdentity(params.snapshotCodexSessionId);
   const rolloutSessionId = normalizeSessionIdentity(params.rollout.sessionMeta?.sessionId);
   if (!snapshotSessionId) {
-    return { history: null, rejectionReason: "snapshot_session_identity_missing" };
+    return rejected("snapshot_session_identity_missing");
   }
   if (expectedSessionId && snapshotSessionId !== expectedSessionId) {
-    return { history: null, rejectionReason: "snapshot_session_identity_mismatch" };
+    return rejected("snapshot_session_identity_mismatch");
   }
   if (!rolloutSessionId) {
-    return { history: null, rejectionReason: "rollout_session_identity_missing" };
+    return rejected("rollout_session_identity_missing");
   }
   if (rolloutSessionId !== (expectedSessionId ?? snapshotSessionId)) {
-    return { history: null, rejectionReason: "rollout_session_identity_mismatch" };
+    return rejected("rollout_session_identity_mismatch");
   }
 
   if (!hasEncryptedReplayItems(params.rollout)) {
-    return { history: params.rollout.history };
+    return accepted(params.rollout);
   }
 
   const rolloutProvider = normalizeDimension(params.rollout.sessionMeta?.modelProvider);
   const currentCodexProvider = normalizeDimension(params.currentCodexProvider);
   if (!rolloutProvider || !currentCodexProvider) {
-    return { history: null, rejectionReason: "encrypted_rollout_codex_provider_missing" };
+    return rejected("encrypted_rollout_codex_provider_missing");
   }
   if (rolloutProvider !== currentCodexProvider) {
-    return { history: null, rejectionReason: "encrypted_rollout_codex_provider_mismatch" };
+    return rejected("encrypted_rollout_codex_provider_mismatch");
   }
 
   const sourceUpstreamProvider = normalizeDimension(params.sourceUpstreamProvider);
   const currentUpstreamProvider = normalizeDimension(params.currentUpstreamProvider);
   if (!sourceUpstreamProvider || !currentUpstreamProvider) {
-    return { history: null, rejectionReason: "encrypted_rollout_upstream_provider_missing" };
+    return rejected("encrypted_rollout_upstream_provider_missing");
   }
   if (sourceUpstreamProvider !== currentUpstreamProvider) {
-    return { history: null, rejectionReason: "encrypted_rollout_upstream_provider_mismatch" };
+    return rejected("encrypted_rollout_upstream_provider_mismatch");
   }
 
   const sourceModel = normalizeDimension(params.sourceModel);
   const currentModel = normalizeDimension(params.currentModel);
   if (!sourceModel || !currentModel) {
-    return { history: null, rejectionReason: "encrypted_rollout_model_missing" };
+    return rejected("encrypted_rollout_model_missing");
   }
   if (sourceModel !== currentModel) {
-    return { history: null, rejectionReason: "encrypted_rollout_model_mismatch" };
+    return rejected("encrypted_rollout_model_mismatch");
   }
 
-  return { history: params.rollout.history };
+  return accepted(params.rollout);
 }

--- a/components/adapters/codex/src/context-history/rollout-parser.ts
+++ b/components/adapters/codex/src/context-history/rollout-parser.ts
@@ -1,5 +1,6 @@
 import { createReadStream } from "node:fs";
 import { createInterface } from "node:readline";
+import { buildTurnAbsId } from "@lightmem2/history";
 
 import {
   asJsonObject,
@@ -10,6 +11,9 @@ import { codexReplayabilityForItem, codexReplayPairRef } from "./replayability.j
 import type {
   CodexEffectiveHistory,
   CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryReasonCode,
+  CodexEffectiveHistoryTurn,
+  CodexEffectiveHistoryView,
   CodexRolloutSessionMeta,
   CodexRolloutSnapshot,
   CodexRolloutTaskEvidence,
@@ -36,7 +40,7 @@ function isToolOutput(item: JsonObject): boolean {
 }
 
 type RolloutAccumulator = {
-  replayCandidates: JsonObject[];
+  replayCandidates: RolloutItemCandidate[];
   observationCandidates: JsonObject[];
   malformedLineCount: number;
   malformedSinceBaseline: number;
@@ -44,6 +48,14 @@ type RolloutAccumulator = {
   compactionBaselineApplied: boolean;
   unknownRecordTypeCounts: Record<string, number>;
   taskEvidence: CodexRolloutTaskEvidence;
+  currentTurnSeq?: number;
+};
+
+type RolloutItemCandidate = {
+  item: JsonObject;
+  turnSeq?: number;
+  phase: "input" | "output";
+  boundarySource?: "compaction" | "rollout";
 };
 
 function createAccumulator(): RolloutAccumulator {
@@ -123,6 +135,42 @@ function compactionReplacementItems(payload: JsonObject): JsonObject[] | undefin
   return undefined;
 }
 
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function turnSeqFromContext(payload: JsonObject): number | undefined {
+  return positiveInteger(payload.turn_seq) ?? positiveInteger(payload.turn_ordinal);
+}
+
+function itemPhase(item: JsonObject): "input" | "output" {
+  const role = typeof item.role === "string" ? item.role : undefined;
+  if (role === "assistant") return "output";
+  const ref = codexReplayPairRef(item);
+  if (ref.side === "call") return "output";
+  if (ref.side === "output") return "input";
+  return item.type === "reasoning"
+    || item.type === "compaction"
+    || (typeof item.type === "string" && item.type.endsWith("_call"))
+    ? "output"
+    : "input";
+}
+
+function candidate(
+  item: JsonObject,
+  turnSeq: number | undefined,
+  boundarySource: "compaction" | "rollout",
+): RolloutItemCandidate {
+  return {
+    item,
+    turnSeq,
+    phase: itemPhase(item),
+    ...(turnSeq === undefined ? { boundarySource } : {}),
+  };
+}
+
 function addTaskEvidence(payload: JsonObject, evidence: CodexRolloutTaskEvidence): void {
   const eventType = typeof payload.type === "string" ? payload.type : undefined;
   const turnId = typeof payload.turn_id === "string" ? payload.turn_id : undefined;
@@ -134,23 +182,24 @@ function addTaskEvidence(payload: JsonObject, evidence: CodexRolloutTaskEvidence
 }
 
 function buildHistory(params: {
-  replayCandidates: JsonObject[];
+  replayCandidates: RolloutItemCandidate[];
   observationCandidates: JsonObject[];
   malformedSinceBaseline: number;
-}): CodexEffectiveHistory {
-  const replayCandidates: JsonObject[] = [];
+  sessionId: string;
+}): CodexEffectiveHistoryView {
+  const replayCandidates: RolloutItemCandidate[] = [];
   const observationCandidates = [...params.observationCandidates];
-  const deferredCandidates: JsonObject[] = [];
-  for (const item of params.replayCandidates) {
-    const replayability = codexReplayabilityForItem(item);
-    if (replayability.mode === "replayable") replayCandidates.push(item);
-    else if (replayability.mode === "observation_only") observationCandidates.push(item);
-    else deferredCandidates.push(item);
+  const deferredCandidates: RolloutItemCandidate[] = [];
+  for (const entry of params.replayCandidates) {
+    const replayability = codexReplayabilityForItem(entry.item);
+    if (replayability.mode === "replayable") replayCandidates.push(entry);
+    else if (replayability.mode === "observation_only") observationCandidates.push(entry.item);
+    else deferredCandidates.push(entry);
   }
 
   const expectedOutputs = new Map<string, string>();
   const outputTypes = new Map<string, string>();
-  for (const item of replayCandidates) {
+  for (const { item } of replayCandidates) {
     const callId = itemCallId(item);
     if (!callId) continue;
     const expectedType = expectedOutputType(item);
@@ -161,7 +210,12 @@ function buildHistory(params: {
   let incomplete = params.malformedSinceBaseline > 0 || deferredCandidates.length > 0;
   const occurrences = new Map<string, number>();
   const replayableItems: CodexEffectiveHistoryItem[] = [];
-  for (const item of replayCandidates) {
+  const effectiveCandidateById = new Map<string, RolloutItemCandidate>();
+  const attributedCandidateByItem = new Map(
+    params.replayCandidates.map((entry) => [entry.item, entry] as const),
+  );
+  for (const entry of replayCandidates) {
+    const item = entry.item;
     const callId = itemCallId(item);
     if (isToolOutput(item) && (
       !callId
@@ -170,13 +224,22 @@ function buildHistory(params: {
       incomplete = true;
       continue;
     }
-    replayableItems.push(createEffectiveItem(item, occurrences));
+    const effective = createEffectiveItem(item, occurrences);
+    replayableItems.push(effective);
+    effectiveCandidateById.set(effective.stableItemId, entry);
   }
 
-  const observationOnlyItems = observationCandidates.map((item) =>
-    createEffectiveItem(item, occurrences)
-  );
-  const deferredItems = deferredCandidates.map((item) => createEffectiveItem(item, occurrences));
+  const observationOnlyItems = observationCandidates.map((item) => {
+    const effective = createEffectiveItem(item, occurrences);
+    const attributed = attributedCandidateByItem.get(item);
+    if (attributed) effectiveCandidateById.set(effective.stableItemId, attributed);
+    return effective;
+  });
+  const deferredItems = deferredCandidates.map((entry) => {
+    const effective = createEffectiveItem(entry.item, occurrences);
+    effectiveCandidateById.set(effective.stableItemId, entry);
+    return effective;
+  });
   const unresolvedCallIds = Array.from(expectedOutputs)
     .filter(([callId, expectedType]) => outputTypes.get(callId) !== expectedType)
     .map(([callId]) => callId)
@@ -200,7 +263,7 @@ function buildHistory(params: {
     incomplete,
   })}`;
 
-  return {
+  const history: CodexEffectiveHistory = {
     revision,
     replayableItems,
     observationOnlyItems,
@@ -208,6 +271,42 @@ function buildHistory(params: {
     unresolvedCallIds,
     source: "rollout_bootstrap",
     incomplete,
+  };
+  const turnBySeq = new Map<number, CodexEffectiveHistoryTurn>();
+  for (const effective of [...replayableItems, ...observationOnlyItems, ...deferredItems]) {
+    const entry = effectiveCandidateById.get(effective.stableItemId);
+    if (!entry?.turnSeq) continue;
+    const turn = turnBySeq.get(entry.turnSeq) ?? {
+      turnSeq: entry.turnSeq,
+      turnAbsId: buildTurnAbsId(params.sessionId, entry.turnSeq),
+      inputItemIds: [],
+      outputItemIds: [],
+    };
+    const itemIds = entry.phase === "input" ? turn.inputItemIds : turn.outputItemIds;
+    if (!itemIds.includes(effective.stableItemId)) itemIds.push(effective.stableItemId);
+    turnBySeq.set(entry.turnSeq, turn);
+  }
+  const effectiveCandidates = Array.from(effectiveCandidateById.values());
+  const boundaryUnavailable = effectiveCandidates.some((entry) => entry.turnSeq === undefined);
+  const compactionBoundaryUnavailable = effectiveCandidates.some((entry) =>
+    entry.turnSeq === undefined && entry.boundarySource === "compaction"
+  );
+  const reasonCodes: CodexEffectiveHistoryReasonCode[] = Array.from(new Set([
+    ...(history.incomplete ? ["history_replay_incomplete" as const] : []),
+    ...(params.malformedSinceBaseline > 0 ? ["rollout_malformed_lines" as const] : []),
+    ...(compactionBoundaryUnavailable
+      ? ["rollout_compaction_turn_boundary_unavailable" as const]
+      : boundaryUnavailable
+        ? ["rollout_turn_boundary_unavailable" as const]
+        : []),
+    ...(deferredItems.length > 0 ? ["history_deferred_items" as const] : []),
+    ...(unresolvedCallIds.length > 0 ? ["history_unresolved_tool_calls" as const] : []),
+  ]));
+  return {
+    history,
+    turns: Array.from(turnBySeq.values()).sort((left, right) => left.turnSeq - right.turnSeq),
+    semanticComplete: reasonCodes.length === 0,
+    reasonCodes,
   };
 }
 
@@ -234,7 +333,7 @@ function consumeRolloutLine(accumulator: RolloutAccumulator, rawLine: string): v
     return;
   }
   if (recordType === "response_item") {
-    accumulator.replayCandidates.push(payload);
+    accumulator.replayCandidates.push(candidate(payload, accumulator.currentTurnSeq, "rollout"));
     return;
   }
   if (recordType === "compacted") {
@@ -244,14 +343,21 @@ function consumeRolloutLine(accumulator: RolloutAccumulator, rawLine: string): v
       accumulator.malformedSinceBaseline += 1;
       return;
     }
-    accumulator.replayCandidates = replacementItems;
+    const compactionTurnSeq = turnSeqFromContext(payload);
+    accumulator.replayCandidates = replacementItems.map((item) =>
+      candidate(item, turnSeqFromContext(item), "compaction")
+    );
     accumulator.observationCandidates = [];
     accumulator.malformedSinceBaseline = 0;
     accumulator.taskEvidence = { completedTurnIds: [], abortedTurnIds: [] };
     accumulator.compactionBaselineApplied = true;
+    accumulator.currentTurnSeq = compactionTurnSeq;
     return;
   }
   if (recordType === "turn_context" || recordType === "event_msg") {
+    if (recordType === "turn_context") {
+      accumulator.currentTurnSeq = turnSeqFromContext(payload);
+    }
     if (recordType === "event_msg") addTaskEvidence(payload, accumulator.taskEvidence);
     accumulator.observationCandidates.push({ type: recordType, payload });
     return;
@@ -269,12 +375,16 @@ function finishRolloutSnapshot(accumulator: RolloutAccumulator): CodexRolloutSna
   ) {
     return null;
   }
-  return {
-    history: buildHistory({
+  const sessionId = accumulator.sessionMeta?.sessionId ?? "unknown-codex-session";
+  const view = buildHistory({
       replayCandidates: accumulator.replayCandidates,
       observationCandidates: accumulator.observationCandidates,
       malformedSinceBaseline: accumulator.malformedSinceBaseline,
-    }),
+      sessionId,
+    });
+  return {
+    history: view.history,
+    view,
     sessionMeta: accumulator.sessionMeta,
     malformedLineCount: accumulator.malformedLineCount,
     unknownRecordTypeCounts: accumulator.unknownRecordTypeCounts,

--- a/components/adapters/codex/src/context-history/types.ts
+++ b/components/adapters/codex/src/context-history/types.ts
@@ -67,6 +67,38 @@ export type CodexEffectiveHistory = {
   incomplete: boolean;
 };
 
+export type CodexEffectiveHistoryTurn = {
+  turnSeq: number;
+  turnAbsId: string;
+  inputItemIds: string[];
+  outputItemIds: string[];
+};
+
+export type CodexEffectiveHistoryReasonCode =
+  | "journal_read_error"
+  | "journal_malformed_lines"
+  | "journal_malformed_stream"
+  | "journal_committed_chain_incomplete"
+  | "journal_history_without_committed_chain"
+  | "journal_uncommitted_request"
+  | "journal_uncommitted_response"
+  | "journal_current_request_uncommitted"
+  | "journal_turn_sequence_conflict"
+  | "journal_turn_attribution_incomplete"
+  | "history_replay_incomplete"
+  | "history_deferred_items"
+  | "history_unresolved_tool_calls"
+  | "rollout_turn_boundary_unavailable"
+  | "rollout_compaction_turn_boundary_unavailable"
+  | "rollout_malformed_lines";
+
+export type CodexEffectiveHistoryView = {
+  history: CodexEffectiveHistory;
+  turns: CodexEffectiveHistoryTurn[];
+  semanticComplete: boolean;
+  reasonCodes: CodexEffectiveHistoryReasonCode[];
+};
+
 export type CodexRolloutSessionMeta = {
   sessionId?: string;
   cwd?: string;
@@ -83,6 +115,7 @@ export type CodexRolloutTaskEvidence = {
 
 export type CodexRolloutSnapshot = {
   history: CodexEffectiveHistory;
+  view: CodexEffectiveHistoryView;
   sessionMeta?: CodexRolloutSessionMeta;
   malformedLineCount: number;
   unknownRecordTypeCounts: Record<string, number>;

--- a/components/adapters/codex/src/context-rewrite/backend.ts
+++ b/components/adapters/codex/src/context-rewrite/backend.ts
@@ -118,13 +118,10 @@ function orderedOperationIds(
     .filter((operationId) => ids.has(operationId));
 }
 
-function requestSnapshot(
-  sessionId: string,
+export function buildCodexContextSnapshot(
   request: CodexSharedBackendRequest,
 ): ModelContextSnapshot<CodexSharedBackendMetadata> {
-  if (request.sessionId !== sessionId) {
-    throw new Error(`Codex shared backend session mismatch: expected ${sessionId}`);
-  }
+  const sessionId = request.sessionId;
   const history = structuredClone(request.effectiveHistory);
   const allItems = [
     ...history.replayableItems,
@@ -202,7 +199,10 @@ export const codexSharedContextRewriteBackend: CodexSharedContextRewriteBackend 
   mode: "response_chain_rebase",
 
   async readSnapshot({ sessionId, request }) {
-    return requestSnapshot(sessionId, request);
+    if (request.sessionId !== sessionId) {
+      throw new Error(`Codex shared backend session mismatch: expected ${sessionId}`);
+    }
+    return buildCodexContextSnapshot(request);
   },
 
   async validate({ snapshot, plan }) {
@@ -312,7 +312,7 @@ export const codexSharedContextRewriteBackend: CodexSharedContextRewriteBackend 
     }
 
     try {
-      const currentSnapshot = requestSnapshot(request.sessionId, request);
+      const currentSnapshot = buildCodexContextSnapshot(request);
       if (!snapshotsMatch(snapshot, currentSnapshot)) {
         return {
           request,

--- a/components/adapters/codex/src/context-rewrite/estimator-config.ts
+++ b/components/adapters/codex/src/context-rewrite/estimator-config.ts
@@ -1,0 +1,205 @@
+import {
+  createApiTaskStateEstimator,
+  type TaskStateEstimator,
+  type TaskStateEstimatorApiConfig,
+} from "@lightmem2/eviction";
+
+export type CodexEstimatorStatus = "disabled" | "incomplete" | "ready";
+export type CodexEstimatorRequiredField = "baseUrl" | "apiKey" | "model";
+export type CodexEstimatorReasonCode =
+  | "feature_disabled"
+  | "missing_required_config"
+  | "estimator_construction_failed"
+  | "ready";
+
+export type CodexResolvedEstimatorConfig = TaskStateEstimatorApiConfig & {
+  enabled: boolean;
+  requestTimeoutMs: number;
+  batchTurns: number;
+  evictionLookaheadTurns: number;
+  inputMode: "sliding_window" | "completed_summary_plus_active_turns";
+  lifecycleMode: "coupled" | "decoupled";
+  evidenceMode: "three_state" | "two_state";
+};
+
+export type CodexEstimatorResolution = {
+  status: CodexEstimatorStatus;
+  config: CodexResolvedEstimatorConfig;
+  estimator?: TaskStateEstimator;
+  missingFields: CodexEstimatorRequiredField[];
+  reasonCode: CodexEstimatorReasonCode;
+};
+
+export type CodexEstimatorStatusView = {
+  status: CodexEstimatorStatus;
+  model: string | null;
+  baseUrlConfigured: boolean;
+  apiKeyConfigured: boolean;
+  requestTimeoutMs: number;
+  batchTurns: number;
+  evictionLookaheadTurns: number;
+};
+
+export type CodexEstimatorDiagnostic = CodexEstimatorStatusView & {
+  missingFields: CodexEstimatorRequiredField[];
+};
+
+type EstimatorEnvironment = Record<string, string | undefined>;
+
+export type ResolveCodexEstimatorOptions = {
+  config?: TaskStateEstimatorApiConfig;
+  env?: EstimatorEnvironment;
+  createEstimator?: (config: TaskStateEstimatorApiConfig) => TaskStateEstimator;
+};
+
+const LIGHTMEM2_PREFIX = "LIGHTMEM2_TASK_STATE_ESTIMATOR_";
+const TOKENPILOT_PREFIX = "TOKENPILOT_TASK_STATE_ESTIMATOR_";
+
+function envValue(env: EstimatorEnvironment, suffix: string): string | undefined {
+  for (const prefix of [LIGHTMEM2_PREFIX, TOKENPILOT_PREFIX]) {
+    const value = env[`${prefix}${suffix}`]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function envBoolean(env: EstimatorEnvironment, suffix: string): boolean | undefined {
+  const value = envValue(env, suffix)?.toLowerCase();
+  if (!value) return undefined;
+  if (["1", "true", "yes", "on"].includes(value)) return true;
+  if (["0", "false", "no", "off"].includes(value)) return false;
+  return undefined;
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number): number {
+  const number = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.max(min, Math.min(max, Math.trunc(number)));
+}
+
+function explicitOrEnvString(
+  explicit: string | undefined,
+  env: EstimatorEnvironment,
+  suffix: string,
+): string | undefined {
+  const value = explicit?.trim() || envValue(env, suffix);
+  return value || undefined;
+}
+
+function resolveInputMode(value: unknown): CodexResolvedEstimatorConfig["inputMode"] {
+  return value === "completed_summary_plus_active_turns"
+    ? "completed_summary_plus_active_turns"
+    : "sliding_window";
+}
+
+function resolveLifecycleMode(value: unknown): CodexResolvedEstimatorConfig["lifecycleMode"] {
+  return value === "decoupled" ? "decoupled" : "coupled";
+}
+
+function resolveEvidenceMode(value: unknown): CodexResolvedEstimatorConfig["evidenceMode"] {
+  return value === "two_state" ? "two_state" : "three_state";
+}
+
+export function resolveCodexTaskStateEstimator(
+  options: ResolveCodexEstimatorOptions = {},
+): CodexEstimatorResolution {
+  const explicit = options.config ?? {};
+  const env = options.env ?? process.env;
+  const enabled = explicit.enabled ?? envBoolean(env, "ENABLED") ?? false;
+  const baseUrl = explicitOrEnvString(explicit.baseUrl, env, "BASE_URL")?.replace(/\/+$/, "");
+  const apiKey = explicitOrEnvString(explicit.apiKey, env, "API_KEY");
+  const model = explicitOrEnvString(explicit.model, env, "MODEL");
+  const requestTimeoutMs = clampNumber(
+    explicit.requestTimeoutMs ?? envValue(env, "TIMEOUT_MS") ?? envValue(env, "REQUEST_TIMEOUT_MS"),
+    60_000,
+    1_000,
+    300_000,
+  );
+  const batchTurns = clampNumber(
+    explicit.batchTurns ?? envValue(env, "BATCH_TURNS"),
+    5,
+    1,
+    100,
+  );
+  const evictionLookaheadTurns = clampNumber(
+    explicit.evictionLookaheadTurns ?? envValue(env, "EVICTION_LOOKAHEAD_TURNS"),
+    3,
+    1,
+    100,
+  );
+  const config: CodexResolvedEstimatorConfig = {
+    ...explicit,
+    enabled,
+    baseUrl,
+    apiKey,
+    model,
+    requestTimeoutMs,
+    batchTurns,
+    evictionLookaheadTurns,
+    inputMode: resolveInputMode(explicit.inputMode ?? envValue(env, "INPUT_MODE")),
+    lifecycleMode: resolveLifecycleMode(explicit.lifecycleMode ?? envValue(env, "LIFECYCLE_MODE")),
+    evidenceMode: resolveEvidenceMode(explicit.evidenceMode ?? envValue(env, "EVIDENCE_MODE")),
+  };
+
+  if (!enabled) {
+    return {
+      status: "disabled",
+      config,
+      missingFields: [],
+      reasonCode: "feature_disabled",
+    };
+  }
+
+  const missingFields: CodexEstimatorRequiredField[] = [];
+  if (!baseUrl) missingFields.push("baseUrl");
+  if (!apiKey) missingFields.push("apiKey");
+  if (!model) missingFields.push("model");
+  if (missingFields.length > 0) {
+    return {
+      status: "incomplete",
+      config,
+      missingFields,
+      reasonCode: "missing_required_config",
+    };
+  }
+
+  try {
+    return {
+      status: "ready",
+      config,
+      estimator: (options.createEstimator ?? createApiTaskStateEstimator)(config),
+      missingFields: [],
+      reasonCode: "ready",
+    };
+  } catch {
+    return {
+      status: "incomplete",
+      config,
+      missingFields: [],
+      reasonCode: "estimator_construction_failed",
+    };
+  }
+}
+
+export function codexEstimatorStatusView(
+  resolution: CodexEstimatorResolution,
+): CodexEstimatorStatusView {
+  return {
+    status: resolution.status,
+    model: resolution.config.model ?? null,
+    baseUrlConfigured: Boolean(resolution.config.baseUrl),
+    apiKeyConfigured: Boolean(resolution.config.apiKey),
+    requestTimeoutMs: resolution.config.requestTimeoutMs,
+    batchTurns: resolution.config.batchTurns,
+    evictionLookaheadTurns: resolution.config.evictionLookaheadTurns,
+  };
+}
+
+export function codexEstimatorDiagnostic(
+  resolution: CodexEstimatorResolution,
+): CodexEstimatorDiagnostic {
+  return {
+    ...codexEstimatorStatusView(resolution),
+    missingFields: resolution.missingFields,
+  };
+}

--- a/components/adapters/codex/src/context-rewrite/index.ts
+++ b/components/adapters/codex/src/context-rewrite/index.ts
@@ -1,4 +1,6 @@
 export * from "./types.js";
+export * from "./estimator-config.js";
+export * from "./semantic-mapping.js";
 export { applyCodexContextRewrite } from "./disabled.js";
 export { executeCodexRebaseWithFallback } from "./fallback.js";
 export {
@@ -9,6 +11,7 @@ export type { CodexProviderContinuationCompatibility } from "./provider-continua
 export { createCodexContextRewriteLifecycle } from "./lifecycle-events.js";
 export type { CodexContextRewriteLifecycle } from "./lifecycle-events.js";
 export {
+  buildCodexContextSnapshot,
   codexSharedContextRewriteBackend,
   runCodexSharedGoldenFixture,
 } from "./backend.js";

--- a/components/adapters/codex/src/context-rewrite/semantic-mapping.ts
+++ b/components/adapters/codex/src/context-rewrite/semantic-mapping.ts
@@ -1,0 +1,460 @@
+import {
+  buildTurnAbsId,
+  createTurnAnchor,
+  type RawSemanticMessageRecord,
+  type RawSemanticToolCallRecord,
+  type RawSemanticToolResultRecord,
+  type RawSemanticTurnRecord,
+} from "@lightmem2/history";
+
+import type {
+  CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryReasonCode,
+  CodexEffectiveHistoryTurn,
+  CodexEffectiveHistoryView,
+  JsonObject,
+} from "../context-history/types.js";
+
+const ARGUMENT_SUMMARY_MAX_CHARS = 400;
+const RESULT_SUMMARY_MAX_CHARS = 800;
+
+export type CodexRawSemanticReasonCode =
+  | CodexEffectiveHistoryReasonCode
+  | "semantic_source_incomplete"
+  | "semantic_turn_identity_invalid"
+  | "semantic_turn_sequence_duplicate"
+  | "semantic_item_attribution_unknown"
+  | "semantic_item_attribution_ambiguous"
+  | "semantic_message_role_unsupported"
+  | "semantic_message_content_unsupported"
+  | "semantic_item_unsupported"
+  | "semantic_tool_call_invalid"
+  | "semantic_tool_result_invalid"
+  | "semantic_tool_closure_incomplete"
+  | "semantic_tool_closure_ambiguous"
+  | "semantic_tool_result_precedes_call"
+  | "semantic_tool_protocol_mismatch";
+
+export type CodexRawSemanticTurnsResult = {
+  turns: RawSemanticTurnRecord[];
+  complete: boolean;
+  reasonCodes: CodexRawSemanticReasonCode[];
+};
+
+type SupportedToolKind = "function" | "custom";
+
+type AttributedItem = {
+  effective: CodexEffectiveHistoryItem;
+  turn: CodexEffectiveHistoryTurn;
+  order: number;
+};
+
+type ToolCallCandidate = AttributedItem & {
+  callId: string;
+  kind: SupportedToolKind;
+};
+
+type ToolResultCandidate = AttributedItem & {
+  callId: string;
+  kind: SupportedToolKind;
+};
+
+function asRecord(value: unknown): JsonObject | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : undefined;
+}
+
+function nonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function originalNonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}
+
+function itemType(item: JsonObject): string {
+  return typeof item.type === "string" ? item.type.toLowerCase() : "";
+}
+
+function summarize(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  return trimmed.length <= maxChars
+    ? trimmed
+    : `${trimmed.slice(0, maxChars)}...`;
+}
+
+function appendReason(
+  reasons: CodexRawSemanticReasonCode[],
+  reason: CodexRawSemanticReasonCode,
+): void {
+  if (!reasons.includes(reason)) reasons.push(reason);
+}
+
+function sessionIdFromTurn(turn: CodexEffectiveHistoryTurn): string | undefined {
+  if (!Number.isInteger(turn.turnSeq) || turn.turnSeq <= 0) return undefined;
+  const suffix = `:t${turn.turnSeq}`;
+  if (!turn.turnAbsId.endsWith(suffix)) return undefined;
+  const sessionId = turn.turnAbsId.slice(0, -suffix.length);
+  return sessionId && buildTurnAbsId(sessionId, turn.turnSeq) === turn.turnAbsId
+    ? sessionId
+    : undefined;
+}
+
+function safeTextParts(content: unknown): { texts: string[]; unsupported: boolean } {
+  if (typeof content === "string") {
+    return { texts: content.trim().length > 0 ? [content] : [], unsupported: false };
+  }
+  if (content === undefined || content === null) return { texts: [], unsupported: false };
+  if (!Array.isArray(content)) return { texts: [], unsupported: true };
+
+  const texts: string[] = [];
+  let unsupported = false;
+  for (const rawPart of content) {
+    if (typeof rawPart === "string") {
+      // String message content is a supported Responses shape, but array
+      // members must carry an explicit safe text-part type. Treat bare array
+      // strings as unknown provider payload instead of guessing their meaning.
+      unsupported = true;
+      continue;
+    }
+    const part = asRecord(rawPart);
+    if (!part) {
+      unsupported = true;
+      continue;
+    }
+    const type = typeof part.type === "string" ? part.type.toLowerCase() : "";
+    if (
+      (type === "input_text" || type === "output_text" || type === "text")
+      && typeof part.text === "string"
+    ) {
+      if (part.text.trim().length > 0) texts.push(part.text);
+      continue;
+    }
+    unsupported = true;
+  }
+  return { texts, unsupported };
+}
+
+function messageTexts(item: JsonObject): { texts: string[]; unsupported: boolean } {
+  if ("content" in item) return safeTextParts(item.content);
+  if (typeof item.text === "string") {
+    return { texts: item.text.trim().length > 0 ? [item.text] : [], unsupported: false };
+  }
+  return { texts: [], unsupported: false };
+}
+
+function toolKindAndSide(item: JsonObject): {
+  kind: SupportedToolKind;
+  side: "call" | "result";
+} | undefined {
+  switch (itemType(item)) {
+    case "function_call":
+      return { kind: "function", side: "call" };
+    case "function_call_output":
+      return { kind: "function", side: "result" };
+    case "custom_tool_call":
+      return { kind: "custom", side: "call" };
+    case "custom_tool_call_output":
+      return { kind: "custom", side: "result" };
+    default:
+      return undefined;
+  }
+}
+
+function isIgnorableNonSemanticItem(item: JsonObject): boolean {
+  const type = itemType(item);
+  if (type === "reasoning" || type === "compaction") return true;
+  if (type === "event_msg" || type === "turn_context") return true;
+  if (
+    type === "web_search_call"
+    || type === "file_search_call"
+    || type === "code_interpreter_call"
+    || type === "image_generation_call"
+    || type === "mcp_call"
+    || type === "mcp_list_tools"
+    || type === "mcp_approval_request"
+    || type === "mcp_approval_response"
+    || type === "additional_tools"
+  ) return true;
+  return (type === "tool_search_call" || type === "tool_search_output")
+    && String(item.execution ?? "").toLowerCase() !== "client";
+}
+
+function toolArgumentsText(item: JsonObject, kind: SupportedToolKind): {
+  text?: string;
+  valid: boolean;
+} {
+  const value = kind === "function" ? item.arguments : item.input;
+  return typeof value === "string"
+    ? { text: value, valid: true }
+    : { valid: false };
+}
+
+function toolResultText(item: JsonObject): { text?: string; valid: boolean } {
+  if (!("output" in item)) return { valid: false };
+  if (typeof item.output === "string") return { text: item.output, valid: true };
+  const extracted = safeTextParts(item.output);
+  if (extracted.unsupported) return { valid: false };
+  return { text: extracted.texts.join("\n"), valid: true };
+}
+
+function toolResultStatus(item: JsonObject): "success" | "error" {
+  const status = typeof item.status === "string" ? item.status.toLowerCase() : "";
+  return item.is_error === true || status === "error" || status === "failed" || status === "incomplete"
+    ? "error"
+    : "success";
+}
+
+function allEffectiveItems(view: CodexEffectiveHistoryView): CodexEffectiveHistoryItem[] {
+  return [
+    ...view.history.replayableItems,
+    ...view.history.observationOnlyItems,
+    ...view.history.deferredItems,
+  ];
+}
+
+/**
+ * Purely maps a provenance-complete Codex effective-history view to the shared
+ * raw semantic turn contract. System/developer, reasoning, compaction and
+ * provider-owned items stay out of semantic messages. Function/custom results
+ * are anchored to the turn containing their paired call so shared consumers
+ * always observe an original-call turn closure.
+ */
+export function buildCodexRawSemanticTurns(
+  view: CodexEffectiveHistoryView,
+): CodexRawSemanticTurnsResult {
+  const reasonCodes: CodexRawSemanticReasonCode[] = [];
+  for (const reason of view.reasonCodes) appendReason(reasonCodes, reason);
+  if (
+    !view.semanticComplete
+    || view.history.incomplete
+    || view.history.deferredItems.length > 0
+    || view.history.unresolvedCallIds.length > 0
+  ) {
+    appendReason(reasonCodes, "semantic_source_incomplete");
+  }
+
+  const effectiveById = new Map<string, CodexEffectiveHistoryItem>();
+  for (const effective of allEffectiveItems(view)) {
+    if (effectiveById.has(effective.stableItemId)) {
+      appendReason(reasonCodes, "semantic_item_attribution_ambiguous");
+      continue;
+    }
+    effectiveById.set(effective.stableItemId, effective);
+  }
+
+  const orderedTurns = [...view.turns].sort((left, right) => left.turnSeq - right.turnSeq);
+  const records: RawSemanticTurnRecord[] = [];
+  const recordByTurnSeq = new Map<number, RawSemanticTurnRecord>();
+  const attributedById = new Map<string, AttributedItem>();
+  let sessionId: string | undefined;
+  let itemOrder = 0;
+
+  for (const turn of orderedTurns) {
+    const derivedSessionId = sessionIdFromTurn(turn);
+    if (!derivedSessionId || (sessionId !== undefined && derivedSessionId !== sessionId)) {
+      appendReason(reasonCodes, "semantic_turn_identity_invalid");
+      continue;
+    }
+    sessionId ??= derivedSessionId;
+    if (recordByTurnSeq.has(turn.turnSeq)) {
+      appendReason(reasonCodes, "semantic_turn_sequence_duplicate");
+      continue;
+    }
+
+    const record: RawSemanticTurnRecord = {
+      sessionId,
+      turnSeq: turn.turnSeq,
+      turnAbsId: turn.turnAbsId,
+      messages: [],
+      toolCalls: [],
+      toolResults: [],
+    };
+    records.push(record);
+    recordByTurnSeq.set(turn.turnSeq, record);
+
+    for (const stableItemId of [...turn.inputItemIds, ...turn.outputItemIds]) {
+      const effective = effectiveById.get(stableItemId);
+      if (!effective) {
+        appendReason(reasonCodes, "semantic_item_attribution_unknown");
+        continue;
+      }
+      if (attributedById.has(stableItemId)) {
+        appendReason(reasonCodes, "semantic_item_attribution_ambiguous");
+        continue;
+      }
+      attributedById.set(stableItemId, { effective, turn, order: itemOrder });
+      itemOrder += 1;
+    }
+  }
+
+  for (const [stableItemId, effective] of effectiveById) {
+    if (
+      !attributedById.has(stableItemId)
+      && !isIgnorableNonSemanticItem(effective.item)
+    ) {
+      appendReason(reasonCodes, "semantic_item_attribution_unknown");
+    }
+  }
+
+  const toolCallsById = new Map<string, ToolCallCandidate[]>();
+  const toolResultsById = new Map<string, ToolResultCandidate[]>();
+  const attributedItems = Array.from(attributedById.values())
+    .sort((left, right) => left.order - right.order);
+
+  for (const attributed of attributedItems) {
+    const item = attributed.effective.item;
+    const type = itemType(item);
+    const role = typeof item.role === "string" ? item.role.toLowerCase() : "";
+    if (type === "message" || (!type && role.length > 0)) {
+      if (role === "system" || role === "developer") continue;
+      if (role !== "user" && role !== "assistant") {
+        appendReason(reasonCodes, "semantic_message_role_unsupported");
+        continue;
+      }
+      const extracted = messageTexts(item);
+      if (extracted.unsupported) {
+        appendReason(reasonCodes, "semantic_message_content_unsupported");
+      }
+      const record = recordByTurnSeq.get(attributed.turn.turnSeq);
+      if (!record || !sessionId) continue;
+      const anchor = createTurnAnchor(sessionId, attributed.turn.turnSeq, role);
+      for (const text of extracted.texts) {
+        const message: RawSemanticMessageRecord = { anchor, role, text };
+        record.messages.push(message);
+      }
+      continue;
+    }
+
+    const tool = toolKindAndSide(item);
+    if (!tool) {
+      if (!isIgnorableNonSemanticItem(item)) {
+        appendReason(reasonCodes, "semantic_item_unsupported");
+      }
+      continue;
+    }
+    const callId = originalNonBlankString(item.call_id);
+    if (!callId) {
+      appendReason(
+        reasonCodes,
+        tool.side === "call" ? "semantic_tool_call_invalid" : "semantic_tool_result_invalid",
+      );
+      appendReason(reasonCodes, "semantic_tool_closure_incomplete");
+      continue;
+    }
+    const candidate = { ...attributed, callId, kind: tool.kind };
+    const target = tool.side === "call" ? toolCallsById : toolResultsById;
+    const values = target.get(callId) ?? [];
+    values.push(candidate);
+    target.set(callId, values);
+  }
+
+  const callIds = Array.from(new Set([
+    ...toolCallsById.keys(),
+    ...toolResultsById.keys(),
+  ])).sort((left, right) => {
+    const leftOrder = toolCallsById.get(left)?.[0]?.order
+      ?? toolResultsById.get(left)?.[0]?.order
+      ?? 0;
+    const rightOrder = toolCallsById.get(right)?.[0]?.order
+      ?? toolResultsById.get(right)?.[0]?.order
+      ?? 0;
+    return leftOrder - rightOrder || left.localeCompare(right);
+  });
+  const mappedToolCalls: Array<{
+    order: number;
+    turnSeq: number;
+    value: RawSemanticToolCallRecord;
+  }> = [];
+  const mappedToolResults: Array<{
+    order: number;
+    turnSeq: number;
+    value: RawSemanticToolResultRecord;
+  }> = [];
+
+  for (const callId of callIds) {
+    const calls = toolCallsById.get(callId) ?? [];
+    const results = toolResultsById.get(callId) ?? [];
+    if (calls.length !== 1 || results.length !== 1) {
+      appendReason(
+        reasonCodes,
+        calls.length > 1 || results.length > 1
+          ? "semantic_tool_closure_ambiguous"
+          : "semantic_tool_closure_incomplete",
+      );
+      continue;
+    }
+
+    const call = calls[0]!;
+    const result = results[0]!;
+    if (call.kind !== result.kind) {
+      appendReason(reasonCodes, "semantic_tool_protocol_mismatch");
+      continue;
+    }
+    if (result.order < call.order) {
+      appendReason(reasonCodes, "semantic_tool_result_precedes_call");
+      continue;
+    }
+    const toolName = nonBlankString(call.effective.item.name);
+    const argumentsValue = toolArgumentsText(call.effective.item, call.kind);
+    const resultValue = toolResultText(result.effective.item);
+    if (!toolName || !argumentsValue.valid) {
+      appendReason(reasonCodes, "semantic_tool_call_invalid");
+      continue;
+    }
+    if (!resultValue.valid || resultValue.text === undefined) {
+      appendReason(reasonCodes, "semantic_tool_result_invalid");
+      continue;
+    }
+
+    const record = recordByTurnSeq.get(call.turn.turnSeq);
+    if (!record || !sessionId) {
+      appendReason(reasonCodes, "semantic_item_attribution_unknown");
+      continue;
+    }
+    const anchor = createTurnAnchor(sessionId, call.turn.turnSeq, "tool");
+    const toolCall: RawSemanticToolCallRecord = {
+      anchor,
+      toolCallId: callId,
+      toolName,
+      ...(argumentsValue.text === undefined ? {} : { argumentsText: argumentsValue.text }),
+      argumentsSummary: summarize(argumentsValue.text ?? toolName, ARGUMENT_SUMMARY_MAX_CHARS),
+    };
+    const toolResult: RawSemanticToolResultRecord = {
+      anchor,
+      toolCallId: callId,
+      toolName,
+      status: toolResultStatus(result.effective.item),
+      fullText: resultValue.text,
+      summary: summarize(resultValue.text, RESULT_SUMMARY_MAX_CHARS),
+    };
+    mappedToolCalls.push({
+      order: call.order,
+      turnSeq: call.turn.turnSeq,
+      value: toolCall,
+    });
+    mappedToolResults.push({
+      order: result.order,
+      turnSeq: call.turn.turnSeq,
+      value: toolResult,
+    });
+  }
+
+  for (const mapped of mappedToolCalls.sort((left, right) => left.order - right.order)) {
+    recordByTurnSeq.get(mapped.turnSeq)?.toolCalls.push(mapped.value);
+  }
+  for (const mapped of mappedToolResults.sort((left, right) => left.order - right.order)) {
+    recordByTurnSeq.get(mapped.turnSeq)?.toolResults.push(mapped.value);
+  }
+
+  return {
+    turns: records,
+    complete: reasonCodes.length === 0,
+    reasonCodes,
+  };
+}

--- a/components/adapters/codex/src/doctor.ts
+++ b/components/adapters/codex/src/doctor.ts
@@ -9,7 +9,11 @@ import {
   asObjectRecord,
   scanInstalledHookEvents,
 } from "../../shared/doctor-shared.js";
-import type { TokenPilotCodexConfig } from "./config.js";
+import type {
+  CodexMcpServerConfig,
+  CodexProviderConfig,
+  TokenPilotCodexConfig,
+} from "./config.js";
 import {
   readCodexMcpServerFromToml,
   readCodexProviderFromToml,
@@ -19,6 +23,11 @@ import {
   formatCodexRebaseCapabilityStatus,
   readCodexRebaseCapabilityJournal,
 } from "./context-rewrite/rebase-capability.js";
+import {
+  codexEstimatorDiagnostic,
+  resolveCodexTaskStateEstimator,
+  type CodexEstimatorDiagnostic,
+} from "./context-rewrite/estimator-config.js";
 import { readDaemonStatus } from "./daemon.js";
 import { resolveCodexHookCommandForInstall, resolveCodexMcpServerSpecForInstall } from "./install.js";
 
@@ -57,6 +66,24 @@ export type CodexDoctorReport = {
   rebaseCapabilityStatus?: string[];
   rebaseCapabilityTrusted?: boolean;
   rebaseCapabilityIssue?: string;
+  taskStateEstimator?: CodexEstimatorDiagnostic;
+};
+
+export type CodexProviderDiagnostic = {
+  configured: boolean;
+  name?: string;
+  baseUrlConfigured: boolean;
+  apiKeyConfigured: boolean;
+  wireApi?: "responses" | "chat";
+  requiresOpenAIAuth?: boolean;
+};
+
+export type CodexMcpServerDiagnostic = {
+  configured: boolean;
+  commandConfigured: boolean;
+  argsCount: number;
+  envKeys: string[];
+  startupTimeoutSec?: number;
 };
 
 const HOOK_EVENT_NAMES = [
@@ -74,6 +101,50 @@ function normalizeLocalProxyBaseUrl(value: string | undefined): string | undefin
   return `http://127.0.0.1:${match[1]}/v1`;
 }
 
+function sanitizeDiagnosticUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, value.endsWith("/") ? "/" : "");
+  } catch {
+    return "(configured but not safely displayable)";
+  }
+}
+
+export function codexProviderDiagnostic(
+  provider: CodexProviderConfig | undefined,
+): CodexProviderDiagnostic {
+  const name = provider?.name?.trim();
+  return {
+    configured: Boolean(provider),
+    name: name && !/(?:\b(?:bearer|api[_-]?key|access[_-]?token|secret|authorization)\b|sk-[a-z0-9_-]{12,}|(?:github_pat_|gh[pousr]_)[a-z0-9_]{20,}|AKIA[0-9A-Z]{16}|ASIA[0-9A-Z]{16}|(?:xapp-|xox[baprsuv]-)[a-z0-9-]{10,}|tvly-[a-z0-9-]{12,}|[?&](?:key|token|signature)=)/iu.test(name)
+      ? name
+      : name
+        ? "(configured but not safely displayable)"
+        : undefined,
+    baseUrlConfigured: Boolean(provider?.baseUrl),
+    apiKeyConfigured: Boolean(provider?.apiKey),
+    wireApi: provider?.wireApi,
+    requiresOpenAIAuth: provider?.requiresOpenAIAuth,
+  };
+}
+
+export function codexMcpServerDiagnostic(
+  server: CodexMcpServerConfig | undefined,
+): CodexMcpServerDiagnostic {
+  return {
+    configured: Boolean(server),
+    commandConfigured: Boolean(server?.command),
+    argsCount: server?.args.length ?? 0,
+    envKeys: Object.keys(server?.env ?? {}).sort(),
+    startupTimeoutSec: server?.startupTimeoutSec,
+  };
+}
+
 async function checkHealth(baseUrl: string): Promise<boolean> {
   try {
     const resp = await fetch(`${baseUrl.replace(/\/+$/, "").replace(/\/v1$/, "")}/health`);
@@ -86,6 +157,16 @@ async function checkHealth(baseUrl: string): Promise<boolean> {
 }
 
 export function formatCodexDoctorReport(report: CodexDoctorReport): string {
+  const taskStateEstimator = report.taskStateEstimator ?? {
+    status: "disabled" as const,
+    model: null,
+    baseUrlConfigured: false,
+    apiKeyConfigured: false,
+    requestTimeoutMs: 60_000,
+    batchTurns: 5,
+    evictionLookaheadTurns: 3,
+    missingFields: [],
+  };
   const rebaseCapabilityStatus = report.rebaseCapabilityStatus ?? [];
   const rebaseCapabilitySummary = report.rebaseCapabilityTrusted === false
     ? `untrusted (${report.rebaseCapabilityIssue ?? "read or validation error"}); runtime will bypass rebase`
@@ -121,10 +202,18 @@ export function formatCodexDoctorReport(report: CodexDoctorReport): string {
     `- recovery MCP startup timeout matches: ${report.mcpStartupTimeoutSecMatches ? "yes" : "no"}`,
     `- daemon running: ${report.daemonRunning ? "yes" : "no"}`,
     `- proxy healthy: ${report.proxyHealthy ? "yes" : "no"}`,
-    `- proxy base URL: ${report.proxyBaseUrl}`,
+    `- proxy base URL: ${sanitizeDiagnosticUrl(report.proxyBaseUrl) ?? "(unset)"}`,
     `- upstream provider: ${report.upstreamProvider ?? "(unset)"}`,
-    `- upstream base URL: ${report.upstreamBaseUrl ?? "(unset)"}`,
+    `- upstream base URL: ${sanitizeDiagnosticUrl(report.upstreamBaseUrl) ?? "(unset)"}`,
     `- upstream loops into local proxy: ${report.upstreamLoopDetected ? "yes" : "no"}`,
+    `- task-state estimator status: ${taskStateEstimator.status}`,
+    `- task-state estimator model: ${taskStateEstimator.model ?? "(unset)"}`,
+    `- task-state estimator base URL configured: ${taskStateEstimator.baseUrlConfigured ? "yes" : "no"}`,
+    `- task-state estimator API key configured: ${taskStateEstimator.apiKeyConfigured ? "yes" : "no"}`,
+    `- task-state estimator request timeout: ${taskStateEstimator.requestTimeoutMs}ms`,
+    `- task-state estimator batch turns: ${taskStateEstimator.batchTurns}`,
+    `- task-state estimator eviction lookahead turns: ${taskStateEstimator.evictionLookaheadTurns}`,
+    `- task-state estimator missing fields: ${taskStateEstimator.missingFields.length > 0 ? taskStateEstimator.missingFields.join(", ") : "(none)"}`,
     `- CDR-05 rebase capability cache: ${rebaseCapabilitySummary}`,
   ];
   const fixes: string[] = [];
@@ -156,6 +245,11 @@ export function formatCodexDoctorReport(report: CodexDoctorReport): string {
   if (report.adapterEnabled && (!report.daemonRunning || !report.proxyHealthy)) {
     fixes.push("- trust the TokenPilot hooks in Codex, then start a new session so SessionStart can boot the local proxy");
     fixes.push("- if the proxy is still unhealthy after a new session starts, run `tokenpilot-codex start` or `tokenpilot-codex restart`");
+  }
+  if (taskStateEstimator.status === "incomplete") {
+    fixes.push(
+      `- configure taskStateEstimator ${taskStateEstimator.missingFields.length > 0 ? taskStateEstimator.missingFields.join(", ") : "settings"}; estimator runtime remains disabled until the configuration is ready`,
+    );
   }
   if (report.degradedMode) {
     lines.push(
@@ -234,6 +328,10 @@ export async function inspectCodexDoctor(params: {
     && daemon.running
     && proxyHealthy;
   const recoveryMcpHealthy = mcpHealth.healthy;
+  const taskStateEstimator = codexEstimatorDiagnostic(resolveCodexTaskStateEstimator({
+    config: params.config.taskStateEstimator,
+    env: process.env,
+  }));
   return {
     configPath: params.configPath,
     hooksConfigPath: params.hooksConfigPath,
@@ -256,7 +354,7 @@ export async function inspectCodexDoctor(params: {
     stateDir: params.config.stateDir,
     upstreamProvider: params.config.upstreamProvider,
     upstreamLoopDetected,
-    upstreamBaseUrl,
+    upstreamBaseUrl: sanitizeDiagnosticUrl(upstreamBaseUrl),
     mcpInstalled: mcpHealth.installed,
     mcpStateDirMatches: mcpHealth.stateDirMatches,
     mcpCommandMatches: mcpHealth.commandMatches,
@@ -269,5 +367,6 @@ export async function inspectCodexDoctor(params: {
     rebaseCapabilityStatus,
     rebaseCapabilityTrusted,
     rebaseCapabilityIssue,
+    taskStateEstimator,
   };
 }

--- a/components/adapters/codex/tests/cli-bridge.test.ts
+++ b/components/adapters/codex/tests/cli-bridge.test.ts
@@ -352,7 +352,8 @@ test("codex mode writes only codex-supported fields", async () => {
     assert.equal(reloaded.reduction.maxToolChars, 1800);
 
     const record = reloaded as unknown as Record<string, unknown>;
-    assert.equal("taskStateEstimator" in record, false);
+    assert.equal("taskStateEstimator" in record, true);
+    assert.equal((record.taskStateEstimator as Record<string, unknown>).enabled, undefined);
     assert.equal("eviction" in record, false);
     const modules = record.modules as Record<string, unknown>;
     assert.equal("policy" in modules, false);

--- a/components/adapters/codex/tests/config.test.ts
+++ b/components/adapters/codex/tests/config.test.ts
@@ -15,6 +15,10 @@ test("normalizeTokenPilotCodexConfig applies stable defaults", () => {
   assert.equal(config.contextRewrite.failureMode, "bypass");
   assert.equal(config.contextRewrite.retryOriginalRequest, true);
   assert.equal(config.contextRewrite.cooldownMs, 300_000);
+  assert.equal(config.taskStateEstimator.enabled, undefined);
+  assert.equal(config.taskStateEstimator.baseUrl, undefined);
+  assert.equal(config.taskStateEstimator.requestTimeoutMs, undefined);
+  assert.equal(config.taskStateEstimator.inputMode, undefined);
 });
 
 test("normalizeTokenPilotCodexConfig derives default stateDir from the tokenpilot config path", () => {
@@ -33,6 +37,50 @@ test("normalizeTokenPilotCodexConfig trims and clamps values", () => {
   assert.equal(config.logLevel, "debug");
   assert.equal(config.proxyPort, 65535);
   assert.equal(config.upstreamProvider, "OPENAI");
+});
+
+test("normalizeTokenPilotCodexConfig normalizes estimator config", () => {
+  const config = normalizeTokenPilotCodexConfig({
+    taskStateEstimator: {
+      enabled: true,
+      baseUrl: "  https://estimator.example/v1///  ",
+      apiKey: "  secret-value  ",
+      model: "  estimator-model  ",
+      requestTimeoutMs: 999_999,
+      batchTurns: 0,
+      evictionLookaheadTurns: 9.8,
+      inputMode: "completed_summary_plus_active_turns",
+      lifecycleMode: "decoupled",
+      evidenceMode: "two_state",
+    },
+  });
+
+  assert.deepEqual(config.taskStateEstimator, {
+    enabled: true,
+    baseUrl: "https://estimator.example/v1",
+    apiKey: "secret-value",
+    model: "estimator-model",
+    requestTimeoutMs: 300_000,
+    batchTurns: 1,
+    evictionLookaheadTurns: 9,
+    inputMode: "completed_summary_plus_active_turns",
+    lifecycleMode: "decoupled",
+    evidenceMode: "two_state",
+  });
+});
+
+test("normalizeTokenPilotCodexConfig falls back from invalid estimator enums", () => {
+  const config = normalizeTokenPilotCodexConfig({
+    taskStateEstimator: {
+      inputMode: "invalid",
+      lifecycleMode: "invalid",
+      evidenceMode: "invalid",
+    },
+  });
+
+  assert.equal(config.taskStateEstimator.inputMode, "sliding_window");
+  assert.equal(config.taskStateEstimator.lifecycleMode, "coupled");
+  assert.equal(config.taskStateEstimator.evidenceMode, "three_state");
 });
 
 test("normalizeTokenPilotCodexConfig preserves context rewrite plan revisions", () => {

--- a/components/adapters/codex/tests/context-history-effective-history.test.ts
+++ b/components/adapters/codex/tests/context-history-effective-history.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -8,6 +8,8 @@ import {
   appendCodexRequestJournalEntry,
   appendCodexResponseJournalEntry,
   buildCodexEffectiveHistory,
+  buildCodexEffectiveHistoryView,
+  codexContextHistoryJournalPath,
   type JsonObject,
 } from "../src/context-history/index.js";
 
@@ -107,6 +109,307 @@ test("CDH-04 Effective History Builder preserves ordered turns when a provider r
     assert.match(JSON.stringify(history.replayableItems), /reused id turn 1/);
     assert.match(JSON.stringify(history.replayableItems), /reused id turn 2/);
     assert.match(JSON.stringify(history.replayableItems), /reused id turn 3/);
+  });
+});
+
+test("CDH-04 Effective History View builds deterministic journal turn sidecars", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-turn-sidecar";
+    for (let turn = 1; turn <= 2; turn += 1) {
+      await appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-${turn}`,
+        turnOrdinal: turn,
+        payload: {
+          ...(turn > 1 ? { previous_response_id: `resp-${turn - 1}` } : {}),
+          input: [{ id: `input-${turn}`, role: "user", content: `turn ${turn}` }],
+        },
+        status: "completed",
+      });
+      await appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-${turn}`,
+        response: {
+          id: `resp-${turn}`,
+          previous_response_id: turn > 1 ? `resp-${turn - 1}` : null,
+          output: [{ id: `output-${turn}`, type: "message", role: "assistant", content: `answer ${turn}` }],
+        },
+        status: "completed",
+      });
+    }
+
+    const first = await buildCodexEffectiveHistoryView({ stateDir, sessionId });
+    const restarted = await buildCodexEffectiveHistoryView({ stateDir, sessionId });
+    const legacy = await buildCodexEffectiveHistory({ stateDir, sessionId });
+
+    assert.equal(first.semanticComplete, true);
+    assert.deepEqual(first.reasonCodes, []);
+    assert.deepEqual(first.turns.map(({ turnSeq, turnAbsId }) => ({ turnSeq, turnAbsId })), [
+      { turnSeq: 1, turnAbsId: `${sessionId}:t1` },
+      { turnSeq: 2, turnAbsId: `${sessionId}:t2` },
+    ]);
+    assert.deepEqual(first.turns, restarted.turns);
+    assert.deepEqual(first.history, legacy);
+    assert.equal(first.history.revision, legacy.revision);
+
+    const allItemIds = new Set([
+      ...first.history.replayableItems,
+      ...first.history.observationOnlyItems,
+      ...first.history.deferredItems,
+    ].map((entry) => entry.stableItemId));
+    for (const turn of first.turns) {
+      assert.equal(turn.inputItemIds.length, 1);
+      assert.equal(turn.outputItemIds.length, 1);
+      assert.equal(turn.inputItemIds.every((itemId) => allItemIds.has(itemId)), true);
+      assert.equal(turn.outputItemIds.every((itemId) => allItemIds.has(itemId)), true);
+    }
+  });
+});
+
+test("CDH-04 Effective History View marks the current request semantic-only incomplete", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-current-request";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      turnOrdinal: 1,
+      payload: { input: [{ role: "user", content: "committed" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      response: { id: "resp-1", output: [{ type: "message", role: "assistant", content: "done" }] },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-current",
+      turnOrdinal: 2,
+      payload: { previous_response_id: "resp-1", input: [{ role: "user", content: "current" }] },
+      status: "pending",
+    });
+
+    const view = await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-1",
+      currentRequestId: "request-current",
+    });
+
+    assert.equal(view.history.incomplete, false);
+    assert.equal(view.semanticComplete, false);
+    assert.deepEqual(view.reasonCodes, ["journal_current_request_uncommitted"]);
+    assert.deepEqual(view.turns.map((turn) => turn.turnSeq), [1]);
+  });
+});
+
+test("CDH-04 Effective History View fails closed on conflicting journal turn sequences", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-turn-conflict";
+    for (let index = 1; index <= 2; index += 1) {
+      const requestId = `request-${index}`;
+      await appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId,
+        turnOrdinal: 1,
+        payload: {
+          ...(index > 1 ? { previous_response_id: "resp-1" } : {}),
+          input: [{ role: "user", content: requestId }],
+        },
+        status: "completed",
+      });
+      await appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId,
+        requestId,
+        response: {
+          id: `resp-${index}`,
+          previous_response_id: index > 1 ? "resp-1" : null,
+          output: [],
+        },
+        status: "completed",
+      });
+    }
+
+    const view = await buildCodexEffectiveHistoryView({ stateDir, sessionId });
+    assert.equal(view.history.incomplete, false);
+    assert.equal(view.semanticComplete, false);
+    assert.equal(view.reasonCodes.includes("journal_turn_sequence_conflict"), true);
+  });
+});
+
+test("CDH-04 Effective History View reports malformed journal records with a finite reason", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-malformed-record";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-valid",
+      payload: { input: [{ role: "user", content: "valid prefix" }] },
+      status: "completed",
+    });
+    await appendFile(
+      codexContextHistoryJournalPath(stateDir, sessionId),
+      "{\"truncated\":\n",
+      "utf8",
+    );
+
+    const view = await buildCodexEffectiveHistoryView({ stateDir, sessionId });
+
+    assert.equal(view.semanticComplete, false);
+    assert.equal(view.reasonCodes.includes("journal_malformed_lines"), true);
+    assert.equal(view.reasonCodes.includes("history_replay_incomplete"), true);
+  });
+});
+
+test("CDH-04 Effective History View fails closed when its journal cannot be read", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-effective-read-error";
+    await mkdir(codexContextHistoryJournalPath(stateDir, sessionId), { recursive: true });
+
+    const view = await buildCodexEffectiveHistoryView({ stateDir, sessionId });
+
+    assert.equal(view.history.incomplete, true);
+    assert.equal(view.semanticComplete, false);
+    assert.equal(view.reasonCodes.includes("journal_read_error"), true);
+    assert.equal(view.reasonCodes.includes("history_replay_incomplete"), true);
+  });
+});
+
+test("CDH-04 Effective History View keeps stateless continuation roots single and deterministic", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-stateless-root";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-old-root",
+      turnOrdinal: 1,
+      payload: { input: [{ id: "old-input", role: "user", content: "old turn" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-old-root",
+      response: { id: "resp-old-root", output: [{ id: "old-output", role: "assistant", content: "old answer" }] },
+      status: "completed",
+    });
+    const replayInput = [
+      { id: "old-input", role: "user", content: "old turn" },
+      { id: "old-output", role: "assistant", content: "old answer" },
+      { id: "current-input", role: "user", content: "current turn" },
+    ];
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-stateless-root",
+      turnOrdinal: 2,
+      payload: {
+        previous_response_id: "resp-old-root",
+        input: [{ id: "current-input", role: "user", content: "current turn" }],
+      },
+      committedInputItems: replayInput,
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-stateless-root",
+      previousResponseId: null,
+      response: {
+        id: "resp-stateless-root",
+        previous_response_id: null,
+        output: [{ id: "current-output", role: "assistant", content: "current answer" }],
+      },
+      status: "completed",
+    });
+
+    const first = await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-stateless-root",
+    });
+    const restarted = await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-stateless-root",
+    });
+
+    assert.equal(first.semanticComplete, true);
+    assert.deepEqual(first.turns.map((turn) => ({
+      turnSeq: turn.turnSeq,
+      inputCount: turn.inputItemIds.length,
+      outputCount: turn.outputItemIds.length,
+    })), [
+      { turnSeq: 1, inputCount: 1, outputCount: 1 },
+      { turnSeq: 2, inputCount: 1, outputCount: 1 },
+    ]);
+    assert.deepEqual(first.turns, restarted.turns);
+    const attributedItemIds = first.turns.flatMap((turn) => [
+      ...turn.inputItemIds,
+      ...turn.outputItemIds,
+    ]);
+    assert.equal(attributedItemIds.length, 4);
+    assert.equal(new Set(attributedItemIds).size, attributedItemIds.length);
+  });
+});
+
+test("CDH-04 Effective History View fails closed on ambiguous cross-turn replay attribution", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-ambiguous-stateless-root";
+    for (let turn = 1; turn <= 2; turn += 1) {
+      await appendCodexRequestJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-${turn}`,
+        turnOrdinal: turn,
+        payload: {
+          ...(turn > 1 ? { previous_response_id: "resp-1" } : {}),
+          input: [{ id: "provider-reused-input", role: "user", content: "same native item" }],
+        },
+        ...(turn === 2 ? {
+          committedInputItems: [
+            { id: "provider-reused-input", role: "user", content: "same native item" },
+          ],
+        } : {}),
+        status: "completed",
+      });
+      await appendCodexResponseJournalEntry({
+        stateDir,
+        sessionId,
+        requestId: `request-${turn}`,
+        ...(turn === 2 ? { previousResponseId: null } : {}),
+        response: {
+          id: `resp-${turn}`,
+          previous_response_id: turn === 2 ? null : undefined,
+          output: [],
+        },
+        status: "completed",
+      });
+    }
+
+    let legacyBootstrapCalled = false;
+    const view = await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-2",
+      async rolloutParserBootstrap() {
+        legacyBootstrapCalled = true;
+        return null;
+      },
+    });
+
+    assert.equal(view.history.incomplete, false);
+    assert.equal(view.semanticComplete, false);
+    assert.equal(view.reasonCodes.includes("journal_turn_attribution_incomplete"), true);
+    assert.equal(legacyBootstrapCalled, false);
   });
 });
 
@@ -404,6 +707,172 @@ test("CDH-04 Effective History Builder merges rollout bootstrap with post-baseli
   });
 });
 
+test("CDH-04 Effective History View merges only evidenced rollout and proxy turns", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-rollout-view-merge";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-2",
+      turnOrdinal: 2,
+      payload: {
+        previous_response_id: "resp-rollout-root",
+        input: [{ id: "proxy-input-2", role: "user", content: "proxy turn" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-2",
+      response: {
+        id: "resp-proxy-2",
+        previous_response_id: "resp-rollout-root",
+        output: [{ id: "proxy-output-2", type: "message", role: "assistant", content: "proxy answer" }],
+      },
+      status: "completed",
+    });
+    const rolloutItem = {
+      stableItemId: "rollout-input-1",
+      nativeId: "rollout-input-1",
+      item: { id: "rollout-input-1", type: "message", role: "user", content: "rollout turn" },
+    };
+    const rolloutHistory = {
+      revision: "rollout-view-revision",
+      replayableItems: [rolloutItem],
+      observationOnlyItems: [],
+      deferredItems: [],
+      unresolvedCallIds: [],
+      source: "rollout_bootstrap" as const,
+      incomplete: false,
+    };
+
+    const view = await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-proxy-2",
+      async rolloutViewBootstrap() {
+        return {
+          history: rolloutHistory,
+          turns: [{
+            turnSeq: 1,
+            turnAbsId: "wrong-host-id:t1",
+            inputItemIds: ["rollout-input-1", "removed-rollout-id"],
+            outputItemIds: [],
+          }, {
+            turnSeq: 2,
+            turnAbsId: "wrong-host-id:t2",
+            inputItemIds: [],
+            outputItemIds: ["rollout-input-1"],
+          }],
+          semanticComplete: true,
+          reasonCodes: [],
+        };
+      },
+    });
+
+    assert.equal(view.history.source, "rollout_proxy_merge");
+    assert.equal(view.semanticComplete, true);
+    assert.deepEqual(view.reasonCodes, []);
+    assert.deepEqual(view.turns.map((turn) => ({
+      turnSeq: turn.turnSeq,
+      turnAbsId: turn.turnAbsId,
+      inputCount: turn.inputItemIds.length,
+      outputCount: turn.outputItemIds.length,
+    })), [
+      { turnSeq: 1, turnAbsId: `${sessionId}:t1`, inputCount: 1, outputCount: 0 },
+      { turnSeq: 2, turnAbsId: `${sessionId}:t2`, inputCount: 1, outputCount: 1 },
+    ]);
+    const allAttributedIds = view.turns.flatMap((turn) => [
+      ...turn.inputItemIds,
+      ...turn.outputItemIds,
+    ]);
+    assert.equal(new Set(allAttributedIds).size, allAttributedIds.length);
+    assert.equal(allAttributedIds.includes("removed-rollout-id"), false);
+  });
+});
+
+test("CDH-04 Effective History View aligns local proxy ordinals after a rollout baseline", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-rollout-local-ordinal";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-after-rollout",
+      payload: {
+        previous_response_id: "resp-rollout-root",
+        input: [{ id: "proxy-input", role: "user", content: "after rollout" }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-after-rollout",
+      response: {
+        id: "resp-proxy-head",
+        previous_response_id: "resp-rollout-root",
+        output: [{
+          id: "proxy-output",
+          type: "message",
+          role: "assistant",
+          content: "after rollout answer",
+        }],
+      },
+      status: "completed",
+    });
+    const rolloutItem = {
+      stableItemId: "rollout-input-7",
+      nativeId: "rollout-input-7",
+      item: {
+        id: "rollout-input-7",
+        type: "message",
+        role: "user",
+        content: "rollout baseline",
+      },
+    };
+
+    const view = await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+      headResponseId: "resp-proxy-head",
+      async rolloutViewBootstrap() {
+        return {
+          history: {
+            revision: "rollout-local-ordinal-revision",
+            replayableItems: [rolloutItem],
+            observationOnlyItems: [],
+            deferredItems: [],
+            unresolvedCallIds: [],
+            source: "rollout_bootstrap",
+            incomplete: false,
+          },
+          turns: [{
+            turnSeq: 7,
+            turnAbsId: `${sessionId}:t7`,
+            inputItemIds: [rolloutItem.stableItemId],
+            outputItemIds: [],
+          }],
+          semanticComplete: true,
+          reasonCodes: [],
+        };
+      },
+    });
+
+    assert.equal(view.semanticComplete, true);
+    assert.deepEqual(view.reasonCodes, []);
+    assert.deepEqual(view.turns.map((turn) => ({
+      turnSeq: turn.turnSeq,
+      turnAbsId: turn.turnAbsId,
+    })), [
+      { turnSeq: 7, turnAbsId: `${sessionId}:t7` },
+      { turnSeq: 8, turnAbsId: `${sessionId}:t8` },
+    ]);
+    assert.deepEqual(view.turns[1]?.inputItemIds.length, 1);
+    assert.deepEqual(view.turns[1]?.outputItemIds.length, 1);
+  });
+});
+
 test("CDH-04 Effective History Builder marks malformed SSE journals incomplete without dropping valid items", async () => {
   await withTempState(async (stateDir) => {
     await appendCodexRequestJournalEntry({
@@ -433,13 +902,16 @@ test("CDH-04 Effective History Builder marks malformed SSE journals incomplete w
       ),
     });
 
-    const history = await buildCodexEffectiveHistory({
+    const view = await buildCodexEffectiveHistoryView({
       stateDir,
       sessionId: "codex-session-1",
       headResponseId: "resp-malformed",
     });
+    const history = view.history;
 
     assert.equal(history.incomplete, true);
+    assert.equal(view.semanticComplete, false);
+    assert.equal(view.reasonCodes.includes("journal_malformed_stream"), true);
     assert.deepEqual(
       history.replayableItems.map((entry) => entry.item.type ?? entry.item.role),
       ["user", "message"],

--- a/components/adapters/codex/tests/context-history-rollout-bootstrap.test.ts
+++ b/components/adapters/codex/tests/context-history-rollout-bootstrap.test.ts
@@ -12,26 +12,33 @@ function rolloutSnapshot(params?: {
   encrypted?: boolean;
 }): CodexRolloutSnapshot {
   const encrypted = params?.encrypted !== false;
+  const history: CodexRolloutSnapshot["history"] = {
+    revision: "rollout-revision",
+    replayableItems: [
+      {
+        stableItemId: "message-1",
+        item: { type: "message", role: "user", content: "continue" },
+      },
+      ...(encrypted
+        ? [{
+          stableItemId: "compaction-1",
+          item: { type: "compaction", encrypted_content: "opaque" },
+        }]
+        : []),
+    ],
+    observationOnlyItems: [],
+    deferredItems: [],
+    unresolvedCallIds: [],
+    source: "rollout_bootstrap",
+    incomplete: false,
+  };
   return {
-    history: {
-      revision: "rollout-revision",
-      replayableItems: [
-        {
-          stableItemId: "message-1",
-          item: { type: "message", role: "user", content: "continue" },
-        },
-        ...(encrypted
-          ? [{
-            stableItemId: "compaction-1",
-            item: { type: "compaction", encrypted_content: "opaque" },
-          }]
-          : []),
-      ],
-      observationOnlyItems: [],
-      deferredItems: [],
-      unresolvedCallIds: [],
-      source: "rollout_bootstrap",
-      incomplete: false,
+    history,
+    view: {
+      history,
+      turns: [],
+      semanticComplete: false,
+      reasonCodes: ["rollout_compaction_turn_boundary_unavailable"],
     },
     sessionMeta: {
       sessionId: params?.sessionId,
@@ -74,6 +81,8 @@ test("rollout bootstrap accepts matching session and encrypted payload provenanc
 
   assert.equal(result.rejectionReason, undefined);
   assert.equal(result.history?.revision, "rollout-revision");
+  assert.equal(result.view?.history, result.history);
+  assert.deepEqual(result.view?.reasonCodes, ["rollout_compaction_turn_boundary_unavailable"]);
 });
 
 test("rollout bootstrap rejects missing and mismatched session identities", () => {

--- a/components/adapters/codex/tests/context-history-rollout.test.ts
+++ b/components/adapters/codex/tests/context-history-rollout.test.ts
@@ -27,6 +27,10 @@ test("GUA-04 parses the latest compacted rollout baseline and post-baseline item
   assert.equal(history.source, "rollout_bootstrap");
   assert.equal(history.incomplete, false);
   assert.equal(snapshot.compactionBaselineApplied, true);
+  assert.equal(snapshot.view.history, snapshot.history);
+  assert.equal(snapshot.view.semanticComplete, false);
+  assert.deepEqual(snapshot.view.turns, []);
+  assert.deepEqual(snapshot.view.reasonCodes, ["rollout_compaction_turn_boundary_unavailable"]);
   assert.deepEqual(history.unresolvedCallIds, []);
   assert.match(history.revision, /^rev-[0-9a-f]{24}$/);
   assert.deepEqual(
@@ -64,6 +68,74 @@ test("GUA-04 parses the latest compacted rollout baseline and post-baseline item
   );
   assert.equal((await stat(rolloutPath)).mtimeMs, before.mtimeMs);
   assert.equal(await readFile(rolloutPath, "utf8"), beforeText);
+});
+
+test("GUA-04 does not convert Codex UUID turn ids into shared turn sequences", () => {
+  const snapshot = parseCodexRolloutText({
+    text: [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "codex-session-rollout-uuid" },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        payload: { turn_id: "00000000-0000-4000-8000-000000000099" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: { id: "msg-uuid", type: "message", role: "assistant", content: "answer" },
+      }),
+    ].join("\n"),
+  });
+
+  assert.ok(snapshot);
+  assert.deepEqual(snapshot.view.turns, []);
+  assert.equal(snapshot.view.semanticComplete, false);
+  assert.deepEqual(snapshot.view.reasonCodes, ["rollout_turn_boundary_unavailable"]);
+});
+
+test("GUA-04 builds rollout sidecars only from explicit positive turn sequences", () => {
+  const snapshot = parseCodexRolloutText({
+    text: [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "codex-session-rollout-seq" },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        payload: { turn_id: "opaque-host-turn", turn_seq: 7 },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: { id: "call-7", type: "function_call", call_id: "tool-7", name: "run", arguments: "{}" },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        payload: { turn_id: "opaque-host-turn-next", turn_ordinal: 8 },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: { id: "output-8", type: "function_call_output", call_id: "tool-7", output: "done" },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: { id: "user-8", type: "message", role: "user", content: "continue" },
+      }),
+    ].join("\n"),
+  });
+
+  assert.ok(snapshot);
+  assert.equal(snapshot.view.semanticComplete, true);
+  assert.deepEqual(snapshot.view.reasonCodes, []);
+  assert.deepEqual(snapshot.view.turns.map((turn) => ({
+    turnSeq: turn.turnSeq,
+    turnAbsId: turn.turnAbsId,
+    inputCount: turn.inputItemIds.length,
+    outputCount: turn.outputItemIds.length,
+  })), [
+    { turnSeq: 7, turnAbsId: "codex-session-rollout-seq:t7", inputCount: 0, outputCount: 1 },
+    { turnSeq: 8, turnAbsId: "codex-session-rollout-seq:t8", inputCount: 2, outputCount: 0 },
+  ]);
 });
 
 test("GUA-04 isolates malformed lines without discarding valid items", async () => {

--- a/components/adapters/codex/tests/context-rewrite-backend.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-backend.test.ts
@@ -8,10 +8,11 @@ import {
 
 import type { CodexEffectiveHistoryItem, JsonObject } from "../src/context-history/types.js";
 import {
+  buildCodexContextSnapshot,
   codexSharedContextRewriteBackend,
   runCodexSharedGoldenFixture,
   type CodexSharedBackendRequest,
-} from "../src/context-rewrite/index.js";
+} from "../src/index.js";
 
 const SESSION_ID = "codex-shared-backend-session";
 
@@ -80,6 +81,96 @@ function planFor(params: {
     createdAt: "2026-08-09T00:00:00.000Z",
   };
 }
+
+test("Codex canonical snapshot builder matches the shared backend and stays deterministic", async () => {
+  const request = requestFor([
+    message("system", "system", "protected system"),
+    message("developer", "developer", "protected developer"),
+    message("active-user", "user", "keep current work"),
+  ]);
+  request.currentInput = [{ type: "message", role: "user", content: "current request" }];
+  request.taskIdsByItemId = {
+    system: ["task-root"],
+    developer: ["task-root"],
+    "active-user": ["task-active"],
+  };
+  request.activeTaskIds = [" task-active ", "task-active"];
+  request.evictableTaskIds = [" task-completed ", "task-completed"];
+
+  const first = buildCodexContextSnapshot(request);
+  const second = buildCodexContextSnapshot(request);
+  const backend = await codexSharedContextRewriteBackend.readSnapshot({
+    sessionId: SESSION_ID,
+    request,
+  });
+
+  assert.deepEqual(first, second);
+  assert.deepEqual(backend, first);
+  assert.deepEqual(
+    first.items.map((item) => [item.stableId, item.kind, item.role, item.taskIds]),
+    [
+      ["system", "system", "system", ["task-root"]],
+      ["developer", "developer", "developer", ["task-root"]],
+      ["active-user", "user", "user", ["task-active"]],
+    ],
+  );
+  assert.deepEqual(first.adapterMetadata?.currentInput, request.currentInput);
+  assert.notEqual(first.adapterMetadata?.currentInput, request.currentInput);
+  assert.deepEqual(first.adapterMetadata?.activeTaskIds, ["task-active"]);
+  assert.deepEqual(first.adapterMetadata?.evictableTaskIds, ["task-completed"]);
+
+  await assert.rejects(
+    codexSharedContextRewriteBackend.readSnapshot({
+      sessionId: "different-session",
+      request,
+    }),
+    /Codex shared backend session mismatch/,
+  );
+});
+
+test("Codex canonical snapshot preserves history buckets and tool closure metadata", () => {
+  const call: CodexEffectiveHistoryItem = {
+    stableItemId: "old-call",
+    callId: "call-old",
+    item: { type: "function_call", call_id: "call-old", name: "read", arguments: "{}" },
+  };
+  const result: CodexEffectiveHistoryItem = {
+    stableItemId: "old-result",
+    callId: "call-old",
+    item: { type: "function_call_output", call_id: "call-old", output: "old result" },
+  };
+  const deferred = message("deferred-user", "user", "deferred request");
+  const request = requestFor([call, result]);
+  request.effectiveHistory.observationOnlyItems = [
+    message("observation-assistant", "assistant", "observation only"),
+  ];
+  request.effectiveHistory.deferredItems = [deferred];
+
+  const snapshot = buildCodexContextSnapshot(request);
+
+  assert.deepEqual(
+    snapshot.items.map((item) => [item.stableId, item.kind, item.callId]),
+    [
+      ["old-call", "tool_call", "call-old"],
+      ["old-result", "tool_result", "call-old"],
+      ["observation-assistant", "assistant", undefined],
+      ["deferred-user", "user", undefined],
+    ],
+  );
+  assert.deepEqual(snapshot.adapterMetadata?.replayableItemIds, ["old-call", "old-result"]);
+  assert.deepEqual(
+    snapshot.adapterMetadata?.effectiveHistory.observationOnlyItems,
+    request.effectiveHistory.observationOnlyItems,
+  );
+  assert.deepEqual(
+    snapshot.adapterMetadata?.effectiveHistory.deferredItems,
+    request.effectiveHistory.deferredItems,
+  );
+  assert.notEqual(
+    snapshot.adapterMetadata?.effectiveHistory,
+    request.effectiveHistory,
+  );
+});
 
 test("Codex shared backend maps effective history and prepares a standard rebase result", async () => {
   const items: CodexEffectiveHistoryItem[] = [

--- a/components/adapters/codex/tests/context-rewrite-estimator-config.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-estimator-config.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { TaskStateEstimator } from "@lightmem2/eviction";
+import {
+  codexEstimatorDiagnostic,
+  codexEstimatorStatusView,
+  resolveCodexTaskStateEstimator,
+} from "../src/index.js";
+import { normalizeTokenPilotCodexConfig } from "../src/config.js";
+
+const fakeEstimator: TaskStateEstimator = {
+  estimate() {
+    throw new Error("not called by config tests");
+  },
+};
+
+test("resolveCodexTaskStateEstimator defaults to disabled", () => {
+  const resolution = resolveCodexTaskStateEstimator({ env: {} });
+
+  assert.equal(resolution.status, "disabled");
+  assert.equal(resolution.estimator, undefined);
+  assert.deepEqual(resolution.missingFields, []);
+});
+
+test("resolveCodexTaskStateEstimator prefers explicit config over environment", () => {
+  let createdWith: unknown;
+  const resolution = resolveCodexTaskStateEstimator({
+    config: {
+      enabled: true,
+      baseUrl: "https://explicit.example/v1/",
+      apiKey: "explicit-secret",
+      model: "explicit-model",
+      requestTimeoutMs: 2_000,
+      batchTurns: 2,
+      evictionLookaheadTurns: 4,
+    },
+    env: {
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_BASE_URL: "https://env.example/v1",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_API_KEY: "env-secret",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_MODEL: "env-model",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_BATCH_TURNS: "99",
+    },
+    createEstimator(config) {
+      createdWith = config;
+      return fakeEstimator;
+    },
+  });
+
+  assert.equal(resolution.status, "ready");
+  assert.equal(resolution.config.baseUrl, "https://explicit.example/v1");
+  assert.equal(resolution.config.apiKey, "explicit-secret");
+  assert.equal(resolution.config.model, "explicit-model");
+  assert.equal(resolution.config.batchTurns, 2);
+  assert.equal(createdWith, resolution.config);
+});
+
+test("resolveCodexTaskStateEstimator keeps explicit disable above environment enable", () => {
+  const resolution = resolveCodexTaskStateEstimator({
+    config: { enabled: false },
+    env: {
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_ENABLED: "true",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_BASE_URL: "https://env.example/v1",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_API_KEY: "env-secret",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_MODEL: "env-model",
+    },
+  });
+
+  assert.equal(resolution.status, "disabled");
+  assert.equal(resolution.estimator, undefined);
+});
+
+test("resolveCodexTaskStateEstimator supports LIGHTMEM2 and TOKENPILOT fallback", () => {
+  const resolution = resolveCodexTaskStateEstimator({
+    env: {
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_ENABLED: "true",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_BASE_URL: "https://lightmem.example/v1/",
+      TOKENPILOT_TASK_STATE_ESTIMATOR_BASE_URL: "https://tokenpilot.example/v1",
+      TOKENPILOT_TASK_STATE_ESTIMATOR_API_KEY: "tokenpilot-secret",
+      TOKENPILOT_TASK_STATE_ESTIMATOR_MODEL: "tokenpilot-model",
+      TOKENPILOT_TASK_STATE_ESTIMATOR_TIMEOUT_MS: "8000",
+      TOKENPILOT_TASK_STATE_ESTIMATOR_INPUT_MODE: "completed_summary_plus_active_turns",
+      TOKENPILOT_TASK_STATE_ESTIMATOR_LIFECYCLE_MODE: "decoupled",
+      TOKENPILOT_TASK_STATE_ESTIMATOR_EVIDENCE_MODE: "two_state",
+    },
+    createEstimator: () => fakeEstimator,
+  });
+
+  assert.equal(resolution.status, "ready");
+  assert.equal(resolution.config.baseUrl, "https://lightmem.example/v1");
+  assert.equal(resolution.config.apiKey, "tokenpilot-secret");
+  assert.equal(resolution.config.model, "tokenpilot-model");
+  assert.equal(resolution.config.requestTimeoutMs, 8_000);
+  assert.equal(resolution.config.inputMode, "completed_summary_plus_active_turns");
+  assert.equal(resolution.config.lifecycleMode, "decoupled");
+  assert.equal(resolution.config.evidenceMode, "two_state");
+});
+
+test("resolveCodexTaskStateEstimator honors environment enablement after config normalization", () => {
+  const normalized = normalizeTokenPilotCodexConfig({});
+  const resolution = resolveCodexTaskStateEstimator({
+    config: normalized.taskStateEstimator,
+    env: {
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_ENABLED: "true",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_BASE_URL: "https://normalized.example/v1",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_API_KEY: "normalized-secret",
+      LIGHTMEM2_TASK_STATE_ESTIMATOR_MODEL: "normalized-model",
+    },
+    createEstimator: () => fakeEstimator,
+  });
+
+  assert.equal(normalized.taskStateEstimator.enabled, undefined);
+  assert.equal(resolution.status, "ready");
+  assert.equal(resolution.config.enabled, true);
+  assert.equal(resolution.estimator, fakeEstimator);
+});
+
+test("resolveCodexTaskStateEstimator returns incomplete without constructing", () => {
+  let constructed = false;
+  const resolution = resolveCodexTaskStateEstimator({
+    config: {
+      enabled: true,
+      baseUrl: "https://estimator.example/v1",
+    },
+    env: {},
+    createEstimator: () => {
+      constructed = true;
+      return fakeEstimator;
+    },
+  });
+
+  assert.equal(resolution.status, "incomplete");
+  assert.deepEqual(resolution.missingFields, ["apiKey", "model"]);
+  assert.equal(constructed, false);
+});
+
+test("resolveCodexTaskStateEstimator converts constructor errors to a safe reason", () => {
+  const resolution = resolveCodexTaskStateEstimator({
+    config: {
+      enabled: true,
+      baseUrl: "https://estimator.example/v1",
+      apiKey: "secret-never-report",
+      model: "estimator-model",
+    },
+    env: {},
+    createEstimator: () => {
+      throw new Error("Authorization: Bearer secret-never-report");
+    },
+  });
+
+  assert.equal(resolution.status, "incomplete");
+  assert.equal(resolution.reasonCode, "estimator_construction_failed");
+  assert.doesNotMatch(JSON.stringify(codexEstimatorDiagnostic(resolution)), /secret-never-report|Authorization/i);
+  assert.deepEqual(Object.keys(codexEstimatorStatusView(resolution)).sort(), [
+    "apiKeyConfigured",
+    "baseUrlConfigured",
+    "batchTurns",
+    "evictionLookaheadTurns",
+    "model",
+    "requestTimeoutMs",
+    "status",
+  ]);
+});

--- a/components/adapters/codex/tests/context-rewrite-semantic-mapping.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-semantic-mapping.test.ts
@@ -1,0 +1,632 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import type {
+  CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryReasonCode,
+  CodexEffectiveHistoryView,
+  JsonObject,
+} from "../src/context-history/index.js";
+import {
+  appendCodexRequestJournalEntry,
+  appendCodexResponseJournalEntry,
+  buildCodexEffectiveHistoryView,
+  parseCodexRolloutText,
+} from "../src/context-history/index.js";
+import { buildCodexRawSemanticTurns } from "../src/index.js";
+
+const SESSION_ID = "codex-semantic-session";
+
+function effective(stableItemId: string, item: JsonObject): CodexEffectiveHistoryItem {
+  return { stableItemId, item };
+}
+
+function view(params: {
+  items: CodexEffectiveHistoryItem[];
+  turns: Array<{ turnSeq: number; inputItemIds?: string[]; outputItemIds?: string[] }>;
+  semanticComplete?: boolean;
+  reasonCodes?: CodexEffectiveHistoryReasonCode[];
+  deferredItems?: CodexEffectiveHistoryItem[];
+}): CodexEffectiveHistoryView {
+  return {
+    history: {
+      revision: "semantic-revision",
+      replayableItems: params.items,
+      observationOnlyItems: [],
+      deferredItems: params.deferredItems ?? [],
+      unresolvedCallIds: [],
+      source: "proxy_journal",
+      incomplete: params.semanticComplete === false,
+    },
+    turns: params.turns.map((turn) => ({
+      turnSeq: turn.turnSeq,
+      turnAbsId: `${SESSION_ID}:t${turn.turnSeq}`,
+      inputItemIds: turn.inputItemIds ?? [],
+      outputItemIds: turn.outputItemIds ?? [],
+    })),
+    semanticComplete: params.semanticComplete ?? true,
+    reasonCodes: params.reasonCodes ?? [],
+  };
+}
+
+test("semantic mapping preserves deterministic multi-turn user and assistant text order", () => {
+  const source = view({
+    items: [
+      effective("u1", { type: "message", role: "user", content: "first user" }),
+      effective("a1", {
+        type: "message",
+        role: "assistant",
+        content: [
+          { type: "output_text", text: "first answer" },
+          { type: "text", text: "second answer part" },
+        ],
+      }),
+      effective("u2", {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "second user" }],
+      }),
+      effective("a2", { type: "message", role: "assistant", content: "final answer" }),
+    ],
+    turns: [
+      { turnSeq: 2, inputItemIds: ["u2"], outputItemIds: ["a2"] },
+      { turnSeq: 1, inputItemIds: ["u1"], outputItemIds: ["a1"] },
+    ],
+  });
+
+  const first = buildCodexRawSemanticTurns(source);
+  const restarted = buildCodexRawSemanticTurns(structuredClone(source));
+
+  assert.equal(first.complete, true);
+  assert.deepEqual(first.reasonCodes, []);
+  assert.deepEqual(first.turns.map((turn) => turn.turnSeq), [1, 2]);
+  assert.deepEqual(first.turns[0]!.messages.map(({ role, text }) => ({ role, text })), [
+    { role: "user", text: "first user" },
+    { role: "assistant", text: "first answer" },
+    { role: "assistant", text: "second answer part" },
+  ]);
+  assert.equal(first.turns[0]!.messages[0]!.anchor.turnAbsId, `${SESSION_ID}:t1`);
+  assert.deepEqual(first, restarted);
+});
+
+test("semantic mapping closes function calls and results on the original call turn", () => {
+  const source = view({
+    items: [
+      effective("call", {
+        type: "function_call",
+        call_id: "call-1",
+        name: "run_tests",
+        arguments: "{\"scope\":\"unit\"}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "all tests passed",
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+    ],
+  });
+
+  const mapped = buildCodexRawSemanticTurns(source);
+
+  assert.equal(mapped.complete, true);
+  assert.equal(mapped.turns[0]!.toolCalls[0]!.toolCallId, "call-1");
+  assert.equal(mapped.turns[0]!.toolCalls[0]!.argumentsText, "{\"scope\":\"unit\"}");
+  assert.equal(mapped.turns[0]!.toolResults[0]!.fullText, "all tests passed");
+  assert.equal(mapped.turns[0]!.toolResults[0]!.anchor.turnSeq, 1);
+  assert.deepEqual(mapped.turns[1]!.toolResults, []);
+});
+
+test("semantic mapping preserves the original call ID and rejects missing call payload", () => {
+  const originalCallId = " call-with-spaces ";
+  const preserved = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("call", {
+        type: "function_call",
+        call_id: originalCallId,
+        name: "  run  ",
+        arguments: "{}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: originalCallId,
+        output: "done",
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+    ],
+  }));
+  assert.equal(preserved.complete, true);
+  assert.equal(preserved.turns[0]!.toolCalls[0]!.toolCallId, originalCallId);
+  assert.equal(preserved.turns[0]!.toolCalls[0]!.toolName, "run");
+  assert.equal(preserved.turns[0]!.toolResults[0]!.toolCallId, originalCallId);
+
+  const missingPayload = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("call", { type: "custom_tool_call", call_id: "missing", name: "custom" }),
+      effective("result", { type: "custom_tool_call_output", call_id: "missing", output: "done" }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+    ],
+  }));
+  assert.equal(missingPayload.complete, false);
+  assert.deepEqual(missingPayload.reasonCodes, ["semantic_tool_call_invalid"]);
+  assert.deepEqual(missingPayload.turns[0]!.toolCalls, []);
+  assert.deepEqual(missingPayload.turns[0]!.toolResults, []);
+});
+
+test("semantic mapping consumes a real journal effective-history view across restart", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-semantic-mapping-"));
+  const sessionId = "codex-semantic-journal-session";
+  try {
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      turnOrdinal: 1,
+      payload: {
+        input: [{
+          id: "user-1",
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "run the tests" }],
+        }],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      response: {
+        id: "response-1",
+        output: [{
+          id: "call-1-item",
+          type: "function_call",
+          call_id: "call-1",
+          name: "run_tests",
+          arguments: "{}",
+        }],
+      },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-2",
+      turnOrdinal: 2,
+      payload: {
+        previous_response_id: "response-1",
+        input: [
+          { type: "function_call_output", call_id: "call-1", output: "passed" },
+          { id: "user-2", type: "message", role: "user", content: "summarize" },
+        ],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-2",
+      response: {
+        id: "response-2",
+        previous_response_id: "response-1",
+        output: [{ id: "assistant-2", type: "message", role: "assistant", content: "done" }],
+      },
+      status: "completed",
+    });
+
+    const first = buildCodexRawSemanticTurns(await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+    }));
+    const restarted = buildCodexRawSemanticTurns(await buildCodexEffectiveHistoryView({
+      stateDir,
+      sessionId,
+    }));
+
+    assert.equal(first.complete, true);
+    assert.deepEqual(first, restarted);
+    assert.deepEqual(first.turns.map((turn) => turn.turnSeq), [1, 2]);
+    assert.deepEqual(first.turns[0]!.messages.map((entry) => entry.text), ["run the tests"]);
+    assert.deepEqual(first.turns[0]!.toolCalls.map((entry) => entry.toolCallId), ["call-1"]);
+    assert.deepEqual(first.turns[0]!.toolResults.map((entry) => entry.toolCallId), ["call-1"]);
+    assert.deepEqual(first.turns[1]!.messages.map((entry) => entry.text), ["summarize", "done"]);
+    assert.deepEqual(first.turns[1]!.toolResults, []);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("semantic mapping closes custom tool calls without treating input as a user message", () => {
+  const source = view({
+    items: [
+      effective("custom-call", {
+        type: "custom_tool_call",
+        call_id: "custom-1",
+        name: "apply_patch",
+        input: "*** Begin Patch",
+      }),
+      effective("custom-result", {
+        type: "custom_tool_call_output",
+        call_id: "custom-1",
+        output: [{ type: "output_text", text: "Done!" }],
+      }),
+    ],
+    turns: [
+      { turnSeq: 4, outputItemIds: ["custom-call"] },
+      { turnSeq: 5, inputItemIds: ["custom-result"] },
+    ],
+  });
+
+  const mapped = buildCodexRawSemanticTurns(source);
+
+  assert.equal(mapped.complete, true);
+  assert.deepEqual(mapped.turns[0]!.messages, []);
+  assert.equal(mapped.turns[0]!.toolCalls[0]!.argumentsSummary, "*** Begin Patch");
+  assert.equal(mapped.turns[0]!.toolResults[0]!.summary, "Done!");
+});
+
+test("semantic mapping preserves independent call and result item order", () => {
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("call-1", { type: "function_call", call_id: "one", name: "one", arguments: "{}" }),
+      effective("call-2", { type: "function_call", call_id: "two", name: "two", arguments: "{}" }),
+      effective("result-2", { type: "function_call_output", call_id: "two", output: "two done" }),
+      effective("result-1", { type: "function_call_output", call_id: "one", output: "one done" }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call-1", "call-2"] },
+      { turnSeq: 2, inputItemIds: ["result-2", "result-1"] },
+    ],
+  }));
+
+  assert.equal(mapped.complete, true);
+  assert.deepEqual(mapped.turns[0]!.toolCalls.map((entry) => entry.toolCallId), ["one", "two"]);
+  assert.deepEqual(mapped.turns[0]!.toolResults.map((entry) => entry.toolCallId), ["two", "one"]);
+});
+
+test("semantic mapping does not disguise system or developer instructions", () => {
+  const source = view({
+    items: [
+      effective("system", { type: "message", role: "system", content: "protected system" }),
+      effective("developer", {
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: "protected developer" }],
+      }),
+      effective("user", { type: "message", role: "user", content: "visible user" }),
+    ],
+    turns: [{ turnSeq: 1, inputItemIds: ["system", "developer", "user"] }],
+  });
+
+  const mapped = buildCodexRawSemanticTurns(source);
+
+  assert.equal(mapped.complete, true);
+  assert.deepEqual(mapped.turns[0]!.messages.map(({ role, text }) => ({ role, text })), [
+    { role: "user", text: "visible user" },
+  ]);
+  assert.doesNotMatch(JSON.stringify(mapped), /protected system|protected developer/);
+});
+
+test("semantic mapping never exposes encrypted reasoning or fabricates provider messages", () => {
+  const encrypted = "opaque-encrypted-reasoning-secret";
+  const source = view({
+    items: [
+      effective("reasoning", { type: "reasoning", encrypted_content: encrypted, summary: "private" }),
+      effective("compaction", { type: "compaction", encrypted_content: "opaque-compaction" }),
+      effective("provider", { type: "web_search_call", id: "search-1", status: "completed" }),
+    ],
+    turns: [{ turnSeq: 3, outputItemIds: ["reasoning", "compaction", "provider"] }],
+  });
+
+  const mapped = buildCodexRawSemanticTurns(source);
+  const serialized = JSON.stringify(mapped);
+
+  assert.equal(mapped.complete, true);
+  assert.deepEqual(mapped.turns[0]!.messages, []);
+  assert.deepEqual(mapped.turns[0]!.toolCalls, []);
+  assert.deepEqual(mapped.turns[0]!.toolResults, []);
+  assert.doesNotMatch(serialized, /opaque-encrypted-reasoning-secret|opaque-compaction|private/);
+});
+
+test("semantic mapping accepts trusted rollout turns with observation-only boundary records", () => {
+  const snapshot = parseCodexRolloutText({
+    text: [
+      JSON.stringify({
+        type: "session_meta",
+        payload: { id: "codex-semantic-rollout" },
+      }),
+      JSON.stringify({
+        type: "turn_context",
+        payload: { turn_seq: 7 },
+      }),
+      JSON.stringify({
+        type: "response_item",
+        payload: {
+          id: "assistant-7",
+          type: "message",
+          role: "assistant",
+          content: "trusted rollout answer",
+        },
+      }),
+      JSON.stringify({
+        type: "event_msg",
+        payload: { type: "task_complete", turn_id: "host-turn-7" },
+      }),
+    ].join("\n"),
+  });
+
+  assert.ok(snapshot);
+  assert.equal(snapshot.view.semanticComplete, true);
+  assert.equal(snapshot.view.history.observationOnlyItems.length, 2);
+
+  const mapped = buildCodexRawSemanticTurns(snapshot.view);
+
+  assert.equal(mapped.complete, true);
+  assert.deepEqual(mapped.reasonCodes, []);
+  assert.deepEqual(mapped.turns.map((turn) => turn.turnSeq), [7]);
+  assert.deepEqual(mapped.turns[0]!.messages.map((message) => message.text), [
+    "trusted rollout answer",
+  ]);
+  assert.doesNotMatch(JSON.stringify(mapped), /turn_context|event_msg|host-turn-7/);
+});
+
+test("semantic mapping fails closed instead of dropping unsupported client tool protocols", () => {
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("computer-call", { type: "computer_call", call_id: "computer-1", action: "click" }),
+      effective("computer-result", {
+        type: "computer_call_output",
+        call_id: "computer-1",
+        output: "clicked",
+      }),
+    ],
+    turns: [{ turnSeq: 1, outputItemIds: ["computer-call"], inputItemIds: ["computer-result"] }],
+  }));
+
+  assert.equal(mapped.complete, false);
+  assert.deepEqual(mapped.reasonCodes, ["semantic_item_unsupported"]);
+  assert.deepEqual(mapped.turns[0]!.toolCalls, []);
+  assert.deepEqual(mapped.turns[0]!.toolResults, []);
+});
+
+test("semantic mapping fails closed for partial, ambiguous and mismatched tool closure", () => {
+  const partial = buildCodexRawSemanticTurns(view({
+    items: [effective("call", {
+      type: "function_call",
+      call_id: "partial",
+      name: "read",
+      arguments: "{}",
+    })],
+    turns: [{ turnSeq: 1, outputItemIds: ["call"] }],
+  }));
+  assert.equal(partial.complete, false);
+  assert.equal(partial.reasonCodes.includes("semantic_tool_closure_incomplete"), true);
+
+  const ambiguous = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("call-1", { type: "function_call", call_id: "same", name: "one", arguments: "{}" }),
+      effective("call-2", { type: "function_call", call_id: "same", name: "two", arguments: "{}" }),
+      effective("result", { type: "function_call_output", call_id: "same", output: "done" }),
+    ],
+    turns: [{ turnSeq: 1, outputItemIds: ["call-1", "call-2"], inputItemIds: ["result"] }],
+  }));
+  assert.equal(ambiguous.complete, false);
+  assert.equal(ambiguous.reasonCodes.includes("semantic_tool_closure_ambiguous"), true);
+
+  const mismatch = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("call", { type: "custom_tool_call", call_id: "mixed", name: "custom", input: "go" }),
+      effective("result", { type: "function_call_output", call_id: "mixed", output: "done" }),
+    ],
+    turns: [{ turnSeq: 1, outputItemIds: ["call"], inputItemIds: ["result"] }],
+  }));
+  assert.equal(mismatch.complete, false);
+  assert.equal(mismatch.reasonCodes.includes("semantic_tool_protocol_mismatch"), true);
+});
+
+test("semantic mapping rejects a tool result that precedes its call", () => {
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("result", { type: "function_call_output", call_id: "late", output: "too early" }),
+      effective("call", { type: "function_call", call_id: "late", name: "run", arguments: "{}" }),
+    ],
+    turns: [
+      { turnSeq: 1, inputItemIds: ["result"] },
+      { turnSeq: 2, outputItemIds: ["call"] },
+    ],
+  }));
+
+  assert.equal(mapped.complete, false);
+  assert.deepEqual(mapped.reasonCodes, ["semantic_tool_result_precedes_call"]);
+  assert.deepEqual(mapped.turns[1]!.toolCalls, []);
+  assert.deepEqual(mapped.turns[1]!.toolResults, []);
+});
+
+test("semantic mapping propagates incomplete history and rejects unknown attribution", () => {
+  const incomplete = buildCodexRawSemanticTurns(view({
+    items: [effective("known", { type: "message", role: "user", content: "known" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["missing"] }],
+    semanticComplete: false,
+    reasonCodes: ["journal_turn_attribution_incomplete"],
+  }));
+
+  assert.equal(incomplete.complete, false);
+  assert.deepEqual(incomplete.reasonCodes, [
+    "journal_turn_attribution_incomplete",
+    "semantic_source_incomplete",
+    "semantic_item_attribution_unknown",
+  ]);
+});
+
+test("semantic mapping fails closed for inconsistent deferred source history", () => {
+  const deferred = effective("deferred", { type: "future_provider_item", payload: "opaque" });
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [],
+    deferredItems: [deferred],
+    turns: [{ turnSeq: 1, outputItemIds: ["deferred"] }],
+  }));
+
+  assert.equal(mapped.complete, false);
+  assert.deepEqual(mapped.reasonCodes, [
+    "semantic_source_incomplete",
+    "semantic_item_unsupported",
+  ]);
+  assert.deepEqual(mapped.turns[0]!.messages, []);
+});
+
+test("semantic mapping rejects arbitrary nested provider payloads as message text", () => {
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [effective("message", {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "provider_payload", nested: { text: "must not leak" } }],
+    })],
+    turns: [{ turnSeq: 1, outputItemIds: ["message"] }],
+  }));
+
+  assert.equal(mapped.complete, false);
+  assert.equal(mapped.reasonCodes.includes("semantic_message_content_unsupported"), true);
+  assert.deepEqual(mapped.turns[0]!.messages, []);
+  assert.doesNotMatch(JSON.stringify(mapped), /must not leak/);
+});
+
+test("semantic mapping requires explicit safe types for content array parts", () => {
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [effective("message", {
+      type: "message",
+      role: "user",
+      content: ["untyped array text", { type: "input_text", text: "typed text" }],
+    })],
+    turns: [{ turnSeq: 1, inputItemIds: ["message"] }],
+  }));
+
+  assert.equal(mapped.complete, false);
+  assert.deepEqual(mapped.reasonCodes, ["semantic_message_content_unsupported"]);
+  assert.deepEqual(mapped.turns[0]!.messages.map((entry) => entry.text), ["typed text"]);
+  assert.doesNotMatch(JSON.stringify(mapped), /untyped array text/);
+});
+
+test("semantic mapping fails closed on invalid turn identity and duplicate turn sequences", () => {
+  const invalid = view({
+    items: [effective("user", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+  });
+  invalid.turns[0]!.turnAbsId = `${SESSION_ID}:t2`;
+
+  const invalidMapped = buildCodexRawSemanticTurns(invalid);
+  assert.equal(invalidMapped.complete, false);
+  assert.deepEqual(invalidMapped.reasonCodes, [
+    "semantic_turn_identity_invalid",
+    "semantic_item_attribution_unknown",
+  ]);
+  assert.deepEqual(invalidMapped.turns, []);
+
+  const duplicate = view({
+    items: [
+      effective("user-1", { type: "message", role: "user", content: "first" }),
+      effective("user-2", { type: "message", role: "user", content: "second" }),
+    ],
+    turns: [
+      { turnSeq: 1, inputItemIds: ["user-1"] },
+      { turnSeq: 1, inputItemIds: ["user-2"] },
+    ],
+  });
+
+  const duplicateMapped = buildCodexRawSemanticTurns(duplicate);
+  assert.equal(duplicateMapped.complete, false);
+  assert.deepEqual(duplicateMapped.reasonCodes, [
+    "semantic_turn_sequence_duplicate",
+    "semantic_item_attribution_unknown",
+  ]);
+  assert.deepEqual(duplicateMapped.turns[0]!.messages.map((entry) => entry.text), ["first"]);
+});
+
+test("semantic mapping fails closed on duplicate stable IDs and repeated attribution", () => {
+  const duplicateStableId = view({
+    items: [
+      effective("duplicate", { type: "message", role: "user", content: "first" }),
+      effective("duplicate", { type: "message", role: "user", content: "second" }),
+    ],
+    turns: [{ turnSeq: 1, inputItemIds: ["duplicate"] }],
+  });
+  const duplicateMapped = buildCodexRawSemanticTurns(duplicateStableId);
+  assert.equal(duplicateMapped.complete, false);
+  assert.deepEqual(duplicateMapped.reasonCodes, ["semantic_item_attribution_ambiguous"]);
+  assert.deepEqual(duplicateMapped.turns[0]!.messages.map((entry) => entry.text), ["first"]);
+
+  const repeatedAttribution = view({
+    items: [effective("shared", { type: "message", role: "user", content: "shared" })],
+    turns: [
+      { turnSeq: 1, inputItemIds: ["shared"] },
+      { turnSeq: 2, inputItemIds: ["shared"] },
+    ],
+  });
+  const repeatedMapped = buildCodexRawSemanticTurns(repeatedAttribution);
+  assert.equal(repeatedMapped.complete, false);
+  assert.deepEqual(repeatedMapped.reasonCodes, ["semantic_item_attribution_ambiguous"]);
+  assert.deepEqual(repeatedMapped.turns[0]!.messages.map((entry) => entry.text), ["shared"]);
+  assert.deepEqual(repeatedMapped.turns[1]!.messages, []);
+});
+
+test("semantic mapping rejects non-string tool payloads without stringifying provider data", () => {
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("call", {
+        type: "function_call",
+        call_id: "unsafe",
+        name: "unsafe_tool",
+        arguments: { secret: "argument must not leak" },
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "unsafe",
+        output: { secret: "result must not leak" },
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+    ],
+  }));
+
+  assert.equal(mapped.complete, false);
+  assert.equal(mapped.reasonCodes.includes("semantic_tool_call_invalid"), true);
+  assert.doesNotMatch(JSON.stringify(mapped), /argument must not leak|result must not leak/);
+});
+
+test("semantic mapping bounds summaries while retaining raw result only in fullText", () => {
+  const longArguments = "a".repeat(500);
+  const longResult = "r".repeat(900);
+  const mapped = buildCodexRawSemanticTurns(view({
+    items: [
+      effective("call", {
+        type: "function_call",
+        call_id: "long",
+        name: "long_tool",
+        arguments: longArguments,
+      }),
+      effective("result", { type: "function_call_output", call_id: "long", output: longResult }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+    ],
+  }));
+
+  assert.equal(mapped.complete, true);
+  assert.equal(mapped.turns[0]!.toolCalls[0]!.argumentsSummary.length, 403);
+  assert.equal(mapped.turns[0]!.toolResults[0]!.summary.length, 803);
+  assert.equal(mapped.turns[0]!.toolResults[0]!.fullText, longResult);
+});

--- a/components/adapters/codex/tests/doctor.test.ts
+++ b/components/adapters/codex/tests/doctor.test.ts
@@ -1,13 +1,21 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import test from "node:test";
 import { appendFile, mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createServer } from "node:net";
 import { createServer as createHttpServer } from "node:http";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import { normalizeTokenPilotCodexConfig } from "../src/config.js";
-import { formatCodexDoctorReport, inspectCodexDoctor } from "../src/doctor.js";
+import {
+  codexMcpServerDiagnostic,
+  codexProviderDiagnostic,
+  formatCodexDoctorReport,
+  inspectCodexDoctor,
+} from "../src/doctor.js";
 import {
   appendCodexRebaseCapability,
   CODEX_REBASE_API_VERSION,
@@ -35,6 +43,8 @@ async function reserveUnusedPort(): Promise<number> {
     });
   });
 }
+
+const execFileAsync = promisify(execFile);
 
 test("inspectCodexDoctor reports missing provider and hooks honestly", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-doctor-"));
@@ -69,6 +79,207 @@ test("inspectCodexDoctor reports missing provider and hooks honestly", async () 
     assert.equal(report.mcpStateDirMatches, false);
     assert.equal(report.mcpCommandMatches, false);
     assert.equal(report.mcpArgsMatch, false);
+    assert.equal(report.taskStateEstimator?.status, "disabled");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("inspectCodexDoctor reports incomplete estimator config without leaking secrets", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-doctor-estimator-"));
+  try {
+    const proxyPort = await reserveUnusedPort();
+    const codexConfigPath = join(dir, "config.toml");
+    const hooksConfigPath = join(dir, "hooks.json");
+    const tokenPilotConfigPath = join(dir, "tokenpilot.json");
+    await writeFile(codexConfigPath, "model_provider = \"OpenAI\"\n", "utf8");
+    await writeFile(hooksConfigPath, JSON.stringify({ hooks: {} }), "utf8");
+
+    const report = await inspectCodexDoctor({
+      config: normalizeTokenPilotCodexConfig({
+        stateDir: join(dir, "state"),
+        proxyPort,
+        taskStateEstimator: {
+          enabled: true,
+          apiKey: "doctor-secret-never-report",
+          model: "estimator-model",
+        },
+      }),
+      configPath: codexConfigPath,
+      hooksConfigPath,
+      tokenPilotConfigPath,
+    });
+    const text = formatCodexDoctorReport(report);
+
+    assert.equal(report.taskStateEstimator?.status, "incomplete");
+    assert.deepEqual(report.taskStateEstimator?.missingFields, ["baseUrl"]);
+    assert.match(text, /task-state estimator status: incomplete/);
+    assert.match(text, /missing fields: baseUrl/);
+    assert.match(text, /runtime remains disabled/);
+    assert.doesNotMatch(text, /doctor-secret-never-report|Authorization/i);
+    assert.doesNotMatch(JSON.stringify(report), /doctor-secret-never-report/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("doctor diagnostics summarize provider and MCP config without secret values", () => {
+  const provider = codexProviderDiagnostic({
+    name: "provider-name",
+    baseUrl: "https://user:provider-password@example.com/v1?api_key=query-secret",
+    apiKey: "provider-api-secret",
+    wireApi: "responses",
+    requiresOpenAIAuth: true,
+  });
+  const mcp = codexMcpServerDiagnostic({
+    command: "node",
+    args: ["server.js", "--token", "mcp-argument-secret"],
+    env: {
+      TOKENPILOT_STATE_DIR: "/tmp/state",
+      SERVICE_API_KEY: "mcp-env-secret",
+    },
+    startupTimeoutSec: 90,
+  });
+  const serialized = JSON.stringify({ provider, mcp });
+
+  assert.deepEqual(provider, {
+    configured: true,
+    name: "provider-name",
+    baseUrlConfigured: true,
+    apiKeyConfigured: true,
+    wireApi: "responses",
+    requiresOpenAIAuth: true,
+  });
+  assert.deepEqual(mcp, {
+    configured: true,
+    commandConfigured: true,
+    argsCount: 3,
+    envKeys: ["SERVICE_API_KEY", "TOKENPILOT_STATE_DIR"],
+    startupTimeoutSec: 90,
+  });
+  assert.doesNotMatch(serialized, /provider-password|query-secret|provider-api-secret|mcp-argument-secret|mcp-env-secret/);
+
+  const unsafeName = codexProviderDiagnostic({
+    name: "Authorization Bearer provider-name-secret",
+    baseUrl: "https://example.com/v1",
+  });
+  assert.equal(unsafeName.name, "(configured but not safely displayable)");
+  assert.doesNotMatch(JSON.stringify(unsafeName), /Authorization|Bearer|provider-name-secret/i);
+});
+
+test("formatCodexDoctorReport redacts credentials embedded in diagnostic URLs", () => {
+  const text = formatCodexDoctorReport({
+    configPath: "/tmp/config.toml",
+    hooksConfigPath: "/tmp/hooks.json",
+    tokenPilotConfigPath: "/tmp/tokenpilot.json",
+    proxyBaseUrl: "http://127.0.0.1:17667/v1",
+    expectedHookCommand: "node hooks-handler.js",
+    expectedMcpCommand: process.execPath,
+    expectedMcpArgs: ["/tmp/server.js"],
+    expectedMcpStartupTimeoutSec: 90,
+    adapterEnabled: false,
+    providerInstalled: true,
+    providerActive: true,
+    providerIntercepted: false,
+    hooksInstalled: true,
+    hooksComplete: true,
+    hooksMatchExpectedCommand: true,
+    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse", "Stop"],
+    missingHookEvents: [],
+    daemonRunning: false,
+    proxyHealthy: false,
+    stateDir: "/tmp/state",
+    upstreamLoopDetected: false,
+    upstreamBaseUrl: "https://user:url-password@example.com/v1?api_key=url-query-secret",
+    mcpInstalled: true,
+    mcpStateDirMatches: true,
+    mcpCommandMatches: true,
+    mcpArgsMatch: true,
+    mcpStartupTimeoutSecMatches: true,
+    coreRuntimeHealthy: false,
+    recoveryMcpHealthy: true,
+    degradedMode: false,
+  });
+
+  assert.match(text, /upstream base URL: https:\/\/example\.com\/v1/);
+  assert.doesNotMatch(text, /url-password|url-query-secret/);
+});
+
+test("doctor-codex script exposes estimator diagnostics without serializing configured secrets", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-doctor-script-"));
+  try {
+    const proxyPort = await reserveUnusedPort();
+    const stateDir = join(dir, "state");
+    const codexConfigPath = join(dir, "config.toml");
+    const hooksConfigPath = join(dir, "hooks.json");
+    const tokenPilotConfigPath = join(dir, "tokenpilot.json");
+    await writeFile(codexConfigPath, [
+      'model_provider = "tokenpilot"',
+      "",
+      "[model_providers.tokenpilot]",
+      `base_url = ${JSON.stringify(`http://127.0.0.1:${proxyPort}/v1`)}`,
+      'api_key = "tokenpilot-provider-secret"',
+      'wire_api = "responses"',
+      "",
+      "[model_providers.OpenAI]",
+      'base_url = "https://user:url-password@example.com/v1?api_key=query-secret"',
+      'api_key = "upstream-provider-secret"',
+      'wire_api = "responses"',
+      "",
+      "[mcp_servers.tokenpilot_memory_fault_recover]",
+      `command = ${JSON.stringify(process.execPath)}`,
+      'args = ["server.js", "--token", "mcp-argument-secret"]',
+      "startup_timeout_sec = 90",
+      "",
+      "[mcp_servers.tokenpilot_memory_fault_recover.env]",
+      'SERVICE_API_KEY = "mcp-env-secret"',
+      `TOKENPILOT_STATE_DIR = ${JSON.stringify(stateDir)}`,
+      "",
+    ].join("\n"), "utf8");
+    await writeFile(hooksConfigPath, JSON.stringify({ hooks: {} }), "utf8");
+    await writeFile(tokenPilotConfigPath, JSON.stringify({
+      stateDir,
+      proxyPort,
+      providerName: "tokenpilot",
+      upstreamProvider: "OpenAI",
+      taskStateEstimator: {
+        enabled: true,
+        apiKey: "estimator-script-secret",
+        model: "estimator-model",
+      },
+    }), "utf8");
+
+    const adapterDir = fileURLToPath(new URL("..", import.meta.url));
+    const { stdout, stderr } = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", "scripts/doctor-codex.ts"],
+      {
+        cwd: adapterDir,
+        env: {
+          ...process.env,
+          CODEX_CONFIG_PATH: codexConfigPath,
+          CODEX_HOOKS_CONFIG_PATH: hooksConfigPath,
+          TOKENPILOT_CODEX_CONFIG: tokenPilotConfigPath,
+          LIGHTMEM2_TASK_STATE_ESTIMATOR_ENABLED: "",
+          LIGHTMEM2_TASK_STATE_ESTIMATOR_API_KEY: "",
+          TOKENPILOT_TASK_STATE_ESTIMATOR_ENABLED: "",
+          TOKENPILOT_TASK_STATE_ESTIMATOR_API_KEY: "",
+        },
+      },
+    );
+    const output = JSON.parse(stdout) as Record<string, any>;
+    const serialized = `${stdout}\n${stderr}`;
+
+    assert.equal(output.taskStateEstimator.status, "incomplete");
+    assert.deepEqual(output.taskStateEstimator.missingFields, ["baseUrl"]);
+    assert.equal(output.tokenpilotProvider.apiKeyConfigured, true);
+    assert.equal(output.upstream.apiKeyConfigured, true);
+    assert.equal(output.recoveryMcp.argsCount, 3);
+    assert.deepEqual(output.recoveryMcp.envKeys, ["SERVICE_API_KEY", "TOKENPILOT_STATE_DIR"]);
+    assert.doesNotMatch(
+      serialized,
+      /tokenpilot-provider-secret|url-password|query-secret|upstream-provider-secret|mcp-argument-secret|mcp-env-secret|estimator-script-secret|Authorization/i,
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,12 @@ importers:
       '@lightmem2/artifact-store':
         specifier: workspace:*
         version: link:../../packages/foundation/artifact-store
+      '@lightmem2/eviction':
+        specifier: workspace:*
+        version: link:../../packages/features/eviction
+      '@lightmem2/history':
+        specifier: workspace:*
+        version: link:../../packages/foundation/history
       '@lightmem2/host-adapter':
         specifier: workspace:*
         version: link:../../packages/foundation/host-adapter


### PR DESCRIPTION
## Summary

- add formal Codex task-state estimator configuration and environment resolution
- build deterministic effective-history views from proxy journals and Codex rollout files
- map effective history into estimator semantic turns with fail-closed validation
- expose estimator readiness and history diagnostics through the Codex doctor/CLI surface
- add canonical context-rewrite snapshot support and comprehensive regression coverage

## Why

Codex needs a trustworthy history bridge before estimator-driven eviction can be connected to the shared lifecycle planner. Raw proxy and rollout records must be normalized into complete, ordered semantic turns without leaking observation-only records or ambiguous response branches.

## Notable fixes

- accept trusted rollout turns containing observation-only boundary records
- align fresh proxy-local turn ordinals after an existing rollout baseline
- preserve environment-based estimator enablement when normalized config omits `enabled`

## Scope

This PR provides the PR-B foundation only. It does not invoke the estimator or shared lifecycle planner from the production proxy runtime, and it does not enable automatic context rebase. Those integrations remain follow-up work.

## Validation

- Codex tests: 322/322 passed with serial concurrency
- TypeScript typecheck passed
- Codex production build passed
- `git diff --cached --check` passed
- personal `components/adapters/codex/work/` evidence was excluded