### PR TITLE
feat(codex): wire shared lifecycle planner into proxy runtime

### DIFF
--- a/components/adapters/codex/src/context-rewrite/fallback.ts
+++ b/components/adapters/codex/src/context-rewrite/fallback.ts
@@ -9,6 +9,7 @@ import type {
   CodexRebaseCooldownNotice,
   CodexRebaseCooldownStoreParams,
   CodexRebaseEpochStoreParams,
+  CodexRebaseExecutionGuard,
   CodexUpstreamResponse,
   CodexUpstreamSender,
   JsonObject,
@@ -131,6 +132,8 @@ export async function executeCodexRebaseWithFallback(params: {
   epochStore?: CodexRebaseEpochStoreParams;
   cooldownStore?: CodexRebaseCooldownStoreParams;
   capabilityStore?: CodexRebaseCapabilityStoreParams;
+  /** Runs after the session lock is acquired and before an epoch is created. */
+  executionGuard?: CodexRebaseExecutionGuard;
 }): Promise<CodexRebaseFallbackResult> {
   let rebaseResponse: CodexUpstreamResponse | undefined;
   let epoch: CodexRebaseEpoch | undefined;
@@ -144,14 +147,19 @@ export async function executeCodexRebaseWithFallback(params: {
 
   async function sendOriginalBypass(
     notice?: CodexRebaseCapabilityNotice,
+    reason?: string,
   ): Promise<CodexRebaseFallbackResult> {
     const response = await params.sendUpstream(cloneJson(params.originalPayload));
     return {
       response,
       outcome: isSuccessfulResponse(response) ? "bypassed" : "failed",
-      reason: notice?.reason ?? "rewrite_guard_busy",
+      reason: notice?.reason ?? reason ?? "rewrite_guard_busy",
       capability: notice,
     };
+  }
+
+  if (params.executionGuard && !params.epochStore) {
+    return sendOriginalBypass(undefined, "rewrite_execution_guard_unavailable");
   }
 
   if (params.capabilityStore && rebaseItems.length > 0) {
@@ -365,33 +373,54 @@ export async function executeCodexRebaseWithFallback(params: {
   let sessionLock: CodexRebaseSessionLock | undefined;
 
   try {
+    let preflightBypassReason: string | undefined;
     if (params.epochStore) {
       try {
         sessionLock = await acquireCodexRebaseSessionLock({
           stateDir: params.epochStore.stateDir,
           sessionId: params.sessionId,
         });
-        if (!sessionLock) return await sendOriginalBypass();
-        const activeEpoch = (await readPendingCodexRebaseEpochs({
-          stateDir: params.epochStore.stateDir,
-          sessionId: params.sessionId,
-        })).find((entry) => entry.epochId !== params.epochId);
-        if (activeEpoch) {
-          return await sendOriginalBypass();
-        }
+        if (!sessionLock) {
+          preflightBypassReason = "rewrite_guard_busy";
+        } else {
+          const activeEpoch = (await readPendingCodexRebaseEpochs({
+            stateDir: params.epochStore.stateDir,
+            sessionId: params.sessionId,
+          })).find((entry) => entry.epochId !== params.epochId);
+          if (activeEpoch) {
+            preflightBypassReason = "rewrite_guard_busy";
+          }
 
-        epoch = await appendPendingCodexRebaseEpoch({
-          stateDir: params.epochStore.stateDir,
-          sessionId: params.sessionId,
-          planId: params.planId,
-          epochId: params.epochId,
-          oldPreviousResponseId: params.epochStore.oldPreviousResponseId,
-          oldRevision: params.epochStore.oldRevision,
-          accounting: params.accounting,
-        });
+          if (!preflightBypassReason && params.executionGuard) {
+            try {
+              const guardDecision = await params.executionGuard();
+              if (!guardDecision.allowed) {
+                preflightBypassReason = guardDecision.reason?.trim()
+                  || "rewrite_execution_guard_rejected";
+              }
+            } catch {
+              preflightBypassReason = "rewrite_execution_guard_error";
+            }
+          }
+
+          if (!preflightBypassReason) {
+            epoch = await appendPendingCodexRebaseEpoch({
+              stateDir: params.epochStore.stateDir,
+              sessionId: params.sessionId,
+              planId: params.planId,
+              epochId: params.epochId,
+              oldPreviousResponseId: params.epochStore.oldPreviousResponseId,
+              oldRevision: params.epochStore.oldRevision,
+              accounting: params.accounting,
+            });
+          }
+        }
       } catch {
         return await sendOriginalWithFallbackOutcome("epoch_store_error");
       }
+    }
+    if (preflightBypassReason) {
+      return await sendOriginalBypass(undefined, preflightBypassReason);
     }
 
     try {

--- a/components/adapters/codex/src/context-rewrite/index.ts
+++ b/components/adapters/codex/src/context-rewrite/index.ts
@@ -1,6 +1,8 @@
 export * from "./types.js";
 export * from "./estimator-config.js";
 export * from "./semantic-mapping.js";
+export * from "./lifecycle-input.js";
+export * from "./lifecycle-runner.js";
 export { applyCodexContextRewrite } from "./disabled.js";
 export { executeCodexRebaseWithFallback } from "./fallback.js";
 export {

--- a/components/adapters/codex/src/context-rewrite/lifecycle-input.ts
+++ b/components/adapters/codex/src/context-rewrite/lifecycle-input.ts
@@ -1,0 +1,536 @@
+import {
+  buildDeltaViewFromRawSemanticSnapshot,
+  type DeltaInputMode,
+  type DeltaTaskSummary,
+  type DeltaView,
+  type HistoryBlock,
+  type RawSemanticSnapshot,
+  type RawSemanticTurnRecord,
+  type SessionTaskRegistry,
+} from "@lightmem2/history";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+
+import { codexReplayPairRef } from "../context-history/replayability.js";
+import type {
+  CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryView,
+  CodexRequestJournalEntry,
+} from "../context-history/types.js";
+import {
+  buildCodexContextSnapshot,
+  type CodexSharedBackendMetadata,
+  type CodexSharedBackendRequest,
+} from "./backend.js";
+import {
+  buildCodexRawSemanticTurns,
+  type CodexRawSemanticReasonCode,
+} from "./semantic-mapping.js";
+
+export type CodexLifecycleInputReasonCode =
+  | CodexRawSemanticReasonCode
+  | "lifecycle_current_request_boundary_untrusted"
+  | "lifecycle_registry_session_mismatch"
+  | "lifecycle_registry_version_invalid"
+  | "lifecycle_registry_watermark_invalid"
+  | "lifecycle_registry_ahead_of_history"
+  | "lifecycle_no_pending_turns"
+  | "lifecycle_snapshot_identity_invalid"
+  | "lifecycle_semantic_source_incomplete"
+  | "lifecycle_tool_pair_target_missing"
+  | "lifecycle_tool_pair_target_ambiguous"
+  | "lifecycle_tool_pair_task_mismatch";
+
+export type CodexLifecycleBackendRequestBase = Omit<
+  CodexSharedBackendRequest,
+  "taskIdsByItemId" | "activeTaskIds" | "evictableTaskIds"
+>;
+
+export type BuildCodexLifecycleBackendRequestParams = {
+  view: CodexEffectiveHistoryView;
+  registry: SessionTaskRegistry;
+  request: CodexLifecycleBackendRequestBase;
+};
+
+export type BuildCodexLifecycleInputParams = {
+  view: CodexEffectiveHistoryView;
+  registry: SessionTaskRegistry;
+  backendRequest: CodexLifecycleBackendRequestBase;
+  expectedCurrentRequest?: Pick<
+    CodexRequestJournalEntry,
+    "requestId" | "sessionId" | "status" | "turnOrdinal"
+  >;
+  currentTaskIds?: readonly string[];
+  closureDeferredTaskIds?: readonly string[];
+  currentActiveTaskHint?: string;
+  inputMode?: DeltaInputMode;
+  completedTaskSummaries?: DeltaTaskSummary[];
+};
+
+export type CodexLifecycleInputDeferred = {
+  status: "deferred";
+  reasonCodes: CodexLifecycleInputReasonCode[];
+};
+
+export type CodexLifecycleInputReady = {
+  status: "ready";
+  reasonCodes: [];
+  committedView: CodexEffectiveHistoryView;
+  rawSemanticTurns: RawSemanticTurnRecord[];
+  rawSemanticSnapshot: RawSemanticSnapshot;
+  delta: DeltaView;
+  pendingTurnCount: number;
+  historyBlocks: HistoryBlock[];
+  stableItemIdsByMessageId: Record<string, string[]>;
+  backendRequest: CodexSharedBackendRequest;
+  snapshot: ModelContextSnapshot<CodexSharedBackendMetadata>;
+  activeTaskIds: string[];
+  currentTaskIds: string[];
+  currentTurnAbsId?: string;
+  closureDeferredTaskIds: string[];
+};
+
+export type CodexLifecycleInputResult =
+  | CodexLifecycleInputDeferred
+  | CodexLifecycleInputReady;
+
+type ToolPairEntry = {
+  entry: CodexEffectiveHistoryItem;
+  kind: "function" | "custom";
+  side: "call" | "output";
+};
+
+function uniqueStrings(values: Iterable<string | undefined>): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const normalized = value?.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function uniqueReasons(
+  values: Iterable<CodexLifecycleInputReasonCode | undefined>,
+): CodexLifecycleInputReasonCode[] {
+  const result: CodexLifecycleInputReasonCode[] = [];
+  const seen = new Set<CodexLifecycleInputReasonCode>();
+  for (const value of values) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function deferred(
+  values: Iterable<CodexLifecycleInputReasonCode | undefined>,
+): CodexLifecycleInputDeferred {
+  return { status: "deferred", reasonCodes: uniqueReasons(values) };
+}
+
+function allEffectiveItems(view: CodexEffectiveHistoryView): CodexEffectiveHistoryItem[] {
+  return [
+    ...view.history.replayableItems,
+    ...view.history.observationOnlyItems,
+    ...view.history.deferredItems,
+  ];
+}
+
+function expectedCurrentRequestTrusted(
+  params: BuildCodexLifecycleInputParams,
+): boolean {
+  const request = params.expectedCurrentRequest;
+  if (!request) return false;
+  const latestCommittedTurn = Math.max(0, ...params.view.turns.map((turn) => turn.turnSeq));
+  return request.requestId.trim().length > 0
+    && request.sessionId === params.backendRequest.sessionId
+    && request.sessionId === params.registry.sessionId
+    && request.status === "pending"
+    && Number.isInteger(request.turnOrdinal)
+    && request.turnOrdinal > latestCommittedTurn;
+}
+
+function committedHeadView(
+  params: BuildCodexLifecycleInputParams,
+): CodexEffectiveHistoryView | CodexLifecycleInputDeferred {
+  const currentPendingReason = "journal_current_request_uncommitted" as const;
+  const hasExpectedPendingBoundary = params.view.reasonCodes.includes(currentPendingReason);
+  if (hasExpectedPendingBoundary && !expectedCurrentRequestTrusted(params)) {
+    return deferred([
+      currentPendingReason,
+      "lifecycle_current_request_boundary_untrusted",
+    ]);
+  }
+
+  const remainingReasons = params.view.reasonCodes.filter(
+    (reason) => reason !== currentPendingReason,
+  );
+  const structuralReasons: CodexLifecycleInputReasonCode[] = [
+    ...(params.view.history.incomplete
+      ? ["history_replay_incomplete" as const]
+      : []),
+    ...(params.view.history.deferredItems.length > 0
+      ? ["history_deferred_items" as const]
+      : []),
+    ...(params.view.history.unresolvedCallIds.length > 0
+      ? ["history_unresolved_tool_calls" as const]
+      : []),
+  ];
+  const structurallyIncomplete = params.view.history.incomplete
+    || params.view.history.deferredItems.length > 0
+    || params.view.history.unresolvedCallIds.length > 0;
+  const unexplainedSemanticIncomplete = !params.view.semanticComplete
+    && !hasExpectedPendingBoundary;
+  if (
+    remainingReasons.length > 0
+    || structurallyIncomplete
+    || unexplainedSemanticIncomplete
+  ) {
+    return deferred([
+      ...remainingReasons,
+      ...structuralReasons,
+      "lifecycle_semantic_source_incomplete",
+    ]);
+  }
+
+  return {
+    ...params.view,
+    semanticComplete: true,
+    reasonCodes: [],
+  };
+}
+
+function stableItemTurnIds(view: CodexEffectiveHistoryView): Map<string, string[]> {
+  const result = new Map<string, string[]>();
+  for (const turn of [...view.turns].sort((left, right) => left.turnSeq - right.turnSeq)) {
+    for (const stableItemId of [...turn.inputItemIds, ...turn.outputItemIds]) {
+      result.set(stableItemId, uniqueStrings([
+        ...(result.get(stableItemId) ?? []),
+        turn.turnAbsId,
+      ]));
+    }
+  }
+  return result;
+}
+
+function taskIdsForStableItem(params: {
+  registry: SessionTaskRegistry;
+  stableItemId: string;
+  turnIdsByStableItemId: ReadonlyMap<string, readonly string[]>;
+}): string[] {
+  return uniqueStrings([
+    ...(params.turnIdsByStableItemId.get(params.stableItemId) ?? [])
+      .flatMap((turnAbsId) => params.registry.turnToTaskIds[turnAbsId] ?? []),
+    ...(params.registry.blockToTaskIds[params.stableItemId] ?? []),
+    ...(params.registry.blockToTaskIds[`history-block:${params.stableItemId}`] ?? []),
+  ]);
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  const normalizedLeft = uniqueStrings(left);
+  const normalizedRight = uniqueStrings(right);
+  return normalizedLeft.length === normalizedRight.length
+    && normalizedLeft.every((value) => normalizedRight.includes(value));
+}
+
+/**
+ * Rebinds the canonical Codex backend request to one registry version. PR-C can
+ * call this again after estimator updates so validation sees the post-update
+ * task ownership without inventing another snapshot or stable-id rule.
+ */
+export function buildCodexLifecycleBackendRequest(
+  params: BuildCodexLifecycleBackendRequestParams,
+): CodexSharedBackendRequest {
+  const turnIdsByStableItemId = stableItemTurnIds(params.view);
+  const taskIdsByItemId: Record<string, string[]> = {};
+  for (const item of allEffectiveItems(params.view)) {
+    const taskIds = taskIdsForStableItem({
+      registry: params.registry,
+      stableItemId: item.stableItemId,
+      turnIdsByStableItemId,
+    });
+    if (taskIds.length > 0) taskIdsByItemId[item.stableItemId] = taskIds;
+  }
+  for (const pairEntries of toolPairsByCallId(params.view).values()) {
+    const calls = pairEntries.filter((entry) => entry.side === "call");
+    const outputs = pairEntries.filter((entry) => entry.side === "output");
+    if (
+      calls.length !== 1
+      || outputs.length !== 1
+      || calls[0]!.kind !== outputs[0]!.kind
+    ) continue;
+
+    const callId = calls[0]!.entry.stableItemId;
+    const outputId = outputs[0]!.entry.stableItemId;
+    const callTaskIds = taskIdsByItemId[callId] ?? [];
+    const outputTaskIds = taskIdsByItemId[outputId] ?? [];
+    if (
+      callTaskIds.length > 0
+      && outputTaskIds.length > 0
+      && !sameStringSet(callTaskIds, outputTaskIds)
+    ) continue;
+
+    // The semantic estimator intentionally anchors a completed pair to the
+    // original call turn. Mirror that ownership onto the later result item so
+    // the shared backend observes one protocol closure after registry update.
+    const pairTaskIds = uniqueStrings([...callTaskIds, ...outputTaskIds]);
+    if (pairTaskIds.length > 0) {
+      taskIdsByItemId[callId] = pairTaskIds;
+      taskIdsByItemId[outputId] = pairTaskIds;
+    }
+  }
+  return {
+    ...params.request,
+    effectiveHistory: params.view.history,
+    taskIdsByItemId,
+    activeTaskIds: uniqueStrings(params.registry.activeTaskIds),
+    evictableTaskIds: uniqueStrings(params.registry.evictableTaskIds),
+  };
+}
+
+function rawSnapshot(
+  sessionId: string,
+  turns: readonly RawSemanticTurnRecord[],
+): RawSemanticSnapshot {
+  return {
+    sessionId,
+    lastTurnSeq: Math.max(0, ...turns.map((turn) => turn.turnSeq)),
+    messages: turns.flatMap((turn) => turn.messages),
+    toolCalls: turns.flatMap((turn) => turn.toolCalls),
+    toolResults: turns.flatMap((turn) => turn.toolResults),
+  };
+}
+
+function toolPairsByCallId(
+  view: CodexEffectiveHistoryView,
+): Map<string, ToolPairEntry[]> {
+  const result = new Map<string, ToolPairEntry[]>();
+  for (const entry of view.history.replayableItems) {
+    const pair = codexReplayPairRef(entry.item);
+    const originalCallId = typeof entry.item.call_id === "string"
+      && entry.item.call_id.trim().length > 0
+      ? entry.item.call_id
+      : undefined;
+    if (
+      !originalCallId
+      || !pair.side
+      || (pair.kind !== "function" && pair.kind !== "custom")
+    ) continue;
+    const entries = result.get(originalCallId) ?? [];
+    entries.push({ entry, kind: pair.kind, side: pair.side });
+    result.set(originalCallId, entries);
+  }
+  return result;
+}
+
+function lifecycleBlocks(params: {
+  view: CodexEffectiveHistoryView;
+  registry: SessionTaskRegistry;
+  turns: readonly RawSemanticTurnRecord[];
+  taskIdsByItemId: Readonly<Record<string, readonly string[]>>;
+}): {
+  historyBlocks: HistoryBlock[];
+  stableItemIdsByMessageId: Record<string, string[]>;
+} | CodexLifecycleInputDeferred {
+  const pairsByCallId = toolPairsByCallId(params.view);
+  const turnIdsByStableItemId = stableItemTurnIds(params.view);
+  const turnsByAbsId = new Map(
+    params.view.turns.map((turn) => [turn.turnAbsId, turn]),
+  );
+  const historyBlocks: HistoryBlock[] = [];
+  const stableItemIdsByMessageId: Record<string, string[]> = {};
+  const claimedSegmentIds = new Set<string>();
+
+  for (const result of params.turns.flatMap((turn) => turn.toolResults)) {
+    const pairs = pairsByCallId.get(result.toolCallId) ?? [];
+    const calls = pairs.filter((entry) => entry.side === "call");
+    const outputs = pairs.filter((entry) => entry.side === "output");
+    if (calls.length === 0 || outputs.length === 0) {
+      return deferred(["lifecycle_tool_pair_target_missing"]);
+    }
+    if (
+      calls.length !== 1
+      || outputs.length !== 1
+      || calls[0]!.kind !== outputs[0]!.kind
+    ) {
+      return deferred(["lifecycle_tool_pair_target_ambiguous"]);
+    }
+
+    const call = calls[0]!;
+    const output = outputs[0]!;
+    const segmentId = output.entry.stableItemId;
+    if (claimedSegmentIds.has(segmentId)) {
+      return deferred(["lifecycle_tool_pair_target_ambiguous"]);
+    }
+    claimedSegmentIds.add(segmentId);
+
+    const callTaskIds = uniqueStrings(
+      params.taskIdsByItemId[call.entry.stableItemId] ?? [],
+    );
+    const outputTaskIds = uniqueStrings(
+      params.taskIdsByItemId[output.entry.stableItemId] ?? [],
+    );
+    if (
+      callTaskIds.length > 0
+      && outputTaskIds.length > 0
+      && !sameStringSet(callTaskIds, outputTaskIds)
+    ) {
+      return deferred(["lifecycle_tool_pair_task_mismatch"]);
+    }
+    const taskIds = uniqueStrings([
+      ...callTaskIds,
+      ...outputTaskIds,
+      ...(params.registry.turnToTaskIds[result.anchor.turnAbsId] ?? []),
+    ]);
+    const turnAbsIds = uniqueStrings([
+      ...(turnIdsByStableItemId.get(call.entry.stableItemId) ?? []),
+      ...(turnIdsByStableItemId.get(output.entry.stableItemId) ?? []),
+      result.anchor.turnAbsId,
+    ]);
+    const turnAnchors = turnAbsIds.map((turnAbsId) => {
+      const turn = turnsByAbsId.get(turnAbsId);
+      return turn
+        ? {
+            sessionId: result.anchor.sessionId,
+            turnAbsId,
+            turnSeq: turn.turnSeq,
+            role: "tool" as const,
+          }
+        : result.anchor;
+    });
+    const charCount = result.fullText.length;
+    historyBlocks.push({
+      blockId: `history-block:${segmentId}`,
+      blockType: "tool_result",
+      lifecycleState: "ACTIVE",
+      segmentIds: [segmentId],
+      text: result.fullText,
+      charCount,
+      approxTokens: Math.max(0, Math.round(charCount / 4)),
+      source: "codex_effective_history",
+      toolName: result.toolName,
+      turnAnchors,
+      turnAbsIds,
+      ...(taskIds.length > 0 ? { taskIds } : {}),
+      metadata: {
+        callId: result.toolCallId,
+        replayPairKind: call.kind,
+      },
+    });
+    stableItemIdsByMessageId[segmentId] = [
+      call.entry.stableItemId,
+      output.entry.stableItemId,
+    ];
+  }
+
+  return { historyBlocks, stableItemIdsByMessageId };
+}
+
+function validSnapshotIdentity(
+  snapshot: ModelContextSnapshot<CodexSharedBackendMetadata>,
+): boolean {
+  const stableIds = snapshot.items.map((item) => item.stableId);
+  return snapshot.schemaVersion === MODEL_CONTEXT_REWRITE_SCHEMA_VERSION
+    && snapshot.hostId.trim().length > 0
+    && snapshot.sessionId.trim().length > 0
+    && snapshot.revision.trim().length > 0
+    && stableIds.length === new Set(stableIds).size
+    && snapshot.items.every(
+      (item) => item.stableId.trim().length > 0
+        && item.fingerprint.trim().length > 0,
+    );
+}
+
+/**
+ * Pure Codex adapter projection for the shared lifecycle planner. It performs
+ * no filesystem writes, estimator calls, planner calls, tracing, or mutation.
+ */
+export function buildCodexLifecycleInput(
+  params: BuildCodexLifecycleInputParams,
+): CodexLifecycleInputResult {
+  if (
+    !params.backendRequest.sessionId.trim()
+    || params.registry.sessionId !== params.backendRequest.sessionId
+  ) {
+    return deferred(["lifecycle_registry_session_mismatch"]);
+  }
+  if (!Number.isInteger(params.registry.version) || params.registry.version < 0) {
+    return deferred(["lifecycle_registry_version_invalid"]);
+  }
+  if (
+    !Number.isInteger(params.registry.lastProcessedTurnSeq)
+    || params.registry.lastProcessedTurnSeq < 0
+  ) {
+    return deferred(["lifecycle_registry_watermark_invalid"]);
+  }
+
+  const committed = committedHeadView(params);
+  if ("status" in committed) return committed;
+  const semantic = buildCodexRawSemanticTurns(committed);
+  if (!semantic.complete) return deferred(semantic.reasonCodes);
+  if (semantic.turns.some((turn) => turn.sessionId !== params.registry.sessionId)) {
+    return deferred(["lifecycle_registry_session_mismatch"]);
+  }
+
+  const snapshot = rawSnapshot(params.registry.sessionId, semantic.turns);
+  if (params.registry.lastProcessedTurnSeq > snapshot.lastTurnSeq) {
+    return deferred(["lifecycle_registry_ahead_of_history"]);
+  }
+  if (params.registry.lastProcessedTurnSeq === snapshot.lastTurnSeq) {
+    return deferred(["lifecycle_no_pending_turns"]);
+  }
+  const delta = buildDeltaViewFromRawSemanticSnapshot(snapshot, {
+    fromTurnSeqExclusive: params.registry.lastProcessedTurnSeq,
+    toTurnSeqInclusive: snapshot.lastTurnSeq,
+    currentActiveTaskHint: params.currentActiveTaskHint,
+    inputMode: params.inputMode,
+    completedTaskSummaries: params.completedTaskSummaries,
+  });
+  const pendingTurnCount = semantic.turns.filter(
+    (turn) => turn.turnSeq > params.registry.lastProcessedTurnSeq
+      && turn.turnSeq <= snapshot.lastTurnSeq,
+  ).length;
+
+  const backendRequest = buildCodexLifecycleBackendRequest({
+    view: committed,
+    registry: params.registry,
+    request: params.backendRequest,
+  });
+  const blocks = lifecycleBlocks({
+    view: committed,
+    registry: params.registry,
+    turns: semantic.turns,
+    taskIdsByItemId: backendRequest.taskIdsByItemId ?? {},
+  });
+  if ("status" in blocks) return blocks;
+  const contextSnapshot = buildCodexContextSnapshot(backendRequest);
+  if (!validSnapshotIdentity(contextSnapshot)) {
+    return deferred(["lifecycle_snapshot_identity_invalid"]);
+  }
+
+  const latestTurn = [...committed.turns]
+    .sort((left, right) => left.turnSeq - right.turnSeq)
+    .at(-1);
+  return {
+    status: "ready",
+    reasonCodes: [],
+    committedView: committed,
+    rawSemanticTurns: semantic.turns,
+    rawSemanticSnapshot: snapshot,
+    delta,
+    pendingTurnCount,
+    historyBlocks: blocks.historyBlocks,
+    stableItemIdsByMessageId: blocks.stableItemIdsByMessageId,
+    backendRequest,
+    snapshot: contextSnapshot,
+    activeTaskIds: uniqueStrings(params.registry.activeTaskIds),
+    currentTaskIds: uniqueStrings(params.currentTaskIds ?? []),
+    ...(latestTurn ? { currentTurnAbsId: latestTurn.turnAbsId } : {}),
+    closureDeferredTaskIds: uniqueStrings(params.closureDeferredTaskIds ?? []),
+  };
+}

--- a/components/adapters/codex/src/context-rewrite/lifecycle-runner.ts
+++ b/components/adapters/codex/src/context-rewrite/lifecycle-runner.ts
@@ -1,0 +1,433 @@
+import {
+  loadSessionTaskRegistry,
+  persistSessionTaskRegistry,
+  SessionTaskRegistryVersionMismatchError,
+} from "@lightmem2/history";
+import {
+  planLifecycleEviction,
+  type LifecyclePlannerConfig,
+  type LifecyclePlannerReasonCode,
+  type TaskStateEstimator,
+} from "@lightmem2/eviction";
+import type {
+  ContextMutationPlan,
+  ContextRewriteValidation,
+  ModelContextSnapshot,
+} from "@lightmem2/host-adapter";
+
+import type {
+  CodexEffectiveHistoryView,
+  CodexRequestJournalEntry,
+} from "../context-history/types.js";
+import {
+  buildCodexContextSnapshot,
+  codexSharedContextRewriteBackend,
+  type CodexSharedBackendMetadata,
+  type CodexSharedBackendRequest,
+} from "./backend.js";
+import {
+  buildCodexLifecycleBackendRequest,
+  buildCodexLifecycleInput,
+  type CodexLifecycleBackendRequestBase,
+  type CodexLifecycleInputReasonCode,
+} from "./lifecycle-input.js";
+import {
+  acquireCodexRebaseSessionLock,
+  type CodexRebaseSessionLock,
+} from "./rebase-epoch.js";
+
+export type CodexLifecycleRunnerReasonCode =
+  | CodexLifecycleInputReasonCode
+  | LifecyclePlannerReasonCode
+  | "lifecycle_runner_state_dir_invalid"
+  | "lifecycle_runner_session_mismatch"
+  | "lifecycle_runner_lock_busy"
+  | "lifecycle_runner_lock_failed"
+  | "lifecycle_runner_registry_load_failed"
+  | "lifecycle_runner_registry_version_conflict"
+  | "lifecycle_runner_registry_persist_failed"
+  | "lifecycle_runner_plan_invalid"
+  | "lifecycle_runner_failed";
+
+export type CodexLifecyclePreparedPlan = {
+  plan: ContextMutationPlan;
+  /** CAS version that must still be current when runtime consumes the plan. */
+  registryVersion: number;
+  backendRequest: CodexSharedBackendRequest;
+  snapshot: ModelContextSnapshot<CodexSharedBackendMetadata>;
+  validation: ContextRewriteValidation;
+};
+
+export type CodexLifecycleRunnerResult = {
+  status: "completed" | "deferred" | "bypassed";
+  reasonCodes: CodexLifecycleRunnerReasonCode[];
+  attemptedEstimator: boolean;
+  registryPersisted: boolean;
+  registryChanged: boolean;
+  registryVersionBefore?: number;
+  registryVersionAfter?: number;
+  preparedPlan?: CodexLifecyclePreparedPlan;
+};
+
+export type CodexLifecycleHandoffReasonCode =
+  | "lifecycle_execution_registry_load_failed"
+  | "lifecycle_execution_registry_version_changed"
+  | "lifecycle_execution_snapshot_changed"
+  | "lifecycle_execution_plan_invalid";
+
+export type CodexLifecycleHandoffValidation = {
+  valid: boolean;
+  reasonCodes: CodexLifecycleHandoffReasonCode[];
+  registryVersion?: number;
+};
+
+export type RevalidateCodexLifecyclePreparedPlanParams = {
+  stateDir: string;
+  sessionId: string;
+  preparedPlan: CodexLifecyclePreparedPlan;
+  view: CodexEffectiveHistoryView;
+  backendRequest: CodexLifecycleBackendRequestBase;
+};
+
+export type RunCodexLifecyclePlannerParams = {
+  stateDir: string;
+  sessionId: string;
+  view: Parameters<typeof buildCodexLifecycleInput>[0]["view"];
+  backendRequest: CodexLifecycleBackendRequestBase;
+  estimator?: TaskStateEstimator | null;
+  config: LifecyclePlannerConfig;
+  createdAt: string;
+  expectedCurrentRequest?: Pick<
+    CodexRequestJournalEntry,
+    "requestId" | "sessionId" | "status" | "turnOrdinal"
+  >;
+  currentTaskIds?: readonly string[];
+  closureDeferredTaskIds?: readonly string[];
+  currentActiveTaskHint?: string;
+  inputMode?: Parameters<typeof buildCodexLifecycleInput>[0]["inputMode"];
+  completedTaskSummaries?: Parameters<
+    typeof buildCodexLifecycleInput
+  >[0]["completedTaskSummaries"];
+  duplicateWindow?: boolean;
+  sourcePresetId?: string;
+};
+
+function result(params: {
+  status: CodexLifecycleRunnerResult["status"];
+  reasonCodes: Iterable<CodexLifecycleRunnerReasonCode>;
+  attemptedEstimator?: boolean;
+  registryPersisted?: boolean;
+  registryChanged?: boolean;
+  registryVersionBefore?: number;
+  registryVersionAfter?: number;
+  preparedPlan?: CodexLifecyclePreparedPlan;
+}): CodexLifecycleRunnerResult {
+  return {
+    status: params.status,
+    reasonCodes: [...new Set(params.reasonCodes)],
+    attemptedEstimator: params.attemptedEstimator ?? false,
+    registryPersisted: params.registryPersisted ?? false,
+    registryChanged: params.registryChanged ?? false,
+    ...(params.registryVersionBefore !== undefined
+      ? { registryVersionBefore: params.registryVersionBefore }
+      : {}),
+    ...(params.registryVersionAfter !== undefined
+      ? { registryVersionAfter: params.registryVersionAfter }
+      : {}),
+    ...(params.preparedPlan ? { preparedPlan: params.preparedPlan } : {}),
+  };
+}
+
+function fullyApplicable(
+  plan: ContextMutationPlan,
+  validation: ContextRewriteValidation,
+): boolean {
+  const operationIds = [...new Set(plan.operations.map((operation) => operation.id))];
+  return validation.valid
+    && validation.deferredOperationIds.length === 0
+    && validation.applicableOperationIds.length === operationIds.length
+    && operationIds.every((operationId) => (
+      validation.applicableOperationIds.includes(operationId)
+    ));
+}
+
+function sameLifecycleSnapshot(
+  left: ModelContextSnapshot<CodexSharedBackendMetadata>,
+  right: ModelContextSnapshot<CodexSharedBackendMetadata>,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/**
+ * Revalidates the planner-to-runtime handoff. The caller must hold the Codex
+ * rebase session lock continuously from this check through provider execution.
+ */
+export async function revalidateCodexLifecyclePreparedPlan(
+  params: RevalidateCodexLifecyclePreparedPlanParams,
+): Promise<CodexLifecycleHandoffValidation> {
+  let registry;
+  try {
+    registry = await loadSessionTaskRegistry(params.stateDir, params.sessionId);
+  } catch {
+    return {
+      valid: false,
+      reasonCodes: ["lifecycle_execution_registry_load_failed"],
+    };
+  }
+  if (
+    registry.sessionId !== params.sessionId
+    || registry.version !== params.preparedPlan.registryVersion
+  ) {
+    return {
+      valid: false,
+      reasonCodes: ["lifecycle_execution_registry_version_changed"],
+      registryVersion: registry.version,
+    };
+  }
+
+  let currentSnapshot: ModelContextSnapshot<CodexSharedBackendMetadata>;
+  try {
+    const currentRequest = buildCodexLifecycleBackendRequest({
+      view: params.view,
+      registry,
+      request: params.backendRequest,
+    });
+    currentSnapshot = buildCodexContextSnapshot(currentRequest);
+  } catch {
+    return {
+      valid: false,
+      reasonCodes: ["lifecycle_execution_snapshot_changed"],
+      registryVersion: registry.version,
+    };
+  }
+  if (!sameLifecycleSnapshot(params.preparedPlan.snapshot, currentSnapshot)) {
+    return {
+      valid: false,
+      reasonCodes: ["lifecycle_execution_snapshot_changed"],
+      registryVersion: registry.version,
+    };
+  }
+
+  let validation: ContextRewriteValidation;
+  try {
+    validation = await codexSharedContextRewriteBackend.validate({
+      snapshot: currentSnapshot,
+      plan: params.preparedPlan.plan,
+    });
+  } catch {
+    return {
+      valid: false,
+      reasonCodes: ["lifecycle_execution_plan_invalid"],
+      registryVersion: registry.version,
+    };
+  }
+  return fullyApplicable(params.preparedPlan.plan, validation)
+    ? {
+        valid: true,
+        reasonCodes: [],
+        registryVersion: registry.version,
+      }
+    : {
+        valid: false,
+        reasonCodes: ["lifecycle_execution_plan_invalid"],
+        registryVersion: registry.version,
+      };
+}
+
+/**
+ * Consumes the shared lifecycle planner inside the existing Codex rebase
+ * session lock. The runner owns registry I/O and post-estimator Host
+ * validation, but never calls an upstream provider or mutates the request.
+ * A plan is exposed only after its registry update wins the expected-version
+ * CAS. The returned registryVersion is a handoff token: runtime wiring must
+ * re-check it if planning and provider execution do not share one continuous
+ * session-lock scope.
+ */
+export async function runCodexLifecyclePlanner(
+  params: RunCodexLifecyclePlannerParams,
+): Promise<CodexLifecycleRunnerResult> {
+  if (!params.config.enabled) {
+    return result({
+      status: "bypassed",
+      reasonCodes: ["planner_disabled"],
+    });
+  }
+  if (!params.estimator) {
+    return result({
+      status: "bypassed",
+      reasonCodes: ["estimator_missing"],
+    });
+  }
+  if (!params.stateDir.trim()) {
+    return result({
+      status: "bypassed",
+      reasonCodes: ["lifecycle_runner_state_dir_invalid"],
+    });
+  }
+  if (
+    !params.sessionId.trim()
+    || params.backendRequest.sessionId !== params.sessionId
+    || (params.expectedCurrentRequest
+      && params.expectedCurrentRequest.sessionId !== params.sessionId)
+  ) {
+    return result({
+      status: "bypassed",
+      reasonCodes: ["lifecycle_runner_session_mismatch"],
+    });
+  }
+
+  let lock: CodexRebaseSessionLock | undefined;
+  try {
+    lock = await acquireCodexRebaseSessionLock({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+    });
+  } catch {
+    return result({
+      status: "bypassed",
+      reasonCodes: ["lifecycle_runner_lock_failed"],
+    });
+  }
+  if (!lock) {
+    return result({
+      status: "deferred",
+      reasonCodes: ["lifecycle_runner_lock_busy"],
+    });
+  }
+
+  try {
+    let registry;
+    try {
+      registry = await loadSessionTaskRegistry(params.stateDir, params.sessionId);
+    } catch {
+      return result({
+        status: "bypassed",
+        reasonCodes: ["lifecycle_runner_registry_load_failed"],
+      });
+    }
+    const registryVersionBefore = registry.version;
+
+    const lifecycleInput = buildCodexLifecycleInput({
+      view: params.view,
+      registry,
+      backendRequest: params.backendRequest,
+      expectedCurrentRequest: params.expectedCurrentRequest,
+      currentTaskIds: params.currentTaskIds,
+      closureDeferredTaskIds: params.closureDeferredTaskIds,
+      currentActiveTaskHint: params.currentActiveTaskHint,
+      inputMode: params.inputMode,
+      completedTaskSummaries: params.completedTaskSummaries,
+    });
+    if (lifecycleInput.status === "deferred") {
+      return result({
+        status: "deferred",
+        reasonCodes: lifecycleInput.reasonCodes,
+        registryVersionBefore,
+        registryVersionAfter: registryVersionBefore,
+      });
+    }
+
+    const planned = await planLifecycleEviction({
+      registry,
+      delta: lifecycleInput.delta,
+      pendingTurnCount: lifecycleInput.pendingTurnCount,
+      duplicateWindow: params.duplicateWindow,
+      estimator: params.estimator,
+      historyBlocks: lifecycleInput.historyBlocks,
+      snapshot: lifecycleInput.snapshot,
+      stableItemIdsByMessageId: lifecycleInput.stableItemIdsByMessageId,
+      activeTaskIds: lifecycleInput.activeTaskIds,
+      currentTaskIds: lifecycleInput.currentTaskIds,
+      currentTurnAbsId: lifecycleInput.currentTurnAbsId,
+      closureDeferredTaskIds: lifecycleInput.closureDeferredTaskIds,
+      config: params.config,
+      createdAt: params.createdAt,
+      sourcePresetId: params.sourcePresetId,
+    });
+
+    let preparedPlan: CodexLifecyclePreparedPlan | undefined;
+    const runnerReasons: CodexLifecycleRunnerReasonCode[] = [...planned.reasonCodes];
+    if (planned.plan) {
+      const backendRequest = buildCodexLifecycleBackendRequest({
+        view: lifecycleInput.committedView,
+        registry: planned.registry,
+        request: params.backendRequest,
+      });
+      const snapshot = buildCodexContextSnapshot(backendRequest);
+      const validation = await codexSharedContextRewriteBackend.validate({
+        snapshot,
+        plan: planned.plan,
+      });
+      if (fullyApplicable(planned.plan, validation)) {
+        preparedPlan = {
+          plan: planned.plan,
+          registryVersion: planned.registry.version,
+          backendRequest,
+          snapshot,
+          validation,
+        };
+      } else {
+        runnerReasons.push("lifecycle_runner_plan_invalid");
+      }
+    }
+    if (preparedPlan && !planned.registryUpdateRequired) {
+      preparedPlan = undefined;
+      runnerReasons.push("lifecycle_runner_plan_invalid");
+    }
+
+    let registryPersisted = false;
+    if (planned.registryUpdateRequired) {
+      try {
+        await persistSessionTaskRegistry(params.stateDir, planned.registry, {
+          expectedVersion: planned.expectedRegistryVersion,
+        });
+        registryPersisted = true;
+      } catch (error) {
+        if (error instanceof SessionTaskRegistryVersionMismatchError) {
+          return result({
+            status: "deferred",
+            reasonCodes: [
+              ...runnerReasons,
+              "lifecycle_runner_registry_version_conflict",
+            ],
+            attemptedEstimator: planned.attemptedEstimator,
+            registryVersionBefore,
+            registryVersionAfter: error.actualVersion,
+          });
+        }
+        return result({
+          status: "bypassed",
+          reasonCodes: [
+            ...runnerReasons,
+            "lifecycle_runner_registry_persist_failed",
+          ],
+          attemptedEstimator: planned.attemptedEstimator,
+          registryVersionBefore,
+          registryVersionAfter: registryVersionBefore,
+        });
+      }
+    }
+
+    return result({
+      status: runnerReasons.includes("lifecycle_runner_plan_invalid")
+        ? "deferred"
+        : planned.status,
+      reasonCodes: runnerReasons,
+      attemptedEstimator: planned.attemptedEstimator,
+      registryPersisted,
+      registryChanged: planned.registryChanged,
+      registryVersionBefore,
+      registryVersionAfter: registryPersisted
+        ? planned.registry.version
+        : registryVersionBefore,
+      preparedPlan,
+    });
+  } catch {
+    return result({
+      status: "bypassed",
+      reasonCodes: ["lifecycle_runner_failed"],
+    });
+  } finally {
+    await lock.release();
+  }
+}

--- a/components/adapters/codex/src/context-rewrite/types.ts
+++ b/components/adapters/codex/src/context-rewrite/types.ts
@@ -94,6 +94,13 @@ export type CodexRebaseFallbackResult = {
   capability?: CodexRebaseCapabilityNotice;
 };
 
+export type CodexRebaseExecutionGuardDecision = {
+  allowed: boolean;
+  reason?: string;
+};
+
+export type CodexRebaseExecutionGuard = () => Promise<CodexRebaseExecutionGuardDecision>;
+
 export type CodexProviderContinuationResult = {
   response: CodexUpstreamResponse;
   outcome: "chained" | "stateless_replay" | "failed";

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -9,6 +9,7 @@ import {
 import {
   countTextWithPreciseTokens,
   createStaticStatePathResolver,
+  type ContextMutationPlan,
   type ContextRewriteEventInput,
   type ContextRewriteEventName,
   type HostRequestEnvelope,
@@ -62,7 +63,7 @@ import { initializeCodexTokenPilotPreset } from "./preset.js";
 import {
   appendCodexRequestJournalEntry,
   appendCodexResponseJournalEntry,
-  buildCodexEffectiveHistory,
+  buildCodexEffectiveHistoryView,
   collectCodexResponseItemsFromStream,
   parseCodexRollout,
   validateCodexRolloutBootstrap,
@@ -79,11 +80,16 @@ import {
   acquireCodexRebaseSessionLock,
   buildCodexRebaseRequest,
   codexRebaseEndpointIdentity,
+  codexSharedContextRewriteBackend,
   createCodexContextRewriteLifecycle,
   executeCodexProviderContinuationWithReplay,
   executeCodexRebaseWithFallback,
   failPendingCodexRebaseEpochsAfterRestart,
+  type CodexLifecyclePreparedPlan,
   resolveCodexProviderContinuationCompatibility,
+  resolveCodexTaskStateEstimator,
+  revalidateCodexLifecyclePreparedPlan,
+  runCodexLifecyclePlanner,
   withCodexRebaseReplayAccountingInput,
 } from "./context-rewrite/index.js";
 import type {
@@ -196,6 +202,32 @@ function codexMutationLifecyclePlan(plan: CodexMutationPlan): CodexLifecyclePlan
   };
 }
 
+function codexSharedLifecyclePlan(plan: ContextMutationPlan): CodexLifecyclePlan {
+  return {
+    planId: plan.planId,
+    operationIds: plan.operations.map((operation) => operation.id),
+    itemIds: [...new Set(plan.operations.flatMap((operation) => operation.targetItemIds))],
+    previousRevision: plan.baseRevision,
+    estimatedSavedChars: plan.operations.reduce(
+      (total, operation) => total + Math.max(0, operation.estimatedSavedChars ?? 0),
+      0,
+    ),
+  };
+}
+
+function allLifecycleOperationsApplied(
+  plan: CodexLifecyclePlan,
+  appliedOperationIds: readonly string[],
+  deferredOperationIds: readonly string[],
+): boolean {
+  const expected = [...new Set(plan.operationIds ?? [])];
+  const applied = [...new Set(appliedOperationIds)];
+  return expected.length > 0
+    && deferredOperationIds.length === 0
+    && applied.length === expected.length
+    && expected.every((operationId) => applied.includes(operationId));
+}
+
 function codexValidationReasonCodes(error: unknown): string[] {
   const message = error instanceof Error ? error.message.toLowerCase() : "";
   const reasons: string[] = [];
@@ -218,6 +250,10 @@ const SAFE_REWRITE_REASON_CODES = new Set([
   "feature_disabled",
   "history_journal_write_failed",
   "item_schema_unsupported",
+  "lifecycle_execution_plan_invalid",
+  "lifecycle_execution_registry_load_failed",
+  "lifecycle_execution_registry_version_changed",
+  "lifecycle_execution_snapshot_changed",
   "native_response_chain_used",
   "provider_replay_probe_required",
   "provider_replay_rejected",
@@ -233,12 +269,22 @@ const SAFE_REWRITE_REASON_CODES = new Set([
   "request_journal_unavailable",
   "response_chain_head_missing",
   "rewrite_configuration_unsupported",
+  "rewrite_execution_guard_error",
+  "rewrite_execution_guard_rejected",
+  "rewrite_execution_guard_unavailable",
   "rewrite_guard_busy",
   "stateless_continuation_succeeded",
 ]);
 
 function codexSafeRuntimeReason(reason: string | undefined, fallback: string): string {
   return reason && SAFE_REWRITE_REASON_CODES.has(reason) ? reason : fallback;
+}
+
+function isLifecycleExecutionDeferredReason(reason: string | undefined): boolean {
+  return reason === "lifecycle_execution_plan_invalid"
+    || reason === "lifecycle_execution_registry_load_failed"
+    || reason === "lifecycle_execution_registry_version_changed"
+    || reason === "lifecycle_execution_snapshot_changed";
 }
 
 function encodedRequestPayload(params: {
@@ -333,6 +379,10 @@ export async function startCodexResponsesProxy(params: {
   await mkdir(config.stateDir, { recursive: true });
   const upstream = await resolveUpstreamProvider(config, params.codexConfigPath ?? defaultCodexConfigPath());
   const upstreamProviderName = upstream.name ?? config.upstreamProvider ?? "OpenAI";
+  const estimatorResolution = resolveCodexTaskStateEstimator({
+    config: config.taskStateEstimator,
+  });
+  const lifecyclePlanningConfigured = estimatorResolution.config.enabled;
   const epochRecoveryBySession = new Map<string, Promise<void>>();
 
   async function recoverSessionEpochsAfterRestart(sessionId: string): Promise<void> {
@@ -493,10 +543,184 @@ export async function startCodexResponsesProxy(params: {
 
       let rebaseRequest: CodexRebaseRequestResult | undefined;
       let rebasePlanId: string | undefined;
+      let lifecyclePreparedPlan: CodexLifecyclePreparedPlan | undefined;
       let continuationReplayRequest: CodexRebaseRequestResult | undefined;
       let rebaseAccounting = rebaseRequest?.accounting;
-      const mutationPlan = activeMutationPlan(config);
-      if (mutationPlan) {
+      const mutationPlan = lifecyclePlanningConfigured ? undefined : activeMutationPlan(config);
+      let effectiveHistoryViewPromise: ReturnType<typeof buildCodexEffectiveHistoryView> | undefined;
+      const buildEffectiveHistoryViewForHead = (): ReturnType<typeof buildCodexEffectiveHistoryView> => {
+        if (!requestJournalEntry || typeof originalPayload.previous_response_id !== "string") {
+          throw new Error("Codex effective history requires a journaled response-chain request");
+        }
+        return buildCodexEffectiveHistoryView({
+          stateDir: config.stateDir,
+          sessionId,
+          headResponseId: originalPayload.previous_response_id,
+          currentRequestId: requestJournalEntry.requestId,
+          async rolloutViewBootstrap() {
+            const snapshot = await loadCodexSessionSnapshot(config.stateDir, sessionId);
+            if (!snapshot?.transcriptPath) return null;
+            const rollout = await parseCodexRollout(snapshot.transcriptPath);
+            if (!rollout) return null;
+            const validation = validateCodexRolloutBootstrap({
+              rollout,
+              // prompt_cache_key is an upstream cache namespace, not the
+              // Codex host session identity used by rollout metadata.
+              expectedCodexSessionId: snapshot.codexSessionId,
+              snapshotCodexSessionId: snapshot.codexSessionId,
+              sourceModel: snapshot.latestModel,
+              sourceUpstreamProvider: snapshot.latestUpstreamProvider,
+              currentModel: model,
+              currentCodexProvider: config.providerName,
+              currentUpstreamProvider: upstreamProviderName,
+            });
+            if (validation.rejectionReason) {
+              await appendTrace(config.stateDir, {
+                stage: "context_history_rollout_bootstrap_rejected",
+                sessionId,
+                reason: validation.rejectionReason,
+              });
+            }
+            return validation.view;
+          },
+        });
+      };
+      const effectiveHistoryViewForHead = (): ReturnType<typeof buildCodexEffectiveHistoryView> => {
+        effectiveHistoryViewPromise ??= buildEffectiveHistoryViewForHead();
+        return effectiveHistoryViewPromise;
+      };
+      const effectiveHistoryForHead = async () => (
+        await effectiveHistoryViewForHead()
+      ).history;
+
+      if (lifecyclePlanningConfigured) {
+        if (!config.contextRewrite.enabled) {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["feature_disabled"],
+            fallbackUsed: true,
+          });
+        } else if (!requestJournalEntry) {
+          await emitContextRewriteStage("context_rewrite_failed", {
+            reasonCodes: ["request_journal_unavailable"],
+            errorCategory: "history_journal_write_failed",
+            fallbackUsed: true,
+          });
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["fallback_original_request"],
+            fallbackUsed: true,
+          });
+        } else if (typeof originalPayload.previous_response_id !== "string"
+          || !originalPayload.previous_response_id) {
+          await emitContextRewriteStage("context_rewrite_deferred", {
+            reasonCodes: ["response_chain_head_missing"],
+          });
+        } else if (!config.contextRewrite.retryOriginalRequest
+          || config.contextRewrite.mode !== "response_chain_rebase"
+          || config.contextRewrite.failureMode !== "bypass") {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["rewrite_configuration_unsupported"],
+            fallbackUsed: true,
+          });
+        } else if (!estimatorResolution.estimator) {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["estimator_missing"],
+            fallbackUsed: true,
+          });
+        } else {
+          try {
+            const effectiveHistoryView = await effectiveHistoryViewForHead();
+            const lifecycleResult = await runCodexLifecyclePlanner({
+              stateDir: config.stateDir,
+              sessionId,
+              view: effectiveHistoryView,
+              backendRequest: {
+                sessionId,
+                payload: originalPayload,
+                effectiveHistory: effectiveHistoryView.history,
+                currentInput: originalPayload.input,
+              },
+              estimator: estimatorResolution.estimator,
+              config: {
+                enabled: true,
+                batchTurns: estimatorResolution.config.batchTurns,
+                evictionEnabled: true,
+                evictionPolicy: "model_scored",
+                evictionMinBlockChars: 256,
+              },
+              createdAt: new Date().toISOString(),
+              expectedCurrentRequest: requestJournalEntry,
+              inputMode: estimatorResolution.config.inputMode,
+              sourcePresetId: "tokenpilot",
+            });
+            if (lifecycleResult.preparedPlan) {
+              activeLifecyclePlan = codexSharedLifecyclePlan(lifecycleResult.preparedPlan.plan);
+              await emitContextRewriteStage("context_rewrite_planned");
+              const applied = await codexSharedContextRewriteBackend.apply({
+                snapshot: lifecycleResult.preparedPlan.snapshot,
+                plan: lifecycleResult.preparedPlan.plan,
+                request: lifecycleResult.preparedPlan.backendRequest,
+              });
+              const details = applied.result.details;
+              if (
+                applied.result.applied
+                && details?.rebasePrepared
+                && allLifecycleOperationsApplied(
+                  activeLifecyclePlan,
+                  applied.result.appliedOperationIds,
+                  applied.result.deferredOperationIds,
+                )
+              ) {
+                lifecyclePreparedPlan = lifecycleResult.preparedPlan;
+                rebaseRequest = {
+                  payload: applied.request.payload,
+                  oldRevision: applied.result.previousRevision,
+                  rebaseRevision: applied.result.nextRevision,
+                  accounting: details.accounting,
+                };
+                rebasePlanId = lifecycleResult.preparedPlan.plan.planId;
+                activeLifecyclePlan = {
+                  ...activeLifecyclePlan,
+                  previousRevision: rebaseRequest.oldRevision,
+                  nextRevision: rebaseRequest.rebaseRevision,
+                  estimatedSavedChars: rebaseRequest.accounting.plannedSavedChars,
+                  savedChars: rebaseRequest.accounting.actuallyRemovedChars,
+                };
+              } else {
+                lifecyclePreparedPlan = undefined;
+                await emitContextRewriteStage("context_rewrite_deferred", {
+                  reasonCodes: ["lifecycle_runner_plan_invalid"],
+                  deferredOperationIds: activeLifecyclePlan.operationIds,
+                });
+              }
+            } else {
+              lifecyclePreparedPlan = undefined;
+              activeLifecyclePlan = undefined;
+              await emitContextRewriteStage(
+                lifecycleResult.status === "bypassed"
+                  ? "context_rewrite_bypassed"
+                  : "context_rewrite_deferred",
+                {
+                  reasonCodes: lifecycleResult.reasonCodes,
+                  ...(lifecycleResult.status === "bypassed" ? { fallbackUsed: true } : {}),
+                },
+              );
+            }
+          } catch (err) {
+            lifecyclePreparedPlan = undefined;
+            activeLifecyclePlan = undefined;
+            await appendTrace(config.stateDir, {
+              stage: "context_rewrite_lifecycle_planning_failed",
+              sessionId,
+              model,
+              reason: err instanceof Error ? err.message : String(err),
+            });
+            await emitContextRewriteStage("context_rewrite_bypassed", {
+              reasonCodes: ["lifecycle_runner_failed"],
+              fallbackUsed: true,
+            });
+          }
+        }
+      } else if (mutationPlan) {
         activeLifecyclePlan = codexMutationLifecyclePlan(mutationPlan);
         await emitContextRewriteStage("context_rewrite_planned");
         if (!config.contextRewrite.enabled) {
@@ -528,45 +752,6 @@ export async function startCodexResponsesProxy(params: {
           });
         }
       }
-      let effectiveHistoryPromise: ReturnType<typeof buildCodexEffectiveHistory> | undefined;
-      const effectiveHistoryForHead = (): ReturnType<typeof buildCodexEffectiveHistory> => {
-        if (!requestJournalEntry || typeof originalPayload.previous_response_id !== "string") {
-          throw new Error("Codex effective history requires a journaled response-chain request");
-        }
-        effectiveHistoryPromise ??= buildCodexEffectiveHistory({
-          stateDir: config.stateDir,
-          sessionId,
-          headResponseId: originalPayload.previous_response_id,
-          currentRequestId: requestJournalEntry.requestId,
-          async rolloutParserBootstrap() {
-            const snapshot = await loadCodexSessionSnapshot(config.stateDir, sessionId);
-            if (!snapshot?.transcriptPath) return null;
-            const rollout = await parseCodexRollout(snapshot.transcriptPath);
-            if (!rollout) return null;
-            const validation = validateCodexRolloutBootstrap({
-              rollout,
-              // prompt_cache_key is an upstream cache namespace, not the
-              // Codex host session identity used by rollout metadata.
-              expectedCodexSessionId: snapshot.codexSessionId,
-              snapshotCodexSessionId: snapshot.codexSessionId,
-              sourceModel: snapshot.latestModel,
-              sourceUpstreamProvider: snapshot.latestUpstreamProvider,
-              currentModel: model,
-              currentCodexProvider: config.providerName,
-              currentUpstreamProvider: upstreamProviderName,
-            });
-            if (validation.rejectionReason) {
-              await appendTrace(config.stateDir, {
-                stage: "context_history_rollout_bootstrap_rejected",
-                sessionId,
-                reason: validation.rejectionReason,
-              });
-            }
-            return validation.history;
-          },
-        });
-        return effectiveHistoryPromise;
-      };
       if (canAttemptCodexRebase({ config, payload: originalPayload, requestEntry: requestJournalEntry })
         && mutationPlan
         && requestJournalEntry) {
@@ -1054,6 +1239,35 @@ export async function startCodexResponsesProxy(params: {
                 cooldownMs: config.contextRewrite.cooldownMs,
               },
               capabilityStore,
+              executionGuard: lifecyclePreparedPlan
+                ? async () => {
+                    let currentView;
+                    try {
+                      currentView = await buildEffectiveHistoryViewForHead();
+                    } catch {
+                      return {
+                        allowed: false,
+                        reason: "lifecycle_execution_snapshot_changed",
+                      };
+                    }
+                    const handoff = await revalidateCodexLifecyclePreparedPlan({
+                      stateDir: config.stateDir,
+                      sessionId,
+                      preparedPlan: lifecyclePreparedPlan,
+                      view: currentView,
+                      backendRequest: {
+                        sessionId,
+                        payload: originalPayload,
+                        effectiveHistory: currentView.history,
+                        currentInput: originalPayload.input,
+                      },
+                    });
+                    return {
+                      allowed: handoff.valid,
+                      reason: handoff.reasonCodes[0],
+                    };
+                  }
+                : undefined,
             });
             contextRewriteOutcome = result.outcome;
             contextRewriteValidationPassed = Boolean(result.rebaseResponse)
@@ -1075,6 +1289,9 @@ export async function startCodexResponsesProxy(params: {
                 contextRewriteBypassReason = "cooldown_active";
               } else if (result.reason === "rewrite_guard_busy") {
                 contextRewriteBypassReason = "rewrite_guard_busy";
+              } else if (isLifecycleExecutionDeferredReason(result.reason)) {
+                contextRewriteDeferredReason = result.reason;
+                contextRewriteBypassReason = "fallback_original_request";
               } else if (result.reason) {
                 contextRewriteFailureReason = result.reason;
                 contextRewriteBypassReason = "fallback_original_request";

--- a/components/adapters/codex/tests/context-rebase-epoch.test.ts
+++ b/components/adapters/codex/tests/context-rebase-epoch.test.ts
@@ -591,6 +591,109 @@ test("CDR-03 Rebase Epoch records fallback extra request accounting", async () =
   });
 });
 
+test("CDR-03 Rebase Epoch evaluates the execution guard under the session lock", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-session-execution-guard";
+    const sentInputs: string[] = [];
+    let guardCalled = false;
+    const result = await executeCodexRebaseWithFallback({
+      sessionId,
+      planId: "plan-execution-guard",
+      epochId: "epoch-execution-guard",
+      originalPayload: { input: [{ role: "user", content: "original" }] },
+      rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      async executionGuard() {
+        guardCalled = true;
+        const competingLock = await acquireCodexRebaseSessionLock({ stateDir, sessionId });
+        assert.equal(competingLock, undefined);
+        return {
+          allowed: false,
+          reason: "lifecycle_execution_registry_version_changed",
+        };
+      },
+      async sendUpstream(payload) {
+        sentInputs.push(String((payload.input as JsonObject[])[0]?.content));
+        return {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          text: JSON.stringify({ id: "resp-original", status: "completed" }),
+        };
+      },
+    });
+
+    assert.equal(guardCalled, true);
+    assert.equal(result.outcome, "bypassed");
+    assert.equal(result.reason, "lifecycle_execution_registry_version_changed");
+    assert.deepEqual(sentInputs, ["original"]);
+    assert.equal(await readLatestCodexRebaseEpoch({ stateDir, sessionId }), undefined);
+  });
+});
+
+test("CDR-03 Rebase Epoch never executes a guard without a session-lock store", async () => {
+  const sentInputs: string[] = [];
+  let guardCalled = false;
+  const result = await executeCodexRebaseWithFallback({
+    sessionId: "codex-session-guard-without-lock",
+    planId: "plan-guard-without-lock",
+    epochId: "epoch-guard-without-lock",
+    originalPayload: { input: [{ role: "user", content: "original" }] },
+    rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+    executionGuard: async () => {
+      guardCalled = true;
+      return { allowed: true };
+    },
+    async sendUpstream(payload) {
+      sentInputs.push(String((payload.input as JsonObject[])[0]?.content));
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({ id: "resp-original", status: "completed" }),
+      };
+    },
+  });
+
+  assert.equal(guardCalled, false);
+  assert.equal(result.outcome, "bypassed");
+  assert.equal(result.reason, "rewrite_execution_guard_unavailable");
+  assert.deepEqual(sentInputs, ["original"]);
+});
+
+test("CDR-03 Rebase Epoch does not retry an original request rejected by the execution guard", async () => {
+  await withTempState(async (stateDir) => {
+    let upstreamCalls = 0;
+    await assert.rejects(() => executeCodexRebaseWithFallback({
+      sessionId: "codex-session-guard-upstream-error",
+      planId: "plan-guard-upstream-error",
+      epochId: "epoch-guard-upstream-error",
+      originalPayload: { input: [{ role: "user", content: "original" }] },
+      rebasedPayload: { input: [{ role: "user", content: "rebased" }] },
+      epochStore: {
+        stateDir,
+        oldPreviousResponseId: "resp-old",
+        oldRevision: "rev-old",
+      },
+      executionGuard: async () => ({
+        allowed: false,
+        reason: "lifecycle_execution_snapshot_changed",
+      }),
+      async sendUpstream() {
+        upstreamCalls += 1;
+        throw new Error("original upstream unavailable");
+      },
+    }), /original upstream unavailable/);
+    assert.equal(upstreamCalls, 1);
+    assert.equal(await readLatestCodexRebaseEpoch({
+      stateDir,
+      sessionId: "codex-session-guard-upstream-error",
+    }), undefined);
+  });
+});
+
 test("CDR-03 Rebase Epoch marks failed when original fallback throws", async () => {
   await withTempState(async (stateDir) => {
     let calls = 0;

--- a/components/adapters/codex/tests/context-rewrite-acceptance.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-acceptance.test.ts
@@ -1,0 +1,444 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import {
+  createAcceptanceSentinels,
+  createTemporaryAcceptanceEnvironment,
+  MockUpstreamRecorder,
+  reserveUnusedPort,
+  runAcceptanceHarness,
+  type AcceptancePhase,
+  type AcceptanceSentinels,
+  type MockUpstreamResponse,
+} from "@lightmem2/host-adapter";
+import { loadSessionTaskRegistry } from "@lightmem2/history";
+
+import { normalizeTokenPilotCodexConfig } from "../src/config.js";
+import { createConsoleLogger } from "../src/logger.js";
+import { startCodexResponsesProxy } from "../src/proxy-runtime.js";
+
+type JsonObject = Record<string, unknown>;
+
+const TEST_UUID = "9c281934-c878-4b59-82a8-ec87caedce41";
+const SESSION_ID = "sess-gua06-codex-lifecycle";
+
+function asRecord(value: unknown): JsonObject | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as JsonObject
+    : undefined;
+}
+
+async function readJsonBody(
+  request: Parameters<Parameters<typeof createServer>[0]>[0],
+): Promise<JsonObject> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8")) as JsonObject;
+}
+
+function responseMessage(text: string): JsonObject {
+  return {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text }],
+  };
+}
+
+function upstreamResponse(
+  id: string,
+  output: JsonObject[],
+): MockUpstreamResponse {
+  return {
+    status: 200,
+    body: {
+      id,
+      object: "response",
+      status: "completed",
+      output,
+    },
+  };
+}
+
+function queuedPhaseResponses(phase: AcceptancePhase): MockUpstreamResponse[] {
+  const oldCallId = `call-gua06-${phase}-evict`;
+  const keepCallId = `call-gua06-${phase}-keep`;
+  return [
+    upstreamResponse(`resp-gua06-${phase}-1`, [{
+      id: `item-gua06-${phase}-evict`,
+      type: "function_call",
+      call_id: oldCallId,
+      name: "read_fixture",
+      arguments: "{}",
+    }]),
+    upstreamResponse(`resp-gua06-${phase}-2`, [responseMessage("old fixture task completed")]),
+    upstreamResponse(`resp-gua06-${phase}-3`, [{
+      id: `item-gua06-${phase}-keep`,
+      type: "function_call",
+      call_id: keepCallId,
+      name: "read_fixture",
+      arguments: "{}",
+    }]),
+    upstreamResponse(`resp-gua06-${phase}-4`, [responseMessage("current fixture task remains active")]),
+    upstreamResponse(`resp-gua06-${phase}-5`, [responseMessage(`accepted ${phase}`)]),
+  ];
+}
+
+function estimatorInput(payload: JsonObject): {
+  registry: { version: number };
+  delta: {
+    coveredTurnAbsIds: string[];
+    toolResults: Array<{
+      anchor: { turnAbsId: string };
+      summary: string;
+    }>;
+  };
+} {
+  const input = Array.isArray(payload.input) ? payload.input : [];
+  const userItem = input
+    .map(asRecord)
+    .find((item) => item?.role === "user");
+  const content = Array.isArray(userItem?.content) ? userItem.content : [];
+  const text = content
+    .map(asRecord)
+    .find((item) => item?.type === "input_text")?.text;
+  if (typeof text !== "string") {
+    throw new Error("GUA-06 estimator request is missing the canonical lifecycle input");
+  }
+  return JSON.parse(text) as ReturnType<typeof estimatorInput>;
+}
+
+function nextTurnAbsId(turnAbsId: string): string | undefined {
+  const match = /^(.*:t)(\d+)$/u.exec(turnAbsId);
+  if (!match) return undefined;
+  return `${match[1]}${Number(match[2]) + 1}`;
+}
+
+async function startLifecycleEstimator(
+  sentinels: AcceptanceSentinels,
+): Promise<{
+  baseUrl: string;
+  registryVersions: number[];
+  errors: string[];
+  close(): Promise<void>;
+}> {
+  const registryVersions: number[] = [];
+  const errors: string[] = [];
+  let callCount = 0;
+  const server = createServer(async (request, response) => {
+    try {
+      if (request.method !== "POST" || request.url !== "/responses") {
+        response.statusCode = 404;
+        response.end("not found");
+        return;
+      }
+      const input = estimatorInput(await readJsonBody(request));
+      callCount += 1;
+      registryVersions.push(input.registry.version);
+
+      const evictResult = input.delta.toolResults.find((result) => (
+        result.summary.includes(sentinels.evict)
+      ));
+      const keepResult = input.delta.toolResults.find((result) => (
+        result.summary.includes(sentinels.keep)
+      ));
+      if (!evictResult || !keepResult) {
+        throw new Error("GUA-06 estimator delta is missing an eviction or retention tool result");
+      }
+
+      const keepTurnIds = new Set([
+        keepResult.anchor.turnAbsId,
+        nextTurnAbsId(keepResult.anchor.turnAbsId),
+      ].filter((value): value is string => Boolean(value)));
+      const evictTurnIds = input.delta.coveredTurnAbsIds.filter(
+        (turnAbsId) => !keepTurnIds.has(turnAbsId),
+      );
+      const output = {
+        baseVersion: input.registry.version,
+        taskUpdates: [
+          {
+            taskId: `task-gua06-evict-${callCount}`,
+            objective: "finish the synthetic task selected for eviction",
+            lifecycle: "evictable",
+            coveredTurnAbsIds: evictTurnIds,
+            completionEvidence: ["the synthetic tool-backed task completed"],
+            evictableReason: "the session moved to a different synthetic task",
+          },
+          {
+            taskId: `task-gua06-keep-${callCount}`,
+            objective: "continue the retained synthetic task",
+            lifecycle: "active",
+            coveredTurnAbsIds: [...keepTurnIds].filter((turnAbsId) => (
+              input.delta.coveredTurnAbsIds.includes(turnAbsId)
+            )),
+          },
+        ],
+      };
+      response.statusCode = 200;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({
+        id: `estimator-gua06-${callCount}`,
+        object: "response",
+        status: "completed",
+        output: [responseMessage(JSON.stringify(output))],
+      }));
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+      response.statusCode = 500;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }));
+    }
+  });
+  const port = await reserveUnusedPort();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    registryVersions,
+    errors,
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+function requestMetadata(phase: AcceptancePhase, subject: boolean): JsonObject {
+  return {
+    tokenpilotSessionId: SESSION_ID,
+    ...(subject ? { acceptanceSubject: phase } : {}),
+  };
+}
+
+async function runAcceptancePhase(params: {
+  phase: AcceptancePhase;
+  stateDir: string;
+  upstream: MockUpstreamRecorder;
+  estimatorBaseUrl: string;
+  sentinels: AcceptanceSentinels;
+  previousResponseId?: string;
+}): Promise<{ originalRequest: JsonObject; responseId: string }> {
+  params.upstream.setPhase(params.phase);
+  params.upstream.enqueueResponses(queuedPhaseResponses(params.phase));
+  const config = normalizeTokenPilotCodexConfig({
+    stateDir: params.stateDir,
+    proxyPort: await reserveUnusedPort(),
+    upstreamProvider: "OpenAI",
+    upstream: {
+      baseUrl: `${params.upstream.url}/v1`,
+      wireApi: "responses",
+      requiresOpenAIAuth: false,
+    },
+    modules: { stabilizer: false, reduction: false },
+    taskStateEstimator: {
+      enabled: true,
+      baseUrl: params.estimatorBaseUrl,
+      apiKey: "synthetic-gua06-estimator-key",
+      model: "synthetic-gua06-estimator",
+      batchTurns: 4,
+    },
+    contextRewrite: {
+      enabled: true,
+      providerCompatibilityProbe: "mock_fixture",
+    },
+  });
+  const runtime = await startCodexResponsesProxy({
+    config,
+    logger: createConsoleLogger(false),
+    allowMockFixtureEvidence: true,
+  });
+  let previousResponseId = params.previousResponseId;
+
+  const send = async (input: unknown[], subject = false): Promise<{
+    request: JsonObject;
+    responseId: string;
+  }> => {
+    const request: JsonObject = {
+      model: "gpt-5.4-mini",
+      stream: false,
+      ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
+      metadata: requestMetadata(params.phase, subject),
+      input,
+    };
+    const response = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    const responseText = await response.text();
+    assert.equal(response.status, 200, responseText);
+    const body = JSON.parse(responseText) as JsonObject;
+    const responseId = typeof body.id === "string" ? body.id : "";
+    assert.ok(responseId);
+    previousResponseId = responseId;
+    return { request, responseId };
+  };
+
+  try {
+    const evictCallId = `call-gua06-${params.phase}-evict`;
+    const keepCallId = `call-gua06-${params.phase}-keep`;
+    await send([{ role: "user", content: `start old synthetic task ${params.phase}` }]);
+    await send([{
+      type: "function_call_output",
+      call_id: evictCallId,
+      output: `${params.sentinels.evict}\n${"discardable fixture payload ".repeat(32)}`,
+    }]);
+    await send([{
+      role: "user",
+      content: `${params.sentinels.keep} start current synthetic task ${params.phase}`,
+    }]);
+    await send([{
+      type: "function_call_output",
+      call_id: keepCallId,
+      output: `${params.sentinels.keep} retained fixture result`,
+    }]);
+    const subject = await send([{
+      role: "user",
+      content: `GUA06_SUBJECT_${params.phase}`,
+    }], true);
+    return {
+      originalRequest: subject.request,
+      responseId: subject.responseId,
+    };
+  } finally {
+    await runtime.close();
+  }
+}
+
+function isAcceptanceSubject(body: unknown): boolean {
+  return JSON.stringify(body).includes("GUA06_SUBJECT_");
+}
+
+function countOccurrences(text: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let offset = 0;
+  while (true) {
+    const index = text.indexOf(needle, offset);
+    if (index < 0) return count;
+    count += 1;
+    offset = index + needle.length;
+  }
+}
+
+function responsePairCounts(body: unknown, callId: string): {
+  calls: number;
+  outputs: number;
+} {
+  const input = Array.isArray(asRecord(body)?.input)
+    ? asRecord(body)!.input as unknown[]
+    : [];
+  const items = input.map(asRecord).filter((item): item is JsonObject => Boolean(item));
+  return {
+    calls: items.filter((item) => (
+      item.type === "function_call" && item.call_id === callId
+    )).length,
+    outputs: items.filter((item) => (
+      item.type === "function_call_output" && item.call_id === callId
+    )).length,
+  };
+}
+
+test("GUA-06 accepts estimator-driven Codex rebase through a real proxy restart", async () => {
+  const environment = createTemporaryAcceptanceEnvironment("lightmem2-gua06-codex-");
+  const sentinels = createAcceptanceSentinels(TEST_UUID);
+  const upstream = new MockUpstreamRecorder();
+  const estimator = await startLifecycleEstimator(sentinels);
+  try {
+    await upstream.start();
+    const before = await runAcceptancePhase({
+      phase: "before_restart",
+      stateDir: environment.stateDir,
+      upstream,
+      estimatorBaseUrl: estimator.baseUrl,
+      sentinels,
+    });
+    const beforeRegistry = await loadSessionTaskRegistry(environment.stateDir, SESSION_ID);
+    const beforeTrace = await readFile(
+      `${environment.stateDir}/event-trace.jsonl`,
+      "utf8",
+    );
+    assert.equal(
+      beforeRegistry.version,
+      1,
+      `${beforeTrace}\nestimator_errors=${JSON.stringify(estimator.errors)}`,
+    );
+    assert.equal(beforeRegistry.lastProcessedTurnSeq, 4);
+
+    const after = await runAcceptancePhase({
+      phase: "after_restart",
+      stateDir: environment.stateDir,
+      upstream,
+      estimatorBaseUrl: estimator.baseUrl,
+      sentinels,
+      previousResponseId: before.responseId,
+    });
+    const afterRegistry = await loadSessionTaskRegistry(environment.stateDir, SESSION_ID);
+    assert.equal(afterRegistry.version, 2);
+    assert.equal(afterRegistry.lastProcessedTurnSeq, 9);
+    assert.deepEqual(estimator.registryVersions, [0, 1]);
+
+    const allRequests = upstream.requests();
+    assert.equal(allRequests.length, 10);
+    const afterRestartRequests = allRequests.filter((request) => (
+      request.phase === "after_restart"
+    ));
+    assert.equal(afterRestartRequests.length, 5);
+    assert.equal(
+      asRecord(afterRestartRequests[0]?.body)?.previous_response_id,
+      before.responseId,
+    );
+    const subjectRequests = allRequests.filter((request) => isAcceptanceSubject(request.body));
+    assert.equal(subjectRequests.length, 2);
+    assert.deepEqual(subjectRequests.map((request) => request.phase), [
+      "before_restart",
+      "after_restart",
+    ]);
+    assert.equal(subjectRequests.every((request) => (
+      !Object.hasOwn(asRecord(request.body) ?? {}, "previous_response_id")
+    )), true);
+    for (const request of subjectRequests) {
+      const serialized = JSON.stringify(request.body);
+      const phase = request.phase;
+      assert.equal(countOccurrences(serialized, `GUA06_SUBJECT_${phase}`), 1);
+      assert.deepEqual(
+        responsePairCounts(request.body, `call-gua06-${phase}-evict`),
+        { calls: 0, outputs: 0 },
+      );
+      assert.deepEqual(
+        responsePairCounts(request.body, `call-gua06-${phase}-keep`),
+        { calls: 1, outputs: 1 },
+      );
+    }
+
+    const summary = runAcceptanceHarness({
+      sentinels,
+      requests: subjectRequests,
+      originalRequests: {
+        before_restart: before.originalRequest,
+        after_restart: after.originalRequest,
+      },
+    });
+    assert.equal(summary.passed, true, JSON.stringify(summary));
+    assert.equal(summary.requestCount, 2);
+    assert.equal(summary.fallbackCount, 0);
+    assert.equal(summary.fallbackSucceeded, false);
+    assert.equal(summary.phases.every((phase) => phase.keepFound), true);
+    assert.equal(summary.phases.every((phase) => !phase.evictFound), true);
+    assert.equal(summary.phases.every((phase) => phase.toolClosure.complete), true);
+    assert.equal(summary.phases.every((phase) => (
+      phase.unsafeSuccessfulRequestSequences.length === 0
+    )), true);
+  } finally {
+    await estimator.close();
+    await upstream.close();
+    environment.cleanup();
+  }
+});

--- a/components/adapters/codex/tests/context-rewrite-lifecycle-input.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-lifecycle-input.test.ts
@@ -1,0 +1,706 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  planLifecycleEviction,
+  type TaskStateEstimator,
+} from "@lightmem2/eviction";
+import { createEmptySessionTaskRegistry } from "@lightmem2/history";
+
+import type {
+  CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryReasonCode,
+  CodexEffectiveHistoryView,
+  CodexRequestJournalEntry,
+  JsonObject,
+} from "../src/context-history/index.js";
+import {
+  buildCodexContextSnapshot,
+  buildCodexLifecycleBackendRequest,
+  buildCodexLifecycleInput,
+  codexSharedContextRewriteBackend,
+} from "../src/context-rewrite/index.js";
+
+const SESSION_ID = "codex-lifecycle-input-session";
+
+function effective(stableItemId: string, item: JsonObject): CodexEffectiveHistoryItem {
+  return { stableItemId, item };
+}
+
+function sourceView(params: {
+  items: CodexEffectiveHistoryItem[];
+  turns: Array<{ turnSeq: number; inputItemIds?: string[]; outputItemIds?: string[] }>;
+  semanticComplete?: boolean;
+  reasonCodes?: CodexEffectiveHistoryReasonCode[];
+  deferredItems?: CodexEffectiveHistoryItem[];
+  unresolvedCallIds?: string[];
+  historyIncomplete?: boolean;
+}): CodexEffectiveHistoryView {
+  return {
+    history: {
+      revision: "lifecycle-input-revision",
+      replayableItems: params.items,
+      observationOnlyItems: [],
+      deferredItems: params.deferredItems ?? [],
+      unresolvedCallIds: params.unresolvedCallIds ?? [],
+      source: "proxy_journal",
+      incomplete: params.historyIncomplete ?? false,
+    },
+    turns: params.turns.map((turn) => ({
+      turnSeq: turn.turnSeq,
+      turnAbsId: `${SESSION_ID}:t${turn.turnSeq}`,
+      inputItemIds: turn.inputItemIds ?? [],
+      outputItemIds: turn.outputItemIds ?? [],
+    })),
+    semanticComplete: params.semanticComplete ?? true,
+    reasonCodes: params.reasonCodes ?? [],
+  };
+}
+
+function pendingRequest(overrides: Partial<CodexRequestJournalEntry> = {}): CodexRequestJournalEntry {
+  return {
+    schema: "lightmem2.codex.context-history.request/v1",
+    kind: "request",
+    requestId: "request-current",
+    sessionId: SESSION_ID,
+    turnOrdinal: 4,
+    stream: false,
+    inputItems: [{ type: "message", role: "user", content: "current request" }],
+    status: "pending",
+    observedAt: "2026-08-15T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+test("lifecycle input accepts an explicitly expected pending request and builds closure-safe tool blocks", () => {
+  const encrypted = "opaque-reasoning-must-not-enter-semantic-input";
+  const view = sourceView({
+    items: [
+      effective("system", { type: "message", role: "system", content: "protected system" }),
+      effective("user", { type: "message", role: "user", content: "inspect the repository" }),
+      effective("call", {
+        type: "function_call",
+        call_id: "call-1",
+        name: "run_tests",
+        arguments: "{\"scope\":\"unit\"}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "EVICT_ME_codex-lifecycle-input",
+      }),
+      effective("reasoning", { type: "reasoning", encrypted_content: encrypted }),
+      effective("latest-user", {
+        type: "message",
+        role: "user",
+        content: "KEEP_ME_current-task",
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, inputItemIds: ["system", "user"], outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"], outputItemIds: ["reasoning"] },
+      { turnSeq: 3, inputItemIds: ["latest-user"] },
+    ],
+    semanticComplete: false,
+    reasonCodes: ["journal_current_request_uncommitted"],
+  });
+  const registry = {
+    ...createEmptySessionTaskRegistry(SESSION_ID),
+    version: 4,
+    activeTaskIds: ["task-active"],
+    evictableTaskIds: ["task-evict"],
+    turnToTaskIds: {
+      [`${SESSION_ID}:t1`]: ["task-evict"],
+      [`${SESSION_ID}:t2`]: ["task-evict"],
+      [`${SESSION_ID}:t3`]: ["task-active"],
+    },
+  };
+
+  const result = buildCodexLifecycleInput({
+    view,
+    registry,
+    expectedCurrentRequest: pendingRequest(),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [{ role: "user", content: "current request" }] },
+      effectiveHistory: view.history,
+    },
+    currentTaskIds: ["task-current", "task-current"],
+    closureDeferredTaskIds: ["task-closure"],
+  });
+
+  assert.equal(result.status, "ready");
+  if (result.status !== "ready") return;
+  assert.deepEqual(result.reasonCodes, []);
+  assert.equal(result.pendingTurnCount, 3);
+  assert.equal(result.delta.fromTurnSeqExclusive, 0);
+  assert.equal(result.delta.toTurnSeqInclusive, 3);
+  assert.deepEqual(result.delta.coveredTurnAbsIds, [
+    `${SESSION_ID}:t1`,
+    `${SESSION_ID}:t3`,
+  ]);
+  assert.equal(result.currentTurnAbsId, `${SESSION_ID}:t3`);
+  assert.deepEqual(result.activeTaskIds, ["task-active"]);
+  assert.deepEqual(result.currentTaskIds, ["task-current"]);
+  assert.deepEqual(result.closureDeferredTaskIds, ["task-closure"]);
+
+  assert.equal(result.historyBlocks.length, 1);
+  assert.deepEqual(result.historyBlocks[0], {
+    blockId: "history-block:result",
+    blockType: "tool_result",
+    lifecycleState: "ACTIVE",
+    segmentIds: ["result"],
+    text: "EVICT_ME_codex-lifecycle-input",
+    charCount: 30,
+    approxTokens: 8,
+    source: "codex_effective_history",
+    toolName: "run_tests",
+    turnAnchors: [
+      {
+        sessionId: SESSION_ID,
+        turnAbsId: `${SESSION_ID}:t1`,
+        turnSeq: 1,
+        role: "tool",
+      },
+      {
+        sessionId: SESSION_ID,
+        turnAbsId: `${SESSION_ID}:t2`,
+        turnSeq: 2,
+        role: "tool",
+      },
+    ],
+    turnAbsIds: [`${SESSION_ID}:t1`, `${SESSION_ID}:t2`],
+    taskIds: ["task-evict"],
+    metadata: {
+      callId: "call-1",
+      replayPairKind: "function",
+    },
+  });
+  assert.deepEqual(result.stableItemIdsByMessageId, {
+    result: ["call", "result"],
+  });
+  assert.deepEqual(result.backendRequest.taskIdsByItemId, {
+    system: ["task-evict"],
+    user: ["task-evict"],
+    call: ["task-evict"],
+    result: ["task-evict"],
+    reasoning: ["task-evict"],
+    "latest-user": ["task-active"],
+  });
+  assert.deepEqual(result.snapshot.adapterMetadata?.activeTaskIds, ["task-active"]);
+  assert.deepEqual(result.snapshot.adapterMetadata?.evictableTaskIds, ["task-evict"]);
+  assert.doesNotMatch(
+    JSON.stringify({ turns: result.rawSemanticTurns, blocks: result.historyBlocks }),
+    new RegExp(encrypted),
+  );
+});
+
+test("lifecycle input fails closed when the current pending boundary is not explicitly trusted", () => {
+  const view = sourceView({
+    items: [effective("user", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+    semanticComplete: false,
+    reasonCodes: ["journal_current_request_uncommitted"],
+  });
+  const result = buildCodexLifecycleInput({
+    view,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+
+  assert.equal(result.status, "deferred");
+  assert.deepEqual(result.reasonCodes, [
+    "journal_current_request_uncommitted",
+    "lifecycle_current_request_boundary_untrusted",
+  ]);
+});
+
+test("lifecycle input never masks unrelated history incompleteness behind the expected current request", () => {
+  const view = sourceView({
+    items: [effective("user", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+    semanticComplete: false,
+    reasonCodes: ["journal_current_request_uncommitted", "journal_malformed_stream"],
+    historyIncomplete: true,
+  });
+  const result = buildCodexLifecycleInput({
+    view,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    expectedCurrentRequest: pendingRequest(),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+
+  assert.equal(result.status, "deferred");
+  assert.ok(result.reasonCodes.includes("journal_malformed_stream"));
+  assert.ok(result.reasonCodes.includes("lifecycle_semantic_source_incomplete"));
+});
+
+test("lifecycle input defers partial and ambiguous tool closure", () => {
+  const partial = sourceView({
+    items: [effective("call", {
+      type: "function_call",
+      call_id: "call-partial",
+      name: "read_file",
+      arguments: "{}",
+    })],
+    turns: [{ turnSeq: 1, outputItemIds: ["call"] }],
+  });
+  const partialResult = buildCodexLifecycleInput({
+    view: partial,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: partial.history,
+    },
+  });
+  assert.equal(partialResult.status, "deferred");
+  assert.ok(partialResult.reasonCodes.includes("semantic_tool_closure_incomplete"));
+
+  const ambiguous = sourceView({
+    items: [
+      effective("call-1", {
+        type: "function_call",
+        call_id: "call-ambiguous",
+        name: "read_file",
+        arguments: "{}",
+      }),
+      effective("call-2", {
+        type: "function_call",
+        call_id: "call-ambiguous",
+        name: "read_file",
+        arguments: "{}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "call-ambiguous",
+        output: "result",
+      }),
+    ],
+    turns: [{ turnSeq: 1, outputItemIds: ["call-1", "call-2", "result"] }],
+  });
+  const ambiguousResult = buildCodexLifecycleInput({
+    view: ambiguous,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: ambiguous.history,
+    },
+  });
+  assert.equal(ambiguousResult.status, "deferred");
+  assert.ok(ambiguousResult.reasonCodes.includes("semantic_tool_closure_ambiguous"));
+});
+
+test("lifecycle input maps a complete custom tool pair to one closure-safe target", () => {
+  const view = sourceView({
+    items: [
+      effective("custom-call", {
+        type: "custom_tool_call",
+        call_id: "custom-1",
+        name: "apply_patch",
+        input: "*** Begin Patch",
+      }),
+      effective("custom-result", {
+        type: "custom_tool_call_output",
+        call_id: "custom-1",
+        output: [{ type: "output_text", text: "Done!" }],
+      }),
+    ],
+    turns: [
+      { turnSeq: 4, outputItemIds: ["custom-call"] },
+      { turnSeq: 5, inputItemIds: ["custom-result"] },
+    ],
+  });
+  const registry = {
+    ...createEmptySessionTaskRegistry(SESSION_ID),
+    turnToTaskIds: {
+      [`${SESSION_ID}:t4`]: ["task-custom"],
+      [`${SESSION_ID}:t5`]: ["task-custom"],
+    },
+  };
+  const result = buildCodexLifecycleInput({
+    view,
+    registry,
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+
+  assert.equal(result.status, "ready");
+  if (result.status !== "ready") return;
+  assert.deepEqual(result.stableItemIdsByMessageId, {
+    "custom-result": ["custom-call", "custom-result"],
+  });
+  assert.equal(result.historyBlocks[0]?.blockType, "tool_result");
+  assert.equal(result.historyBlocks[0]?.metadata?.replayPairKind, "custom");
+  assert.deepEqual(result.historyBlocks[0]?.taskIds, ["task-custom"]);
+});
+
+test("lifecycle input preserves the original tool call id when resolving targets", () => {
+  const originalCallId = " call-with-significant-spacing ";
+  const view = sourceView({
+    items: [
+      effective("call", {
+        type: "function_call",
+        call_id: originalCallId,
+        name: "run_tests",
+        arguments: "{}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: originalCallId,
+        output: "finished",
+      }),
+    ],
+    turns: [{ turnSeq: 1, outputItemIds: ["call", "result"] }],
+  });
+  const result = buildCodexLifecycleInput({
+    view,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+
+  assert.equal(result.status, "ready");
+  if (result.status !== "ready") return;
+  assert.equal(result.historyBlocks[0]?.metadata?.callId, originalCallId);
+  assert.deepEqual(result.stableItemIdsByMessageId.result, ["call", "result"]);
+});
+
+test("lifecycle backend request can be rebuilt with post-estimator task ownership", () => {
+  const view = sourceView({
+    items: [
+      effective("call", {
+        type: "function_call",
+        call_id: "call-1",
+        name: "run_tests",
+        arguments: "{}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "call-1",
+        output: "finished",
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+    ],
+  });
+  const before = createEmptySessionTaskRegistry(SESSION_ID);
+  const after = {
+    ...before,
+    version: 1,
+    evictableTaskIds: ["task-finished"],
+    turnToTaskIds: { [`${SESSION_ID}:t1`]: ["task-finished"] },
+  };
+  const backendRequest = buildCodexLifecycleBackendRequest({
+    view,
+    registry: after,
+    request: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+  const snapshot = buildCodexContextSnapshot(backendRequest);
+
+  assert.deepEqual(backendRequest.taskIdsByItemId, {
+    call: ["task-finished"],
+    result: ["task-finished"],
+  });
+  assert.deepEqual(snapshot.items.map((item) => item.taskIds), [
+    ["task-finished"],
+    ["task-finished"],
+  ]);
+  assert.deepEqual(snapshot.adapterMetadata?.evictableTaskIds, ["task-finished"]);
+});
+
+test("lifecycle input defers an explicitly cross-task tool pair", () => {
+  const view = sourceView({
+    items: [
+      effective("call", {
+        type: "function_call",
+        call_id: "call-cross-task",
+        name: "run_tests",
+        arguments: "{}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "call-cross-task",
+        output: "finished",
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+    ],
+  });
+  const result = buildCodexLifecycleInput({
+    view,
+    registry: {
+      ...createEmptySessionTaskRegistry(SESSION_ID),
+      turnToTaskIds: {
+        [`${SESSION_ID}:t1`]: ["task-call"],
+        [`${SESSION_ID}:t2`]: ["task-result"],
+      },
+    },
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+
+  assert.equal(result.status, "deferred");
+  assert.deepEqual(result.reasonCodes, ["lifecycle_tool_pair_task_mismatch"]);
+});
+
+test("lifecycle input defers an empty planner delta instead of emitting an invalid envelope", () => {
+  const view = sourceView({
+    items: [effective("user", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+  });
+  const result = buildCodexLifecycleInput({
+    view,
+    registry: {
+      ...createEmptySessionTaskRegistry(SESSION_ID),
+      lastProcessedTurnSeq: 1,
+    },
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+
+  assert.equal(result.status, "deferred");
+  assert.deepEqual(result.reasonCodes, ["lifecycle_no_pending_turns"]);
+});
+
+test("lifecycle input survives shared planner and backend closure validation across result turns", async () => {
+  const view = sourceView({
+    items: [
+      effective("user-old", {
+        type: "message",
+        role: "user",
+        content: "run the old task",
+      }),
+      effective("call", {
+        type: "function_call",
+        call_id: "call-planner",
+        name: "run_tests",
+        arguments: "{}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "call-planner",
+        output: "EVICT_ME_planner_contract",
+      }),
+      effective("user-current", {
+        type: "message",
+        role: "user",
+        content: "KEEP_ME_current_task",
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, inputItemIds: ["user-old"], outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+      { turnSeq: 3, inputItemIds: ["user-current"] },
+    ],
+  });
+  const registry = createEmptySessionTaskRegistry(SESSION_ID);
+  const lifecycle = buildCodexLifecycleInput({
+    view,
+    registry,
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+  assert.equal(lifecycle.status, "ready");
+  if (lifecycle.status !== "ready") return;
+
+  const estimator: TaskStateEstimator = {
+    estimate: () => ({
+      baseVersion: registry.version,
+      taskUpdates: [
+        {
+          taskId: "task-evict",
+          objective: "finish the old task",
+          lifecycle: "evictable",
+          coveredTurnAbsIds: [`${SESSION_ID}:t1`],
+          completionEvidence: ["tool result completed"],
+          evictableReason: "moved to a new task",
+        },
+        {
+          taskId: "task-current",
+          objective: "continue the current task",
+          lifecycle: "active",
+          coveredTurnAbsIds: [`${SESSION_ID}:t3`],
+        },
+      ],
+    }),
+  };
+  const planned = await planLifecycleEviction({
+    registry,
+    delta: lifecycle.delta,
+    pendingTurnCount: lifecycle.pendingTurnCount,
+    estimator,
+    historyBlocks: lifecycle.historyBlocks,
+    snapshot: lifecycle.snapshot,
+    stableItemIdsByMessageId: lifecycle.stableItemIdsByMessageId,
+    activeTaskIds: lifecycle.activeTaskIds,
+    currentTaskIds: lifecycle.currentTaskIds,
+    currentTurnAbsId: lifecycle.currentTurnAbsId,
+    closureDeferredTaskIds: lifecycle.closureDeferredTaskIds,
+    config: {
+      enabled: true,
+      batchTurns: 1,
+      evictionEnabled: true,
+      evictionPolicy: "model_scored",
+      evictionMinBlockChars: 1,
+    },
+    createdAt: "2026-08-16T00:00:00.000Z",
+  });
+
+  assert.equal(planned.status, "completed");
+  assert.ok(planned.reasonCodes.includes("mutation_plan_created"));
+  assert.deepEqual(planned.plan?.operations[0]?.targetItemIds, ["call", "result"]);
+  assert.ok(planned.plan);
+  if (!planned.plan) return;
+
+  const postEstimatorRequest = buildCodexLifecycleBackendRequest({
+    view: lifecycle.committedView,
+    registry: planned.registry,
+    request: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: lifecycle.committedView.history,
+    },
+  });
+  assert.deepEqual(postEstimatorRequest.taskIdsByItemId?.call, ["task-evict"]);
+  assert.deepEqual(postEstimatorRequest.taskIdsByItemId?.result, ["task-evict"]);
+  const validation = await codexSharedContextRewriteBackend.validate({
+    snapshot: buildCodexContextSnapshot(postEstimatorRequest),
+    plan: planned.plan,
+  });
+  assert.deepEqual(validation.applicableOperationIds, [planned.plan.operations[0]!.id]);
+  assert.deepEqual(validation.deferredOperationIds, []);
+});
+
+test("lifecycle input rejects registry identity and watermark drift", () => {
+  const view = sourceView({
+    items: [effective("user", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+  });
+  const mismatched = buildCodexLifecycleInput({
+    view,
+    registry: createEmptySessionTaskRegistry("another-session"),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+  assert.equal(mismatched.status, "deferred");
+  assert.deepEqual(mismatched.reasonCodes, ["lifecycle_registry_session_mismatch"]);
+
+  const invalidVersion = buildCodexLifecycleInput({
+    view,
+    registry: {
+      ...createEmptySessionTaskRegistry(SESSION_ID),
+      version: -1,
+    },
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+  assert.equal(invalidVersion.status, "deferred");
+  assert.deepEqual(invalidVersion.reasonCodes, ["lifecycle_registry_version_invalid"]);
+
+  const ahead = buildCodexLifecycleInput({
+    view,
+    registry: {
+      ...createEmptySessionTaskRegistry(SESSION_ID),
+      lastProcessedTurnSeq: 2,
+    },
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: view.history,
+    },
+  });
+  assert.equal(ahead.status, "deferred");
+  assert.deepEqual(ahead.reasonCodes, ["lifecycle_registry_ahead_of_history"]);
+});
+
+test("lifecycle input rejects invalid snapshot identity and remains deterministic", () => {
+  const invalidRevision = sourceView({
+    items: [effective("user", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+  });
+  invalidRevision.history.revision = " ";
+  const invalidRevisionResult = buildCodexLifecycleInput({
+    view: invalidRevision,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: invalidRevision.history,
+    },
+  });
+  assert.equal(invalidRevisionResult.status, "deferred");
+  assert.deepEqual(invalidRevisionResult.reasonCodes, ["lifecycle_snapshot_identity_invalid"]);
+
+  const blankStableId = sourceView({
+    items: [effective("", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: [""] }],
+  });
+  const blankStableIdResult = buildCodexLifecycleInput({
+    view: blankStableId,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: blankStableId.history,
+    },
+  });
+  assert.equal(blankStableIdResult.status, "deferred");
+  assert.deepEqual(blankStableIdResult.reasonCodes, ["lifecycle_snapshot_identity_invalid"]);
+
+  const valid = sourceView({
+    items: [effective("user", { type: "message", role: "user", content: "hello" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+  });
+  const params = {
+    view: valid,
+    registry: createEmptySessionTaskRegistry(SESSION_ID),
+    backendRequest: {
+      sessionId: SESSION_ID,
+      payload: { input: [] },
+      effectiveHistory: valid.history,
+    },
+  };
+  assert.deepEqual(
+    buildCodexLifecycleInput(structuredClone(params)),
+    buildCodexLifecycleInput(structuredClone(params)),
+  );
+});

--- a/components/adapters/codex/tests/context-rewrite-lifecycle-runner.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-lifecycle-runner.test.ts
@@ -1,0 +1,651 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  loadSessionTaskRegistry,
+  persistSessionTaskRegistry,
+  sessionTaskRegistryPath,
+} from "@lightmem2/history";
+import type {
+  LifecyclePlannerConfig,
+  TaskStateEstimator,
+} from "@lightmem2/eviction";
+
+import type {
+  CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryView,
+  JsonObject,
+} from "../src/context-history/index.js";
+import {
+  acquireCodexRebaseSessionLock,
+  codexSharedContextRewriteBackend,
+  revalidateCodexLifecyclePreparedPlan,
+  runCodexLifecyclePlanner,
+  type CodexLifecycleBackendRequestBase,
+} from "../src/context-rewrite/index.js";
+
+const SESSION_ID = "codex-lifecycle-runner-session";
+const CREATED_AT = "2026-08-16T00:00:00.000Z";
+const PLANNER_CONFIG: LifecyclePlannerConfig = {
+  enabled: true,
+  batchTurns: 1,
+  evictionEnabled: true,
+  evictionPolicy: "model_scored",
+  evictionMinBlockChars: 1,
+};
+
+async function tempStateDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "lightmem2-codex-lifecycle-runner-"));
+}
+
+function effective(stableItemId: string, item: JsonObject): CodexEffectiveHistoryItem {
+  return { stableItemId, item };
+}
+
+function sourceView(params: {
+  items: CodexEffectiveHistoryItem[];
+  turns: Array<{
+    turnSeq: number;
+    inputItemIds?: string[];
+    outputItemIds?: string[];
+  }>;
+}): CodexEffectiveHistoryView {
+  return {
+    history: {
+      revision: "lifecycle-runner-revision",
+      replayableItems: params.items,
+      observationOnlyItems: [],
+      deferredItems: [],
+      unresolvedCallIds: [],
+      source: "proxy_journal",
+      incomplete: false,
+    },
+    turns: params.turns.map((turn) => ({
+      turnSeq: turn.turnSeq,
+      turnAbsId: `${SESSION_ID}:t${turn.turnSeq}`,
+      inputItemIds: turn.inputItemIds ?? [],
+      outputItemIds: turn.outputItemIds ?? [],
+    })),
+    semanticComplete: true,
+    reasonCodes: [],
+  };
+}
+
+function plannerView(): CodexEffectiveHistoryView {
+  return sourceView({
+    items: [
+      effective("user-old", {
+        type: "message",
+        role: "user",
+        content: "run the old task",
+      }),
+      effective("call", {
+        type: "function_call",
+        call_id: "call-runner",
+        name: "run_tests",
+        arguments: "{}",
+      }),
+      effective("result", {
+        type: "function_call_output",
+        call_id: "call-runner",
+        output: "EVICT_ME_runner_contract",
+      }),
+      effective("user-current", {
+        type: "message",
+        role: "user",
+        content: "KEEP_ME_current_task",
+      }),
+    ],
+    turns: [
+      { turnSeq: 1, inputItemIds: ["user-old"], outputItemIds: ["call"] },
+      { turnSeq: 2, inputItemIds: ["result"] },
+      { turnSeq: 3, inputItemIds: ["user-current"] },
+    ],
+  });
+}
+
+function backendRequest(view: CodexEffectiveHistoryView): CodexLifecycleBackendRequestBase {
+  return {
+    sessionId: SESSION_ID,
+    payload: {
+      model: "fixture-model",
+      previous_response_id: "response-parent",
+      input: [{ type: "message", role: "user", content: "next request" }],
+    },
+    effectiveHistory: view.history,
+  };
+}
+
+function completingEstimator(
+  beforeReturn?: () => Promise<void>,
+): TaskStateEstimator {
+  return {
+    async estimate(input) {
+      await beforeReturn?.();
+      return {
+        baseVersion: input.registry.version,
+        taskUpdates: [
+          {
+            taskId: "task-evict",
+            objective: "finish the old task",
+            lifecycle: "evictable",
+            coveredTurnAbsIds: [`${SESSION_ID}:t1`],
+            completionEvidence: ["tool result completed"],
+            evictableReason: "moved to a new task",
+          },
+          {
+            taskId: "task-current",
+            objective: "continue the current task",
+            lifecycle: "active",
+            coveredTurnAbsIds: [`${SESSION_ID}:t3`],
+          },
+        ],
+      };
+    },
+  };
+}
+
+test("lifecycle runner persists the planner registry before exposing a validated plan", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: completingEstimator(),
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.attemptedEstimator, true);
+  assert.equal(result.registryPersisted, true);
+  assert.equal(result.registryChanged, true);
+  assert.equal(result.registryVersionBefore, 0);
+  assert.equal(result.registryVersionAfter, 1);
+  assert.equal(result.preparedPlan?.registryVersion, 1);
+  assert.ok(result.reasonCodes.includes("mutation_plan_created"));
+  assert.deepEqual(
+    result.preparedPlan?.plan.operations[0]?.targetItemIds,
+    ["call", "result"],
+  );
+  assert.deepEqual(
+    result.preparedPlan?.backendRequest.taskIdsByItemId?.call,
+    ["task-evict"],
+  );
+  assert.deepEqual(
+    result.preparedPlan?.backendRequest.taskIdsByItemId?.result,
+    ["task-evict"],
+  );
+
+  const persisted = await loadSessionTaskRegistry(stateDir, SESSION_ID);
+  assert.equal(persisted.version, 1);
+  assert.equal(persisted.lastProcessedTurnSeq, 3);
+  assert.deepEqual(persisted.evictableTaskIds, ["task-evict"]);
+  assert.deepEqual(persisted.activeTaskIds, ["task-current"]);
+
+  assert.ok(result.preparedPlan);
+  if (!result.preparedPlan) return;
+  const applied = await codexSharedContextRewriteBackend.apply({
+    snapshot: result.preparedPlan.snapshot,
+    plan: result.preparedPlan.plan,
+    request: result.preparedPlan.backendRequest,
+  });
+  assert.equal(applied.result.applied, true);
+  assert.equal(applied.result.changed, true);
+  assert.doesNotMatch(JSON.stringify(applied.request.payload), /EVICT_ME_runner_contract/);
+  assert.match(JSON.stringify(applied.request.payload), /KEEP_ME_current_task/);
+});
+
+test("lifecycle plan handoff rejects registry-version and snapshot drift", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: completingEstimator(),
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+  assert.ok(result.preparedPlan);
+  if (!result.preparedPlan) return;
+
+  const current = await revalidateCodexLifecyclePreparedPlan({
+    stateDir,
+    sessionId: SESSION_ID,
+    preparedPlan: result.preparedPlan,
+    view,
+    backendRequest: backendRequest(view),
+  });
+  assert.deepEqual(current, {
+    valid: true,
+    reasonCodes: [],
+    registryVersion: 1,
+  });
+
+  const changedView = structuredClone(view);
+  changedView.history.revision = "lifecycle-runner-revision-changed";
+  changedView.history.replayableItems[0]!.item.content = "history changed after planning";
+  const snapshotDrift = await revalidateCodexLifecyclePreparedPlan({
+    stateDir,
+    sessionId: SESSION_ID,
+    preparedPlan: result.preparedPlan,
+    view: changedView,
+    backendRequest: backendRequest(changedView),
+  });
+  assert.deepEqual(snapshotDrift, {
+    valid: false,
+    reasonCodes: ["lifecycle_execution_snapshot_changed"],
+    registryVersion: 1,
+  });
+
+  const persisted = await loadSessionTaskRegistry(stateDir, SESSION_ID);
+  await persistSessionTaskRegistry(
+    stateDir,
+    { ...persisted, version: persisted.version + 1 },
+    { expectedVersion: persisted.version },
+  );
+  const registryDrift = await revalidateCodexLifecyclePreparedPlan({
+    stateDir,
+    sessionId: SESSION_ID,
+    preparedPlan: result.preparedPlan,
+    view,
+    backendRequest: backendRequest(view),
+  });
+  assert.deepEqual(registryDrift, {
+    valid: false,
+    reasonCodes: ["lifecycle_execution_registry_version_changed"],
+    registryVersion: 2,
+  });
+});
+
+test("lifecycle runner persists a successful no-op watermark without exposing a plan", async () => {
+  const stateDir = await tempStateDir();
+  const view = sourceView({
+    items: [effective("user", {
+      type: "message",
+      role: "user",
+      content: "nothing to update",
+    })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+  });
+  let estimatorCalls = 0;
+  const estimator: TaskStateEstimator = {
+    estimate: (input) => {
+      estimatorCalls += 1;
+      return { baseVersion: input.registry.version, taskUpdates: [] };
+    },
+  };
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator,
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "completed");
+  assert.equal(result.registryPersisted, true);
+  assert.equal(result.registryChanged, false);
+  assert.equal(result.preparedPlan, undefined);
+  assert.deepEqual(result.reasonCodes, [
+    "registry_watermark_advanced",
+    "no_eviction_candidates",
+  ]);
+  const persisted = await loadSessionTaskRegistry(stateDir, SESSION_ID);
+  assert.equal(persisted.version, 1);
+  assert.equal(persisted.lastProcessedTurnSeq, 1);
+
+  const retry = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator,
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+  assert.equal(retry.status, "deferred");
+  assert.deepEqual(retry.reasonCodes, ["lifecycle_no_pending_turns"]);
+  assert.equal(estimatorCalls, 1);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 1);
+});
+
+test("lifecycle runner defers below the batch threshold without calling the estimator", async () => {
+  const stateDir = await tempStateDir();
+  const view = sourceView({
+    items: [effective("user", { type: "message", role: "user", content: "one turn" })],
+    turns: [{ turnSeq: 1, inputItemIds: ["user"] }],
+  });
+  let estimatorCalled = false;
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: {
+      estimate: () => {
+        estimatorCalled = true;
+        return { baseVersion: 0, taskUpdates: [] };
+      },
+    },
+    config: { ...PLANNER_CONFIG, batchTurns: 2 },
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "deferred");
+  assert.deepEqual(result.reasonCodes, ["insufficient_pending_turns"]);
+  assert.equal(estimatorCalled, false);
+  assert.equal(result.registryPersisted, false);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 0);
+});
+
+test("lifecycle runner leaves the registry unchanged on estimator failure", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: {
+      estimate: () => {
+        throw new Error("private upstream error must not escape");
+      },
+    },
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "bypassed");
+  assert.deepEqual(result.reasonCodes, ["estimator_failed"]);
+  assert.equal(result.attemptedEstimator, true);
+  assert.equal(result.registryPersisted, false);
+  assert.equal(result.preparedPlan, undefined);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 0);
+  assert.doesNotMatch(JSON.stringify(result), /private upstream error/);
+
+  const retry = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: completingEstimator(),
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+  assert.equal(retry.status, "completed");
+  assert.equal(retry.registryVersionBefore, 0);
+  assert.equal(retry.registryVersionAfter, 1);
+  assert.ok(retry.preparedPlan);
+});
+
+test("lifecycle runner rejects invalid estimator output without persisting state", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: {
+      estimate: () => ({
+        baseVersion: 0,
+        taskUpdates: [{
+          taskId: "",
+          objective: "",
+          lifecycle: "active",
+        }],
+      }),
+    },
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "bypassed");
+  assert.deepEqual(result.reasonCodes, ["estimator_output_invalid"]);
+  assert.equal(result.registryPersisted, false);
+  assert.equal(result.preparedPlan, undefined);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 0);
+});
+
+test("lifecycle runner defers incomplete tool closure before estimator execution", async () => {
+  const stateDir = await tempStateDir();
+  const view = sourceView({
+    items: [effective("call", {
+      type: "function_call",
+      call_id: "call-incomplete",
+      name: "run_tests",
+      arguments: "{}",
+    })],
+    turns: [{ turnSeq: 1, outputItemIds: ["call"] }],
+  });
+  let estimatorCalled = false;
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: {
+      estimate: () => {
+        estimatorCalled = true;
+        return { baseVersion: 0, taskUpdates: [] };
+      },
+    },
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "deferred");
+  assert.ok(result.reasonCodes.includes("semantic_tool_closure_incomplete"));
+  assert.equal(estimatorCalled, false);
+  assert.equal(result.registryPersisted, false);
+});
+
+test("lifecycle runner drops a prepared plan when registry CAS loses", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: completingEstimator(async () => {
+      const current = await loadSessionTaskRegistry(stateDir, SESSION_ID);
+      await persistSessionTaskRegistry(stateDir, { ...current, version: 5 });
+    }),
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "deferred");
+  assert.equal(result.registryPersisted, false);
+  assert.equal(result.registryVersionBefore, 0);
+  assert.equal(result.registryVersionAfter, 5);
+  assert.ok(result.reasonCodes.includes("lifecycle_runner_registry_version_conflict"));
+  assert.equal(result.preparedPlan, undefined);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 5);
+
+  const retry = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: completingEstimator(),
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+  assert.equal(retry.status, "completed");
+  assert.equal(retry.registryVersionBefore, 5);
+  assert.equal(retry.registryVersionAfter, 6);
+  assert.equal(retry.preparedPlan?.registryVersion, 6);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 6);
+});
+
+test("lifecycle runner defers while the Codex rebase session lock is owned", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  const lock = await acquireCodexRebaseSessionLock({ stateDir, sessionId: SESSION_ID });
+  assert.ok(lock);
+  let estimatorCalled = false;
+  try {
+    const result = await runCodexLifecyclePlanner({
+      stateDir,
+      sessionId: SESSION_ID,
+      view,
+      backendRequest: backendRequest(view),
+      estimator: {
+        estimate: () => {
+          estimatorCalled = true;
+          return { baseVersion: 0, taskUpdates: [] };
+        },
+      },
+      config: PLANNER_CONFIG,
+      createdAt: CREATED_AT,
+    });
+    assert.equal(result.status, "deferred");
+    assert.deepEqual(result.reasonCodes, ["lifecycle_runner_lock_busy"]);
+    assert.equal(estimatorCalled, false);
+  } finally {
+    await lock?.release();
+  }
+});
+
+test("concurrent lifecycle runners estimate and persist a session only once", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  let releaseEstimator!: () => void;
+  let announceEstimator!: () => void;
+  const estimatorGate = new Promise<void>((resolve) => {
+    releaseEstimator = resolve;
+  });
+  const estimatorEntered = new Promise<void>((resolve) => {
+    announceEstimator = resolve;
+  });
+  let estimatorCalls = 0;
+  const first = runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: {
+      async estimate(input) {
+        estimatorCalls += 1;
+        announceEstimator();
+        await estimatorGate;
+        return {
+          baseVersion: input.registry.version,
+          taskUpdates: [],
+        };
+      },
+    },
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+  await estimatorEntered;
+
+  const concurrent = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: {
+      estimate: () => {
+        estimatorCalls += 1;
+        return { baseVersion: 0, taskUpdates: [] };
+      },
+    },
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+  releaseEstimator();
+  const completed = await first;
+
+  assert.equal(concurrent.status, "deferred");
+  assert.deepEqual(concurrent.reasonCodes, ["lifecycle_runner_lock_busy"]);
+  assert.equal(completed.status, "completed");
+  assert.equal(estimatorCalls, 1);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 1);
+});
+
+test("lifecycle runner bypasses disabled or missing estimators before state I/O", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  let estimatorCalled = false;
+  const disabled = await runCodexLifecyclePlanner({
+    stateDir: "   ",
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: {
+      estimate: () => {
+        estimatorCalled = true;
+        return { baseVersion: 0, taskUpdates: [] };
+      },
+    },
+    config: { ...PLANNER_CONFIG, enabled: false },
+    createdAt: CREATED_AT,
+  });
+  const missing = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: null,
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.deepEqual(disabled.reasonCodes, ["planner_disabled"]);
+  assert.deepEqual(missing.reasonCodes, ["estimator_missing"]);
+  assert.equal(estimatorCalled, false);
+  assert.equal((await loadSessionTaskRegistry(stateDir, SESSION_ID)).version, 0);
+});
+
+test("lifecycle runner rejects an empty state directory before creating lock state", async () => {
+  const view = plannerView();
+  const result = await runCodexLifecyclePlanner({
+    stateDir: "   ",
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: completingEstimator(),
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "bypassed");
+  assert.deepEqual(result.reasonCodes, ["lifecycle_runner_state_dir_invalid"]);
+  assert.equal(result.attemptedEstimator, false);
+  assert.equal(result.preparedPlan, undefined);
+});
+
+test("lifecycle runner fails open when the persisted registry is unreadable", async () => {
+  const stateDir = await tempStateDir();
+  const view = plannerView();
+  const path = sessionTaskRegistryPath(stateDir, SESSION_ID);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, "{not-json", "utf8");
+  const result = await runCodexLifecyclePlanner({
+    stateDir,
+    sessionId: SESSION_ID,
+    view,
+    backendRequest: backendRequest(view),
+    estimator: completingEstimator(),
+    config: PLANNER_CONFIG,
+    createdAt: CREATED_AT,
+  });
+
+  assert.equal(result.status, "bypassed");
+  assert.deepEqual(result.reasonCodes, ["lifecycle_runner_registry_load_failed"]);
+  assert.equal(result.attemptedEstimator, false);
+  assert.equal(result.preparedPlan, undefined);
+});

--- a/components/adapters/codex/tests/context-rewrite-lifecycle-runtime.test.ts
+++ b/components/adapters/codex/tests/context-rewrite-lifecycle-runtime.test.ts
@@ -1,0 +1,531 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { loadSessionTaskRegistry } from "@lightmem2/history";
+import { reserveUnusedPort } from "@lightmem2/host-adapter";
+
+import { normalizeTokenPilotCodexConfig } from "../src/config.js";
+import { buildCodexEffectiveHistory } from "../src/context-history/index.js";
+import { createConsoleLogger } from "../src/logger.js";
+import { startCodexResponsesProxy } from "../src/proxy-runtime.js";
+
+type JsonObject = Record<string, unknown>;
+
+async function readBody(req: Parameters<Parameters<typeof createServer>[0]>[0]): Promise<JsonObject> {
+  const text = await new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk))));
+    req.on("error", reject);
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+  return JSON.parse(text) as JsonObject;
+}
+
+async function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  const port = await reserveUnusedPort();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return port;
+}
+
+async function close(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+function responseMessage(text: string): JsonObject {
+  return {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text }],
+  };
+}
+
+async function startLifecycleUpstream(params?: { firstResponseToolCall?: boolean }): Promise<{
+  baseUrl: string;
+  requests: JsonObject[];
+  close(): Promise<void>;
+}> {
+  const requests: JsonObject[] = [];
+  const server = createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/v1/responses") {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    const payload = await readBody(req);
+    requests.push(payload);
+    const requestNumber = requests.length;
+    const output = requestNumber === 1 && params?.firstResponseToolCall !== false
+      ? [{
+          id: "call-item-lifecycle",
+          type: "function_call",
+          call_id: "call-lifecycle-runtime",
+          name: "read_fixture",
+          arguments: "{}",
+        }]
+      : [responseMessage(`completed request ${requestNumber}`)];
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({
+      id: `resp-lifecycle-${requestNumber}`,
+      object: "response",
+      status: "completed",
+      output,
+    }));
+  });
+  const port = await listen(server);
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close: () => close(server),
+  };
+}
+
+async function startEstimator(
+  sessionId: string,
+  mode: "tasks" | "noop" | "fail" = "tasks",
+): Promise<{
+  baseUrl: string;
+  calls(): number;
+  close(): Promise<void>;
+}> {
+  let callCount = 0;
+  const server = createServer(async (req, res) => {
+    if (
+      req.method !== "POST"
+      || (req.url !== "/responses" && req.url !== "/chat/completions")
+    ) {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    await readBody(req);
+    callCount += 1;
+    if (mode === "fail") {
+      res.statusCode = 500;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: { code: "synthetic_estimator_failure" } }));
+      return;
+    }
+    const estimatorOutput = mode === "noop" ? {
+      baseVersion: 0,
+      taskUpdates: [],
+    } : {
+      baseVersion: 0,
+      taskUpdates: [
+        {
+          taskId: "task-lifecycle-evict",
+          objective: "finish reading the old fixture",
+          lifecycle: "evictable",
+          coveredTurnAbsIds: [`${sessionId}:t1`, `${sessionId}:t2`],
+          completionEvidence: ["fixture read completed"],
+          evictableReason: "the session moved to a different task",
+        },
+        {
+          taskId: "task-lifecycle-current",
+          objective: "continue the retained task",
+          lifecycle: "active",
+          coveredTurnAbsIds: [`${sessionId}:t3`],
+        },
+      ],
+    };
+    res.statusCode = 200;
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(req.url === "/chat/completions"
+      ? {
+          id: `estimator-chat-${callCount}`,
+          choices: [{ message: { content: JSON.stringify(estimatorOutput) } }],
+        }
+      : {
+          id: `estimator-response-${callCount}`,
+          status: "completed",
+          output: [responseMessage(JSON.stringify(estimatorOutput))],
+        }));
+  });
+  const port = await listen(server);
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    calls: () => callCount,
+    close: () => close(server),
+  };
+}
+
+function requestInputText(payload: JsonObject | undefined): string {
+  return JSON.stringify(Array.isArray(payload?.input) ? payload.input : []);
+}
+
+test("Codex proxy uses lifecycle planning instead of a conflicting manual plan", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-lifecycle-runtime-"));
+  const sessionId = "codex-lifecycle-runtime-session";
+  const upstream = await startLifecycleUpstream();
+  const estimator = await startEstimator(sessionId);
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveUnusedPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: { stabilizer: false, reduction: false },
+      taskStateEstimator: {
+        enabled: true,
+        baseUrl: estimator.baseUrl,
+        apiKey: "synthetic-estimator-key",
+        model: "synthetic-estimator",
+        batchTurns: 3,
+      },
+      contextRewrite: {
+        enabled: true,
+        providerCompatibilityProbe: "mock_fixture",
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+      allowMockFixtureEvidence: true,
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "start the fixture task" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const evict = `EVICT_ME_lifecycle_runtime_${"x".repeat(400)}`;
+    const keep = "KEEP_ME_lifecycle_runtime";
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-lifecycle-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [
+          {
+            type: "function_call_output",
+            call_id: "call-lifecycle-runtime",
+            output: evict,
+          },
+        ],
+      }),
+    });
+    assert.equal(second.status, 200);
+
+    const third = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-lifecycle-2",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: keep }],
+      }),
+    });
+    assert.equal(third.status, 200);
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const keepItem = history.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes(keep)
+    ));
+    assert.ok(keepItem);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: keepItem.stableItemId }],
+    };
+
+    const fourth = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-lifecycle-3",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "continue with the current task" }],
+      }),
+    });
+    assert.equal(fourth.status, 200);
+    assert.equal(estimator.calls(), 1);
+    assert.equal(upstream.requests.length, 4);
+    const lifecyclePayload = upstream.requests[3];
+    const lifecycleEvents = (await readFile(join(stateDir, "event-trace.jsonl"), "utf8"))
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as JsonObject)
+      .filter((row) => String(row.stage).startsWith("context_rewrite_"));
+    assert.equal(
+      "previous_response_id" in (lifecyclePayload ?? {}),
+      false,
+      JSON.stringify(lifecycleEvents),
+    );
+    assert.doesNotMatch(requestInputText(lifecyclePayload), /EVICT_ME_lifecycle_runtime/);
+    assert.match(requestInputText(lifecyclePayload), /KEEP_ME_lifecycle_runtime/);
+
+    const registry = await loadSessionTaskRegistry(stateDir, sessionId);
+    assert.equal(registry.version, 1);
+    assert.deepEqual(registry.evictableTaskIds, ["task-lifecycle-evict"]);
+    assert.deepEqual(registry.activeTaskIds, ["task-lifecycle-current"]);
+  } finally {
+    await runtime?.close();
+    await estimator.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex proxy does not fall back to a manual plan when lifecycle config is incomplete", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-lifecycle-incomplete-"));
+  const sessionId = "codex-lifecycle-incomplete-session";
+  const upstream = await startLifecycleUpstream();
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveUnusedPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: { stabilizer: false, reduction: false },
+      taskStateEstimator: {
+        enabled: true,
+        baseUrl: "http://127.0.0.1:1",
+        model: "synthetic-estimator",
+      },
+      contextRewrite: {
+        enabled: true,
+        providerCompatibilityProbe: "disabled",
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "MANUAL_TARGET_lifecycle_incomplete" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const manualTarget = history.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes("MANUAL_TARGET_lifecycle_incomplete")
+    ));
+    assert.ok(manualTarget);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: manualTarget.stableItemId }],
+    };
+
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-lifecycle-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "keep the original response chain" }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    assert.equal(upstream.requests.length, 2);
+    assert.equal(upstream.requests[1]?.previous_response_id, "resp-lifecycle-1");
+  } finally {
+    await runtime?.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex proxy does not consume a completed request retry twice", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-lifecycle-retry-"));
+  const sessionId = "codex-lifecycle-retry-session";
+  const upstream = await startLifecycleUpstream({ firstResponseToolCall: false });
+  const estimator = await startEstimator(sessionId, "noop");
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveUnusedPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: { stabilizer: false, reduction: false },
+      taskStateEstimator: {
+        enabled: true,
+        baseUrl: estimator.baseUrl,
+        apiKey: "synthetic-estimator-key",
+        model: "synthetic-estimator",
+        batchTurns: 1,
+      },
+      contextRewrite: {
+        enabled: true,
+        providerCompatibilityProbe: "disabled",
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "establish one committed turn" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const retryBody = JSON.stringify({
+      model: "gpt-5.4-mini",
+      stream: false,
+      previous_response_id: "resp-lifecycle-1",
+      metadata: { tokenpilotSessionId: sessionId },
+      input: [{ role: "user", content: "retry this exact request" }],
+    });
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: retryBody,
+    });
+    assert.equal(second.status, 200);
+    const retry = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: retryBody,
+    });
+    assert.equal(retry.status, 200);
+
+    assert.equal(estimator.calls(), 1);
+    const registry = await loadSessionTaskRegistry(stateDir, sessionId);
+    assert.equal(registry.version, 1);
+    assert.equal(registry.lastProcessedTurnSeq, 1);
+    assert.equal(upstream.requests.length, 3);
+    assert.equal(upstream.requests[2]?.previous_response_id, "resp-lifecycle-1");
+  } finally {
+    await runtime?.close();
+    await estimator.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex proxy keeps the original chain when the estimator fails", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightmem2-codex-lifecycle-estimator-fail-"));
+  const sessionId = "codex-lifecycle-estimator-fail-session";
+  const upstream = await startLifecycleUpstream({ firstResponseToolCall: false });
+  const estimator = await startEstimator(sessionId, "fail");
+  let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+  try {
+    const config = normalizeTokenPilotCodexConfig({
+      stateDir,
+      proxyPort: await reserveUnusedPort(),
+      upstreamProvider: "OpenAI",
+      upstream: {
+        baseUrl: upstream.baseUrl,
+        wireApi: "responses",
+        requiresOpenAIAuth: false,
+      },
+      modules: { stabilizer: false, reduction: false },
+      taskStateEstimator: {
+        enabled: true,
+        baseUrl: estimator.baseUrl,
+        apiKey: "synthetic-estimator-key",
+        model: "synthetic-estimator",
+        batchTurns: 1,
+      },
+      contextRewrite: {
+        enabled: true,
+        providerCompatibilityProbe: "disabled",
+        mutationPlan: { operations: [] },
+      },
+    } as any);
+    runtime = await startCodexResponsesProxy({
+      config,
+      logger: createConsoleLogger(false),
+    });
+
+    const first = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "MANUAL_TARGET_estimator_failure" }],
+      }),
+    });
+    assert.equal(first.status, 200);
+
+    const history = await buildCodexEffectiveHistory({ stateDir, sessionId });
+    const manualTarget = history.replayableItems.find((entry) => (
+      JSON.stringify(entry.item).includes("MANUAL_TARGET_estimator_failure")
+    ));
+    assert.ok(manualTarget);
+    (config as any).contextRewrite.mutationPlan = {
+      operations: [{ type: "evict", stableItemId: manualTarget.stableItemId }],
+    };
+
+    const second = await fetch(`${runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "resp-lifecycle-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "preserve the chain after estimator failure" }],
+      }),
+    });
+    assert.equal(second.status, 200);
+    assert.equal(estimator.calls(), 2);
+    assert.equal(upstream.requests.length, 2);
+    assert.equal(upstream.requests[1]?.previous_response_id, "resp-lifecycle-1");
+    const registry = await loadSessionTaskRegistry(stateDir, sessionId);
+    assert.equal(registry.version, 0);
+    assert.equal(registry.lastProcessedTurnSeq, 0);
+  } finally {
+    await runtime?.close();
+    await estimator.close();
+    await upstream.close();
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/docs/acceptance/GUA-06.md
+++ b/docs/acceptance/GUA-06.md
@@ -39,31 +39,69 @@ The restart check proves that request overlay remains safe across process lifeti
 
 ## Codex Response-chain Rebase
 
-The Codex adapter already owns streaming, non-streaming, fallback, cooldown, epoch recovery, journal ordering, malformed closure, and restart tests under:
-
-```text
-components/adapters/codex/tests/
-```
-
 Command:
 
 ```text
 pnpm --dir components/adapters/codex test
 ```
 
-Codex status: **PASS** for committed mock response-chain rebase tests. PR #15 does not add or modify Codex runtime behavior.
+The focused estimator-driven acceptance test verifies:
+
+- Ten successful requests pass through two distinct Codex proxy runtime
+  lifetimes using one isolated state directory and one response-chain session.
+- A fake estimator consumes the real canonical delta and automatically drives
+  `registry -> shared lifecycle planner -> ContextMutationPlan -> rebase`; the
+  test does not inject `contextRewrite.mutationPlan`.
+- The task registry persists across restart (`version 0 -> 1 -> 2`) and the
+  estimator observes the expected base versions (`0`, then `1`).
+- Each lifetime first commits four setup turns containing one evictable and one
+  retained tool pair. The shared oracle scores the planner-triggering request
+  from each phase, identified by its current-user subject marker.
+- Both captured stateless rebase requests remove `previous_response_id` and
+  `EVICT_ME_<uuid>`, preserve `KEEP_ME_<uuid>` and the current turn, and retain
+  complete Responses `function_call` / `function_call_output` closure.
+- No fallback request succeeds in either phase.
+
+Codex status: **PASS** for non-streaming estimator-driven mock-upstream
+acceptance across proxy restart. Streaming, fallback, cooldown, epoch recovery,
+journal ordering, malformed closure, and provider-compatibility scenarios stay
+covered by the adapter's dedicated tests.
+
+Unlike a full-history gateway request, a Codex native continuation carries old
+history implicitly through `previous_response_id`. Consequently the shared
+oracle is used here for sentinel, closure, and fallback safety on the two
+planner-triggering requests; raw request-byte savings are not claimed by this
+test.
+
+## Three-host Fixture Oracle
+
+The existing GUA-02 suite runs the same four logical fixtures through the
+OpenClaw reference backend, Claude overlay backend, and Codex response-chain
+backend:
+
+```text
+pnpm --dir components/adapters/openclaw test
+```
+
+It remains the cross-host target-set oracle. GUA-06 complements it with real
+Claude gateway and Codex proxy HTTP paths against mock upstreams; it does not
+replace the OpenClaw reference-backend ownership boundary.
 
 ## Architecture
 
 - Generic acceptance recording, restart orchestration, sentinel inspection,
-  fallback accounting, and multi-protocol closure checks live in `@lightmem2/host-adapter`.
-- Claude acceptance imports the shared harness through the package API and does
-  not import another adapter's source tree.
-- Each phase fails if any successful upstream request retains eviction content,
-  loses required content, or breaks tool protocol closure.
+  fallback accounting, and multi-protocol closure checks live in
+  `@lightmem2/host-adapter`.
+- Claude and Codex acceptance import the shared harness through the package API
+  and do not import another adapter's source tree.
+- Each scored phase fails if any successful upstream request retains eviction
+  content, loses required content, or breaks tool protocol closure.
 
 ## Limitations
 
-- Mock providers only; no real Claude or Codex provider is called.
+- Mock providers only; no real Claude or Codex provider is called, and mock
+  capability evidence does not upgrade production provider compatibility.
 - Claude streaming acceptance remains separate from this non-streaming test.
+- Codex streaming and failure-matrix acceptance remains in dedicated adapter
+  tests rather than this focused shared-oracle scenario.
 - Persistent Claude rewrite-plan replay is not implemented or claimed.


### PR DESCRIPTION
## Summary

- wire Codex effective history and task-registry deltas into the shared lifecycle planner
- persist registry updates with expected-version CAS and revalidate the prepared plan under the rebase session lock before upstream execution
- give lifecycle planning production priority while preserving default-off, fail-open, fallback, cooldown, epoch, replayability, and tool-closure guarantees
- add real Codex proxy/mock-upstream restart acceptance proving `EVICT_ME` removal and `KEEP_ME`, current-turn, and function-call closure retention

## Why

Codex already exposed the estimator/history bridge and shared rewrite backend, but the proxy runtime did not consume the shared lifecycle planner. This left production runtime wiring incomplete and required static mutation-plan injection for the existing smoke path.

## Impact

When the estimator lifecycle configuration is explicitly enabled, Codex can now drive `registry -> shared planner -> ContextMutationPlan -> response-chain rebase` automatically. Incomplete configuration, estimator/planner errors, registry conflicts, stale handoff state, or unsafe history keep the original response chain. Lifecycle remains disabled by default, and mock evidence does not upgrade real-provider compatibility.

## Validation

- `npm --prefix components/adapters/codex test` — 356 passed
- `npm --prefix components/adapters/codex run typecheck`
- `npm --prefix components/adapters/codex run build`
- `npm --prefix components/packages/features/eviction test` — 40 passed
- `npm --prefix components/packages/foundation/host-adapter test` — 93 passed
- GUA-02 three-host fixture/oracle — 7 passed
- `npm run check:boundaries` — 16 packages, 62 internal edges
- `git diff --check origin/main...HEAD`

## Limitations

- focused GUA-06 estimator-driven acceptance is non-streaming; streaming, fallback, cooldown, epoch recovery, malformed closure, and provider compatibility remain covered by dedicated adapter tests
- acceptance uses committed mock upstreams only and does not claim real-provider verification
- local `components/adapters/codex/work/` evidence artifacts are intentionally excluded from this PR
