### PR TITLE
feat(codex): add context cleaner host bridge

### DIFF
--- a/components/adapters/codex/package.json
+++ b/components/adapters/codex/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@lightrsi/artifact-store": "workspace:*",
+    "@lightrsi/cleaner": "workspace:*",
     "@lightrsi/eviction": "workspace:*",
     "@lightrsi/history": "workspace:*",
     "@lightrsi/host-adapter": "workspace:*",

--- a/components/adapters/codex/src/context-cleaner/bridge.ts
+++ b/components/adapters/codex/src/context-cleaner/bridge.ts
@@ -1,0 +1,140 @@
+import {
+  type ContextCleanerControlPlane,
+  type ContextCleanerHostBridge,
+} from "@lightrsi/cleaner";
+import { loadSessionTaskRegistry } from "@lightrsi/history";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  countTextWithPreciseTokens,
+  type ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+
+import { buildCodexEffectiveHistoryView, parseCodexRollout } from "../context-history/index.js";
+import { codexSharedContextRewriteBackend } from "../context-rewrite/backend.js";
+import { buildCodexLifecycleBackendRequest } from "../context-rewrite/lifecycle-input.js";
+import {
+  loadCodexSessionSnapshot,
+} from "../session-state.js";
+import { listCodexCleanerSessions } from "./session-catalog.js";
+
+function validPersistableSnapshot(
+  snapshot: ModelContextSnapshot,
+  sessionId: string,
+  revision: string,
+): boolean {
+  if (snapshot.schemaVersion !== MODEL_CONTEXT_REWRITE_SCHEMA_VERSION
+    || snapshot.hostId !== "codex"
+    || snapshot.sessionId !== sessionId
+    || snapshot.revision !== revision
+    || !snapshot.revision.trim()
+    || Object.prototype.hasOwnProperty.call(snapshot, "adapterMetadata")) return false;
+  const stableIds = new Set<string>();
+  for (const item of snapshot.items) {
+    if (!item.stableId.trim()
+      || stableIds.has(item.stableId)
+      || !item.fingerprint.trim()
+      || !Number.isSafeInteger(item.chars)
+      || item.chars < 0) return false;
+    stableIds.add(item.stableId);
+  }
+  return true;
+}
+
+export function createCodexContextCleanerBridge(params: {
+  stateDir: string;
+  controlPlane: ContextCleanerControlPlane;
+}): ContextCleanerHostBridge {
+  return {
+    hostId: "codex",
+    rewriteMode: "response_chain_rebase",
+    async listSessions() {
+      return listCodexCleanerSessions(params.stateDir);
+    },
+    async readCleanSnapshot(sessionId) {
+      const session = await loadCodexSessionSnapshot(params.stateDir, sessionId);
+      if (!session) throw new Error("codex_clean_session_not_found");
+      const view = await buildCodexEffectiveHistoryView({
+        stateDir: params.stateDir,
+        sessionId,
+        headResponseId: session.latestResponseId,
+        async rolloutViewBootstrap() {
+          if (!session.transcriptPath) return null;
+          return (await parseCodexRollout(session.transcriptPath))?.view ?? null;
+        },
+      });
+      if (view.history.incomplete
+        || !view.semanticComplete
+        || view.reasonCodes.length > 0
+        || view.history.deferredItems.length > 0
+        || view.history.unresolvedCallIds.length > 0) {
+        throw new Error("codex_clean_snapshot_incomplete");
+      }
+      const registry = await loadSessionTaskRegistry(params.stateDir, sessionId);
+      if (registry.sessionId !== sessionId) {
+        throw new Error("codex_clean_registry_session_mismatch");
+      }
+      const model = session.latestModel?.trim() || undefined;
+      const backendRequest = buildCodexLifecycleBackendRequest({
+        view,
+        registry,
+        request: {
+          sessionId,
+          payload: {
+            ...(model ? { model } : {}),
+            ...(session.latestResponseId
+              ? { previous_response_id: session.latestResponseId }
+              : {}),
+            input: [],
+          },
+          effectiveHistory: view.history,
+          currentInput: [],
+        },
+      });
+      const backendSnapshot = await codexSharedContextRewriteBackend.readSnapshot({
+        sessionId,
+        request: backendRequest,
+      });
+      const sourceItems = [
+        ...view.history.replayableItems,
+        ...view.history.observationOnlyItems,
+        ...view.history.deferredItems,
+      ];
+      const sourceItemsById = new Map(
+        sourceItems.map((item) => [item.stableItemId, item] as const),
+      );
+      const { adapterMetadata: _adapterMetadata, ...persistableSnapshot } = backendSnapshot;
+      if (!validPersistableSnapshot(persistableSnapshot, sessionId, view.history.revision)
+        || sourceItemsById.size !== sourceItems.length
+        || sourceItems.length !== persistableSnapshot.items.length
+        || persistableSnapshot.items.some((item) => !sourceItemsById.has(item.stableId))) {
+        throw new Error("codex_clean_snapshot_invalid");
+      }
+      if (Number.isNaN(Date.parse(session.updatedAt))) {
+        throw new Error("codex_clean_snapshot_timestamp_invalid");
+      }
+      const counts = model
+        ? persistableSnapshot.items.map((item) => {
+            const sourceItem = sourceItemsById.get(item.stableId)!;
+            return [
+              item.stableId,
+              countTextWithPreciseTokens(model, JSON.stringify(sourceItem.item)),
+            ] as const;
+          })
+        : [];
+      const exact = counts.length > 0 && counts.every(([, count]) => count.mode === "openai_tokens");
+      return {
+        ...persistableSnapshot,
+        capturedAt: session.updatedAt,
+        ...(model ? { model } : {}),
+        tokenCountMode: exact ? "exact" : "chars_only",
+        tokenCountMethod: exact ? "openai_tokenizer" : "utf16_chars",
+        ...(exact
+          ? { itemTokenCounts: Object.fromEntries(counts.map(([itemId, count]) => [itemId, count.count])) }
+          : {}),
+      };
+    },
+    executeApprovedClean: (request) => params.controlPlane.executeApprovedClean(request),
+    readCleanReceipt: (planId) => params.controlPlane.readCleanReceipt(planId),
+    cancelCleanPlan: (planId) => params.controlPlane.cancelCleanPlan(planId),
+  };
+}

--- a/components/adapters/codex/src/context-cleaner/index.ts
+++ b/components/adapters/codex/src/context-cleaner/index.ts
@@ -1,0 +1,2 @@
+export * from "./bridge.js";
+export * from "./session-catalog.js";

--- a/components/adapters/codex/src/context-cleaner/session-catalog.ts
+++ b/components/adapters/codex/src/context-cleaner/session-catalog.ts
@@ -1,0 +1,42 @@
+import { readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import { sessionStateRoot } from "@lightrsi/host-adapter";
+import type { ContextCleanerSession } from "@lightrsi/cleaner";
+
+import { loadCodexSessionSnapshot } from "../session-state.js";
+
+export async function listCodexCleanerSessions(
+  stateDir: string,
+): Promise<ContextCleanerSession[]> {
+  const directory = join(sessionStateRoot(stateDir), "sessions");
+  let names: string[];
+  try {
+    names = (await readdir(directory, { withFileTypes: true }))
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => entry.name);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const sessions = await Promise.all(names.map(async (name): Promise<ContextCleanerSession | undefined> => {
+    let sessionId: string;
+    try {
+      sessionId = decodeURIComponent(basename(name, ".json"));
+    } catch {
+      return undefined;
+    }
+    if (!sessionId.trim()) return undefined;
+    const snapshot = await loadCodexSessionSnapshot(stateDir, sessionId);
+    if (!snapshot || snapshot.sessionId !== sessionId) return undefined;
+    return { sessionId, updatedAt: snapshot.updatedAt };
+  }));
+
+  return sessions
+    .filter((session): session is ContextCleanerSession => session !== undefined)
+    .sort((left, right) => (
+      String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? ""))
+      || left.sessionId.localeCompare(right.sessionId)
+    ));
+}

--- a/components/adapters/codex/src/index.ts
+++ b/components/adapters/codex/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./config.js";
 export * from "./context-rewrite/index.js";
+export * from "./context-cleaner/index.js";
 export * from "./daemon.js";
 export * from "./install.js";
 export * from "./logger.js";

--- a/components/adapters/codex/tests/context-cleaner-bridge.test.ts
+++ b/components/adapters/codex/tests/context-cleaner-bridge.test.ts
@@ -1,0 +1,491 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  type ContextCleanerControlPlane,
+  type ContextCleanAppliedReceipt,
+  type ContextCleanPendingReceipt,
+  type ContextCleanTerminalReceipt,
+  type ExecuteApprovedContextCleanParams,
+} from "@lightrsi/cleaner";
+import {
+  buildTurnAbsId,
+  createEmptySessionTaskRegistry,
+  persistSessionTaskRegistry,
+} from "@lightrsi/history";
+import { sessionStateRoot, writeSessionSnapshot } from "@lightrsi/host-adapter";
+
+import {
+  appendCodexRequestJournalEntry,
+  appendCodexResponseJournalEntry,
+} from "../src/context-history/index.js";
+import { createCodexContextCleanerBridge } from "../src/context-cleaner/index.js";
+import { upsertCodexSessionSnapshot } from "../src/session-state.js";
+
+function pendingReceipt(
+  status: ContextCleanPendingReceipt["status"],
+): ContextCleanPendingReceipt {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: "clean-plan-1",
+    hostId: "codex",
+    sessionId: "codex-cleaner-session",
+    status,
+    selectedTaskIds: ["task-1"],
+    estimatedSavedTokens: null,
+    estimatedSavedChars: 10,
+    tokenCountMode: "chars_only",
+    deferredTaskIds: [],
+    fallbackUsed: false,
+    reasons: [],
+    updatedAt: "2026-08-20T00:00:00.000Z",
+  };
+}
+
+function terminalReceipt(
+  status: ContextCleanTerminalReceipt["status"],
+): ContextCleanTerminalReceipt {
+  return {
+    ...pendingReceipt("scheduled"),
+    status,
+    fallbackUsed: status === "failed",
+  };
+}
+
+function appliedReceipt(): ContextCleanAppliedReceipt {
+  return {
+    ...pendingReceipt("scheduled"),
+    status: "applied",
+    appliedSavedTokens: 2,
+    appliedSavedChars: 10,
+    evidence: {
+      previousRevision: "revision-before",
+      nextRevision: "revision-after",
+      operationIds: ["operation-1"],
+      itemIds: ["item-1"],
+    },
+  };
+}
+
+function fakeControlPlane(): ContextCleanerControlPlane {
+  return {
+    async executeApprovedClean() { return pendingReceipt("scheduled"); },
+    async readCleanReceipt() { return pendingReceipt("scheduled"); },
+    async cancelCleanPlan() { return terminalReceipt("cancelled"); },
+  };
+}
+
+test("Codex cleaner bridge preserves approved targets and control-plane receipts", async () => {
+  let captured: ExecuteApprovedContextCleanParams | undefined;
+  const applied = appliedReceipt();
+  const cancelled = terminalReceipt("cancelled");
+  const bridge = createCodexContextCleanerBridge({
+    stateDir: "unused-state-dir",
+    controlPlane: {
+      async executeApprovedClean(request) {
+        captured = request;
+        return pendingReceipt("scheduled");
+      },
+      async readCleanReceipt() {
+        return applied;
+      },
+      async cancelCleanPlan() {
+        return cancelled;
+      },
+    },
+  });
+  const request: ExecuteApprovedContextCleanParams = {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    cleanPlanId: "clean-plan-1",
+    hostId: "codex",
+    sessionId: "codex-cleaner-session",
+    baseRevision: "revision-before",
+    approvedAt: "2026-08-21T00:00:00.000Z",
+    selectedTasks: [{
+      taskId: "task-1",
+      itemIds: ["item-1", "item-2"],
+      itemDigests: {
+        "item-1": "digest-1",
+        "item-2": "digest-2",
+      },
+    }],
+  };
+
+  const scheduled = await bridge.executeApprovedClean(request);
+  assert.strictEqual(captured, request);
+  assert.equal(scheduled.status, "scheduled");
+  assert.equal("appliedSavedChars" in scheduled, false);
+  assert.strictEqual(await bridge.readCleanReceipt(request.cleanPlanId), applied);
+  assert.deepEqual(applied.evidence, {
+    previousRevision: "revision-before",
+    nextRevision: "revision-after",
+    operationIds: ["operation-1"],
+    itemIds: ["item-1"],
+  });
+  assert.strictEqual(await bridge.cancelCleanPlan(request.cleanPlanId), cancelled);
+});
+
+test("Codex cleaner bridge lists persisted sessions and reads canonical effective history", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-bridge-"));
+  try {
+    const sessionId = "codex-cleaner-session";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "old task" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      response: {
+        id: "response-1",
+        output: [{ type: "message", role: "assistant", content: "done" }],
+      },
+      status: "completed",
+    });
+    await upsertCodexSessionSnapshot(stateDir, sessionId, {
+      latestResponseId: "response-1",
+      latestModel: "gpt-5.4",
+    });
+    const taskId = "semantic-task-1";
+    const turnAbsId = buildTurnAbsId(sessionId, 1);
+    const registry = createEmptySessionTaskRegistry(sessionId);
+    registry.version = 1;
+    registry.lastProcessedTurnSeq = 1;
+    registry.activeTaskIds = [taskId];
+    registry.turnToTaskIds[turnAbsId] = [taskId];
+    registry.tasks[taskId] = {
+      taskId,
+      title: "semantic task",
+      objective: "verify registry-backed cleaner attribution",
+      lifecycle: "active",
+      completionEvidence: [],
+      unresolvedQuestions: [],
+      span: {
+        firstTurnAbsId: turnAbsId,
+        lastTurnAbsId: turnAbsId,
+        supportingTurnAbsIds: [turnAbsId],
+        lastEstimatorTurnAbsId: turnAbsId,
+      },
+    };
+    await persistSessionTaskRegistry(stateDir, registry);
+
+    const bridge = createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    assert.equal(bridge.hostId, "codex");
+    assert.equal(bridge.rewriteMode, "response_chain_rebase");
+    assert.deepEqual((await bridge.listSessions()).map((session) => session.sessionId), [sessionId]);
+    const snapshot = await bridge.readCleanSnapshot(sessionId);
+    assert.equal(snapshot.hostId, "codex");
+    assert.equal(snapshot.sessionId, sessionId);
+    assert.ok(snapshot.revision);
+    assert.ok(snapshot.items.length > 0);
+    assert.equal(snapshot.tokenCountMode, "exact");
+    assert.equal(snapshot.tokenCountMethod, "openai_tokenizer");
+    assert.ok(snapshot.capturedAt);
+    assert.ok(snapshot.items.every((item) => item.stableId && item.fingerprint));
+    assert.ok(snapshot.items.every((item) => item.taskIds?.length === 1));
+    assert.ok(snapshot.items.every((item) => item.taskIds?.[0] === taskId));
+    assert.ok(snapshot.items.every((item) => !item.taskIds?.includes(turnAbsId)));
+    assert.deepEqual(
+      Object.keys(snapshot.itemTokenCounts ?? {}).sort(),
+      snapshot.items.map((item) => item.stableId).sort(),
+    );
+    assert.equal("adapterMetadata" in snapshot, false);
+
+    const repeated = await bridge.readCleanSnapshot(sessionId);
+    assert.equal(repeated.revision, snapshot.revision);
+    assert.deepEqual(repeated.items, snapshot.items);
+    assert.deepEqual(repeated.itemTokenCounts, snapshot.itemTokenCounts);
+    assert.equal(repeated.capturedAt, snapshot.capturedAt);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex cleaner bridge rejects unknown sessions instead of returning an empty snapshot", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-missing-"));
+  try {
+    const bridge = createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    await assert.rejects(
+      bridge.readCleanSnapshot("missing-session"),
+      /codex_clean_session_not_found/,
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex cleaner bridge rejects a session whose committed response chain is incomplete", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-incomplete-"));
+  try {
+    const sessionId = "codex-cleaner-incomplete";
+    await upsertCodexSessionSnapshot(stateDir, sessionId, {
+      latestResponseId: "missing-response",
+      latestModel: "gpt-5.4",
+    });
+    const bridge = createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    await assert.rejects(
+      bridge.readCleanSnapshot(sessionId),
+      /codex_clean_snapshot_incomplete/,
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex cleaner session catalog sorts valid sessions and isolates malformed entries", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-catalog-"));
+  try {
+    await writeSessionSnapshot(stateDir, "older-session", {
+      sessionId: "older-session",
+      updatedAt: "2026-08-20T00:00:00.000Z",
+    });
+    await writeSessionSnapshot(stateDir, "newer-session", {
+      sessionId: "newer-session",
+      updatedAt: "2026-08-21T00:00:00.000Z",
+    });
+    const sessionsDir = join(sessionStateRoot(stateDir), "sessions");
+    await mkdir(sessionsDir, { recursive: true });
+    await writeFile(join(sessionsDir, "%E0%A4%A.json"), "{}", "utf8");
+    await writeFile(join(sessionsDir, "mismatched.json"), JSON.stringify({
+      sessionId: "different-session",
+      updatedAt: "2026-08-22T00:00:00.000Z",
+    }), "utf8");
+    await writeFile(join(sessionsDir, "malformed.json"), "{", "utf8");
+
+    const bridge = createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    assert.deepEqual(await bridge.listSessions(), [
+      { sessionId: "newer-session", updatedAt: "2026-08-21T00:00:00.000Z" },
+      { sessionId: "older-session", updatedAt: "2026-08-20T00:00:00.000Z" },
+    ]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex cleaner bridge leaves items unassigned when the registry has no evidence", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-unassigned-"));
+  try {
+    const sessionId = "codex-cleaner-unassigned";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "unassigned task" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      response: {
+        id: "response-1",
+        output: [{ type: "message", role: "assistant", content: "done" }],
+      },
+      status: "completed",
+    });
+    await upsertCodexSessionSnapshot(stateDir, sessionId, {
+      latestResponseId: "response-1",
+      latestModel: "gpt-5.4",
+    });
+
+    const snapshot = await createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    }).readCleanSnapshot(sessionId);
+    assert.ok(snapshot.items.length > 0);
+    assert.ok(snapshot.items.every((item) => item.taskIds === undefined));
+    assert.ok(snapshot.items.every((item) => !item.taskIds?.includes(buildTurnAbsId(sessionId, 1))));
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex cleaner bridge keeps a cross-turn tool pair on one semantic task", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-tool-pair-"));
+  try {
+    const sessionId = "codex-cleaner-tool-pair";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "run the tool" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      response: {
+        id: "response-1",
+        output: [{
+          id: "function-call-1",
+          type: "function_call",
+          call_id: "call-1",
+          name: "run",
+          arguments: "{}",
+        }],
+      },
+      status: "completed",
+    });
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-2",
+      payload: {
+        previous_response_id: "response-1",
+        input: [
+          { type: "function_call_output", call_id: "call-1", output: "ok" },
+          { role: "user", content: "continue" },
+        ],
+      },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-2",
+      response: {
+        id: "response-2",
+        previous_response_id: "response-1",
+        output: [{ type: "message", role: "assistant", content: "finished" }],
+      },
+      status: "completed",
+    });
+    await upsertCodexSessionSnapshot(stateDir, sessionId, {
+      latestResponseId: "response-2",
+      latestModel: "gpt-5.4",
+    });
+    const taskId = "tool-task";
+    const turnAbsId = buildTurnAbsId(sessionId, 1);
+    const registry = createEmptySessionTaskRegistry(sessionId);
+    registry.version = 1;
+    registry.lastProcessedTurnSeq = 1;
+    registry.activeTaskIds = [taskId];
+    registry.turnToTaskIds[turnAbsId] = [taskId];
+    registry.tasks[taskId] = {
+      taskId,
+      title: "tool task",
+      objective: "keep tool protocol ownership closed",
+      lifecycle: "active",
+      completionEvidence: [],
+      unresolvedQuestions: [],
+      span: {
+        firstTurnAbsId: turnAbsId,
+        lastTurnAbsId: turnAbsId,
+        supportingTurnAbsIds: [turnAbsId],
+        lastEstimatorTurnAbsId: turnAbsId,
+      },
+    };
+    await persistSessionTaskRegistry(stateDir, registry);
+
+    const snapshot = await createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    }).readCleanSnapshot(sessionId);
+    const call = snapshot.items.find((item) => item.kind === "tool_call");
+    const output = snapshot.items.find((item) => item.kind === "tool_result");
+    assert.deepEqual(call?.taskIds, [taskId]);
+    assert.deepEqual(output?.taskIds, [taskId]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex cleaner bridge reports chars-only accounting when the model is unknown", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-chars-"));
+  try {
+    const sessionId = "codex-cleaner-chars";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "count chars" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      response: {
+        id: "response-1",
+        output: [{ type: "message", role: "assistant", content: "done" }],
+      },
+      status: "completed",
+    });
+    await upsertCodexSessionSnapshot(stateDir, sessionId, {
+      latestResponseId: "response-1",
+    });
+
+    const snapshot = await createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    }).readCleanSnapshot(sessionId);
+    assert.equal(snapshot.tokenCountMode, "chars_only");
+    assert.equal(snapshot.tokenCountMethod, "utf16_chars");
+    assert.equal(snapshot.model, undefined);
+    assert.equal(snapshot.itemTokenCounts, undefined);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex cleaner bridge rejects a snapshot with an invalid capture timestamp", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-time-"));
+  try {
+    const sessionId = "codex-cleaner-invalid-time";
+    await appendCodexRequestJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      payload: { input: [{ role: "user", content: "invalid time" }] },
+      status: "completed",
+    });
+    await appendCodexResponseJournalEntry({
+      stateDir,
+      sessionId,
+      requestId: "request-1",
+      response: {
+        id: "response-1",
+        output: [{ type: "message", role: "assistant", content: "done" }],
+      },
+      status: "completed",
+    });
+    await writeSessionSnapshot(stateDir, sessionId, {
+      sessionId,
+      latestResponseId: "response-1",
+      latestModel: "gpt-5.4",
+      updatedAt: "not-a-time",
+    });
+
+    const bridge = createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    await assert.rejects(
+      bridge.readCleanSnapshot(sessionId),
+      /codex_clean_snapshot_timestamp_invalid/,
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@lightrsi/artifact-store':
         specifier: workspace:*
         version: link:../../packages/foundation/artifact-store
+      '@lightrsi/cleaner':
+        specifier: workspace:*
+        version: link:../../packages/features/cleaner
       '@lightrsi/eviction':
         specifier: workspace:*
         version: link:../../packages/features/eviction


### PR DESCRIPTION
## Summary

- add a Codex-only `ContextCleanerHostBridge` backed by canonical effective history
- reuse the existing task registry and shared Codex rewrite backend for task attribution and stable snapshot construction
- expose deterministic session discovery and exact-or-chars-only accounting
- delegate approved execution, receipt reads, and cancellation directly to the injected control plane without reselecting approved targets

## Safety and historical regressions

- fail closed for unknown sessions, incomplete response chains, unresolved calls, deferred replay items, registry identity drift, and invalid snapshot timestamps
- preserve cross-turn tool-call/output ownership under the same semantic task
- leave items unassigned when task-registry evidence is absent instead of fabricating turn-based task IDs
- validate stable IDs, fingerprints, chars, Host/session/revision identity, and exact source-item coverage
- strip adapter metadata and avoid exposing raw Responses payloads
- preserve exact approved `taskId + itemIds + itemDigests` requests and evidence-backed applied receipts

## Scope boundaries

This PR contains only the Codex Bridge, its tests, package export, and Codex importer dependency.

It does not add:

- Cleaner plan or receipt persistence
- approved-plan scheduling or response-chain apply wiring
- proxy runtime or CLI/skill changes
- shared Cleaner implementation changes
- Claude Code or OpenClaw changes

## Validation

- Codex Cleaner Bridge focused tests: 9/9 passed
- shared Cleaner contract tests: 4/4 passed
- Codex adapter typecheck: passed
- workspace typecheck: passed
- Codex production build: passed
- package boundaries: passed, 17 packages / 64 internal edges
- `git diff --check`: passed

The full Codex suite reported 369/371 on the current Windows host. The two failures are outside this diff:

- capability-journal concurrency timed out inside the sandbox and passed 1/1 when rerun outside it
- the existing daemon stale-PID test could not make its detached child proxy healthy on this host; this PR does not modify daemon code or its tests