### PR TITLE
feat(cleaner): define shared context cleaner contracts

### DIFF
--- a/components/packages/features/cleaner/package.json
+++ b/components/packages/features/cleaner/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@lightrsi/cleaner",
+  "version": "0.1.0-beta.1",
+  "private": true,
+  "lightrsi": { "role": "feature" },
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import tsx --test tests/*.test.ts"
+  },
+  "dependencies": {
+    "@lightrsi/host-adapter": "workspace:*"
+  }
+}

--- a/components/packages/features/cleaner/src/contracts.ts
+++ b/components/packages/features/cleaner/src/contracts.ts
@@ -1,0 +1,134 @@
+import type {
+  ModelContextRewriteMode,
+  ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+
+export const CONTEXT_CLEAN_SCHEMA_VERSION = 1 as const;
+
+export type ContextCleanTokenCountMode = "exact" | "estimated" | "chars_only";
+
+export type ContextCleanLifecycleState =
+  | "active"
+  | "unresolved"
+  | "completed"
+  | "aborted"
+  | "unknown";
+
+export type ContextCleanRecommendation = "clean" | "keep" | "protected";
+
+export type ContextCleanStatus =
+  | "analyzed"
+  | "approved"
+  | "scheduled"
+  | "applied"
+  | "stale"
+  | "cancelled"
+  | "failed";
+
+export type ContextCleanTaskBreakdown = {
+  taskId: string;
+  label: string;
+  description: string;
+  summary: string;
+  lifecycleState: ContextCleanLifecycleState;
+  itemIds: string[];
+  /** Digests captured at analysis time, keyed by stable item id. */
+  itemDigests: Record<string, string>;
+  tokenCount: number | null;
+  charCount: number;
+  tokenPercent: number | null;
+  recallCount?: number;
+  recommendation: ContextCleanRecommendation;
+  reasonCodes: string[];
+  selectable: boolean;
+};
+
+export type ContextCleanPlan = {
+  schemaVersion: typeof CONTEXT_CLEAN_SCHEMA_VERSION;
+  planId: string;
+  hostId: string;
+  sessionId: string;
+  baseRevision: string;
+  model?: string;
+  contextWindowTokens?: number;
+  usedTokens: number | null;
+  usedChars: number;
+  protectedTokens: number | null;
+  protectedChars: number;
+  unassignedTokens: number | null;
+  unassignedChars: number;
+  tokenCountMode: ContextCleanTokenCountMode;
+  tokenCountMethod: string;
+  tasks: ContextCleanTaskBreakdown[];
+  createdAt: string;
+};
+
+export type ContextCleanEvidence = {
+  previousRevision?: string;
+  nextRevision?: string;
+  operationIds?: string[];
+  itemIds?: string[];
+  eventIds?: string[];
+  archiveRefs?: string[];
+  providerResponseId?: string;
+};
+
+export type ContextCleanReceipt = {
+  schemaVersion: typeof CONTEXT_CLEAN_SCHEMA_VERSION;
+  planId: string;
+  hostId: string;
+  sessionId: string;
+  status: ContextCleanStatus;
+  selectedTaskIds: string[];
+  estimatedSavedTokens: number | null;
+  estimatedSavedChars: number;
+  appliedSavedTokens?: number | null;
+  appliedSavedChars?: number;
+  tokenCountMode: ContextCleanTokenCountMode;
+  deferredTaskIds: string[];
+  fallbackUsed: boolean;
+  reasons: string[];
+  evidence?: ContextCleanEvidence;
+  updatedAt: string;
+};
+
+export type ContextCleanSnapshot = ModelContextSnapshot & {
+  capturedAt: string;
+  model?: string;
+  tokenCountMode: ContextCleanTokenCountMode;
+  tokenCountMethod: string;
+  itemTokenCounts?: Record<string, number>;
+};
+
+export type ContextCleanerSession = {
+  sessionId: string;
+  updatedAt?: string;
+};
+
+export type ExecuteApprovedContextCleanParams = {
+  cleanPlanId: string;
+  sessionId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+};
+
+export interface ContextCleanerHostBridge {
+  readonly hostId: string;
+  readonly rewriteMode: ModelContextRewriteMode;
+  listSessions(): Promise<ContextCleanerSession[]>;
+  readCleanSnapshot(sessionId: string): Promise<ContextCleanSnapshot>;
+  executeApprovedClean(
+    params: ExecuteApprovedContextCleanParams,
+  ): Promise<ContextCleanReceipt>;
+  readCleanReceipt(planId: string): Promise<ContextCleanReceipt | undefined>;
+  cancelCleanPlan(planId: string): Promise<ContextCleanReceipt>;
+}
+
+/**
+ * Shared control-plane operations supplied by the Cleaner owner. Host adapters
+ * consume this boundary; they do not implement plan persistence themselves.
+ */
+export type ContextCleanerControlPlane = Pick<
+  ContextCleanerHostBridge,
+  "executeApprovedClean" | "readCleanReceipt" | "cancelCleanPlan"
+>;

--- a/components/packages/features/cleaner/src/index.ts
+++ b/components/packages/features/cleaner/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./contracts.js";

--- a/components/packages/features/cleaner/tests/contracts.test.ts
+++ b/components/packages/features/cleaner/tests/contracts.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  type ContextCleanerHostBridge,
+  type ContextCleanReceipt,
+  type ContextCleanSnapshot,
+} from "../src/index.js";
+import { samplePlan, sampleSnapshot } from "./fixtures.js";
+
+function receipt(status: ContextCleanReceipt["status"]): ContextCleanReceipt {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: "clean-plan-1",
+    hostId: "fake-host",
+    sessionId: "session-1",
+    status,
+    selectedTaskIds: ["task-a"],
+    estimatedSavedTokens: 50,
+    estimatedSavedChars: 200,
+    tokenCountMode: "estimated",
+    deferredTaskIds: [],
+    fallbackUsed: false,
+    reasons: [],
+    updatedAt: "2026-08-20T00:00:00.000Z",
+  };
+}
+
+function snapshot(): ContextCleanSnapshot {
+  return {
+    ...sampleSnapshot(),
+    capturedAt: "2026-08-20T00:00:00.000Z",
+    tokenCountMode: "chars_only",
+    tokenCountMethod: "utf16_chars",
+  };
+}
+
+test("fake Host backend satisfies the shared contract without production behavior", async () => {
+  const calls: string[] = [];
+  const bridge: ContextCleanerHostBridge = {
+    hostId: "fake-host",
+    rewriteMode: "request_overlay",
+    async listSessions() {
+      return [{ sessionId: "session-1", updatedAt: "2026-08-20T00:00:00.000Z" }];
+    },
+    async readCleanSnapshot() {
+      return snapshot();
+    },
+    async executeApprovedClean() {
+      calls.push("execute");
+      return receipt("scheduled");
+    },
+    async readCleanReceipt() {
+      calls.push("read");
+      return receipt("scheduled");
+    },
+    async cancelCleanPlan() {
+      calls.push("cancel");
+      return receipt("cancelled");
+    },
+  };
+
+  assert.equal((await bridge.listSessions())[0]?.sessionId, "session-1");
+  assert.equal((await bridge.readCleanSnapshot("session-1")).tokenCountMode, "chars_only");
+  assert.equal((await bridge.executeApprovedClean({
+    cleanPlanId: "clean-plan-1",
+    sessionId: "session-1",
+    baseRevision: "rev-1",
+    selectedTaskIds: ["task-a"],
+  })).status, "scheduled");
+  assert.equal((await bridge.readCleanReceipt("clean-plan-1"))?.status, "scheduled");
+  assert.equal((await bridge.cancelCleanPlan("clean-plan-1")).status, "cancelled");
+  assert.deepEqual(calls, ["execute", "read", "cancel"]);
+});
+
+test("shared plan fixture is data-only and contains no raw Host payload", () => {
+  const plan = samplePlan();
+  assert.equal(plan.schemaVersion, CONTEXT_CLEAN_SCHEMA_VERSION);
+  assert.equal(plan.tasks[0]?.recommendation, "clean");
+  assert.equal("adapterMetadata" in plan, false);
+});

--- a/components/packages/features/cleaner/tests/fixtures.ts
+++ b/components/packages/features/cleaner/tests/fixtures.ts
@@ -1,0 +1,92 @@
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  type ContextCleanPlan,
+} from "../src/index.js";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+
+export function sampleSnapshot(revision = "rev-1"): ModelContextSnapshot {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    hostId: "codex",
+    sessionId: "session-1",
+    revision,
+    items: [
+      {
+        stableId: "item-a",
+        kind: "user",
+        taskIds: ["task-a"],
+        fingerprint: "digest-a",
+        chars: 120,
+      },
+      {
+        stableId: "item-b",
+        kind: "assistant",
+        taskIds: ["task-a"],
+        fingerprint: "digest-b",
+        chars: 80,
+      },
+      {
+        stableId: "item-current",
+        kind: "user",
+        taskIds: ["task-current"],
+        fingerprint: "digest-current",
+        chars: 40,
+      },
+    ],
+  };
+}
+
+export function samplePlan(): ContextCleanPlan {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: "clean-plan-1",
+    hostId: "codex",
+    sessionId: "session-1",
+    baseRevision: "rev-1",
+    model: "gpt-5.4",
+    usedTokens: 60,
+    usedChars: 240,
+    protectedTokens: 10,
+    protectedChars: 40,
+    unassignedTokens: 0,
+    unassignedChars: 0,
+    tokenCountMode: "estimated",
+    tokenCountMethod: "fixture",
+    tasks: [
+      {
+        taskId: "task-a",
+        label: "finished task",
+        description: "finished task description",
+        summary: "finished task summary",
+        lifecycleState: "completed",
+        itemIds: ["item-a", "item-b"],
+        itemDigests: { "item-a": "digest-a", "item-b": "digest-b" },
+        tokenCount: 50,
+        charCount: 200,
+        tokenPercent: 83.33,
+        recommendation: "clean",
+        reasonCodes: ["completed"],
+        selectable: true,
+      },
+      {
+        taskId: "task-current",
+        label: "current task",
+        description: "current task description",
+        summary: "current task summary",
+        lifecycleState: "active",
+        itemIds: ["item-current"],
+        itemDigests: { "item-current": "digest-current" },
+        tokenCount: 10,
+        charCount: 40,
+        tokenPercent: 16.67,
+        recommendation: "protected",
+        reasonCodes: ["current_task"],
+        selectable: false,
+      },
+    ],
+    createdAt: "2026-08-19T00:00:00.000Z",
+  };
+}

--- a/components/packages/features/cleaner/tsconfig.json
+++ b/components/packages/features/cleaner/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,12 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  components/packages/features/cleaner:
+    dependencies:
+      '@lightrsi/host-adapter':
+        specifier: workspace:*
+        version: link:../../foundation/host-adapter
+
   components/packages/features/eviction:
     dependencies:
       '@lightrsi/artifact-store':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,6 +36,9 @@
             "@lightrsi/eviction": [
                 "components/packages/features/eviction/src/index.ts"
             ],
+            "@lightrsi/cleaner": [
+                "components/packages/features/cleaner/src/index.ts"
+            ],
             "@lightrsi/host-adapter": [
                 "components/packages/foundation/host-adapter/src/index.ts"
             ],


### PR DESCRIPTION
## Ownership

This is the joint Context Cleaner contract-skeleton PR defined in the development plan.

- Joint owners: Yabin and Yutong
- Final interface/merge review: Xu Buqiang
- This PR freezes only the shared schema and Host boundary. Host implementations will branch from the merge commit.

## Scope

- add the data-only Context Cleaner schema and versioned contract types
- define `ContextCleanerHostBridge` and the injected `ContextCleanerControlPlane` interface
- add a test-local fake Host backend that compiles against and exercises the contract
- register the Cleaner feature package in the workspace TypeScript and lockfile metadata

## Explicit non-goals

- no plan or receipt persistence
- no state-transition implementation
- no task attribution or token-accounting algorithm
- no recommendation model or provider calls
- no CLI/TUI or OpenClaw integration
- no Codex/Claude runtime, snapshot, scheduling, apply, or receipt implementation
- no production bridge factory or Host-specific normalization

## Follow-up

After this PR is merged:

- Yabin: accounting, analyzer, CLI/TUI, OpenClaw
- Yutong: Codex/Claude execution bridges and receipts

## Verification

- Cleaner contract tests: 2/2 passed
- Cleaner typecheck/build: passed
- Workspace typecheck/build: passed
- Package boundaries: passed (17 packages / 65 internal edges)
- `git diff --check`: passed