### PR TITLE
feat(cleaner): add plan and receipt state machine

### DIFF
--- a/components/packages/features/cleaner/src/clean-plan-store.ts
+++ b/components/packages/features/cleaner/src/clean-plan-store.ts
@@ -1,0 +1,124 @@
+import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
+import {
+  CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+  canTransitionContextCleanStatus,
+  type ContextCleanPlan,
+  type ContextCleanPlanRecord,
+  type ContextCleanStatus,
+  type ContextCleanStoreReadResult,
+  type ContextCleanStoreWriteResult,
+} from "./contracts.js";
+import {
+  contextCleanPlanFilePath,
+  parseContextCleanPlan,
+  parseContextCleanPlanRecord,
+  readStoredJson,
+  sameCanonicalValue,
+  isIsoTimestamp,
+  withContextCleanStoreLock,
+} from "./clean-store-support.js";
+
+function bypassed<T>(reason: string): ContextCleanStoreWriteResult<T> {
+  return { outcome: "bypassed", bypassed: true, reasons: [reason] };
+}
+
+export async function readContextCleanPlan(params: {
+  stateDir: string;
+  planId: string;
+}): Promise<ContextCleanStoreReadResult<ContextCleanPlanRecord>> {
+  if (!params.planId.trim()) return { bypassed: true, reasons: ["clean_plan_id_empty"] };
+  const stored = await readStoredJson(contextCleanPlanFilePath(params.stateDir, params.planId));
+  if (stored.kind === "missing") return { bypassed: false, reasons: [] };
+  if (stored.kind === "unreadable") return { bypassed: true, reasons: ["clean_plan_store_unreadable"] };
+  const record = parseContextCleanPlanRecord(stored.value);
+  if (!record || record.plan.planId !== params.planId) {
+    return { bypassed: true, reasons: ["clean_plan_store_invalid"] };
+  }
+  return { value: record, bypassed: false, reasons: [] };
+}
+
+export async function saveContextCleanPlan(params: {
+  stateDir: string;
+  plan: ContextCleanPlan;
+  updatedAt?: string;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  try {
+    return await withContextCleanStoreLock({ stateDir: params.stateDir, planId: params.plan.planId,
+      action: () => saveContextCleanPlanUnlocked(params) });
+  } catch {
+    return bypassed("clean_plan_store_lock_failed");
+  }
+}
+
+/** @internal Used by the transaction coordinator while holding the plan lock. */
+export async function saveContextCleanPlanUnlocked(params: {
+  stateDir: string;
+  plan: ContextCleanPlan;
+  updatedAt?: string;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  const plan = parseContextCleanPlan(params.plan);
+  if (!plan) return bypassed("clean_plan_invalid");
+  const updatedAt = params.updatedAt ?? plan.createdAt;
+  if (!isIsoTimestamp(updatedAt)) return bypassed("clean_plan_updated_at_invalid");
+  const current = await readContextCleanPlan({ stateDir: params.stateDir, planId: plan.planId });
+  if (current.bypassed) return bypassed(current.reasons[0] ?? "clean_plan_store_unreadable");
+  if (current.value) {
+    if (!sameCanonicalValue(current.value.plan, plan)) {
+      return { outcome: "conflict", value: current.value, bypassed: true,
+        reasons: ["clean_plan_id_content_conflict"] };
+    }
+    return { outcome: "unchanged", value: current.value, bypassed: false, reasons: [] };
+  }
+  const record: ContextCleanPlanRecord = {
+    storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+    status: "analyzed",
+    plan,
+    updatedAt,
+  };
+  try {
+    await writeJsonFileAtomic(contextCleanPlanFilePath(params.stateDir, plan.planId), record);
+    return { outcome: "stored", value: record, bypassed: false, reasons: [] };
+  } catch {
+    return bypassed("clean_plan_store_write_failed");
+  }
+}
+
+export async function transitionContextCleanPlan(params: {
+  stateDir: string;
+  planId: string;
+  status: ContextCleanStatus;
+  updatedAt: string;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  try {
+    return await withContextCleanStoreLock({ stateDir: params.stateDir, planId: params.planId,
+      action: () => transitionContextCleanPlanUnlocked(params) });
+  } catch {
+    return bypassed("clean_plan_store_lock_failed");
+  }
+}
+
+/** @internal Used by the transaction coordinator while holding the plan lock. */
+export async function transitionContextCleanPlanUnlocked(params: {
+  stateDir: string;
+  planId: string;
+  status: ContextCleanStatus;
+  updatedAt: string;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  if (!isIsoTimestamp(params.updatedAt)) return bypassed("clean_plan_updated_at_invalid");
+  const current = await readContextCleanPlan(params);
+  if (current.bypassed) return bypassed(current.reasons[0] ?? "clean_plan_store_unreadable");
+  if (!current.value) return { outcome: "missing", bypassed: true, reasons: ["clean_plan_missing"] };
+  if (current.value.status === params.status) {
+    return { outcome: "unchanged", value: current.value, bypassed: false, reasons: [] };
+  }
+  if (!canTransitionContextCleanStatus(current.value.status, params.status)) {
+    return bypassed(`clean_plan_invalid_transition:${current.value.status}->${params.status}`);
+  }
+  const record: ContextCleanPlanRecord = { ...current.value, status: params.status, updatedAt: params.updatedAt };
+  try {
+    await writeJsonFileAtomic(contextCleanPlanFilePath(params.stateDir, params.planId), record);
+    return { outcome: "transitioned", value: record, bypassed: false, reasons: [] };
+  } catch {
+    return bypassed("clean_plan_store_write_failed");
+  }
+}

--- a/components/packages/features/cleaner/src/clean-receipt-store.ts
+++ b/components/packages/features/cleaner/src/clean-receipt-store.ts
@@ -1,0 +1,100 @@
+import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
+import {
+  CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+  canTransitionContextCleanStatus,
+  type ContextCleanReceipt,
+  type ContextCleanStoreReadResult,
+  type ContextCleanStoreWriteResult,
+} from "./contracts.js";
+import {
+  contextCleanReceiptFilePath,
+  parseContextCleanReceipt,
+  parseContextCleanStoredReceipt,
+  readStoredJson,
+  sameCanonicalValue,
+  withContextCleanStoreLock,
+  type ContextCleanStoredReceipt,
+} from "./clean-store-support.js";
+import { readContextCleanPlan } from "./clean-plan-store.js";
+
+function bypassed(reason: string): ContextCleanStoreWriteResult<ContextCleanReceipt> {
+  return { outcome: "bypassed", bypassed: true, reasons: [reason] };
+}
+
+export async function readContextCleanReceipt(params: {
+  stateDir: string;
+  planId: string;
+}): Promise<ContextCleanStoreReadResult<ContextCleanReceipt>> {
+  if (!params.planId.trim()) return { bypassed: true, reasons: ["clean_plan_id_empty"] };
+  const stored = await readStoredJson(contextCleanReceiptFilePath(params.stateDir, params.planId));
+  if (stored.kind === "missing") return { bypassed: false, reasons: [] };
+  if (stored.kind === "unreadable") return { bypassed: true, reasons: ["clean_receipt_store_unreadable"] };
+  const entry = parseContextCleanStoredReceipt(stored.value);
+  if (!entry || entry.receipt.planId !== params.planId) {
+    return { bypassed: true, reasons: ["clean_receipt_store_invalid"] };
+  }
+  return { value: entry.receipt, bypassed: false, reasons: [] };
+}
+
+export async function saveContextCleanReceipt(params: {
+  stateDir: string;
+  receipt: ContextCleanReceipt;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanReceipt>> {
+  try {
+    return await withContextCleanStoreLock({ stateDir: params.stateDir, planId: params.receipt.planId,
+      action: () => saveContextCleanReceiptUnlocked(params) });
+  } catch {
+    return bypassed("clean_receipt_store_lock_failed");
+  }
+}
+
+/** @internal Used by the transaction coordinator while holding the plan lock. */
+export async function saveContextCleanReceiptUnlocked(params: {
+  stateDir: string;
+  receipt: ContextCleanReceipt;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanReceipt>> {
+  const receipt = parseContextCleanReceipt(params.receipt);
+  if (!receipt) return bypassed("clean_receipt_invalid");
+  const planRead = await readContextCleanPlan({ stateDir: params.stateDir, planId: receipt.planId });
+  if (planRead.bypassed) return bypassed("clean_receipt_plan_unavailable");
+  if (!planRead.value) return bypassed("clean_receipt_plan_missing");
+  if (planRead.value.plan.hostId !== receipt.hostId
+    || planRead.value.plan.sessionId !== receipt.sessionId) {
+    return bypassed("clean_receipt_plan_identity_conflict");
+  }
+  if (!canTransitionContextCleanStatus(planRead.value.status, receipt.status)) {
+    return bypassed(`clean_receipt_plan_status_conflict:${planRead.value.status}->${receipt.status}`);
+  }
+  const current = await readContextCleanReceipt({ stateDir: params.stateDir, planId: receipt.planId });
+  if (current.bypassed) return bypassed(current.reasons[0] ?? "clean_receipt_store_unreadable");
+  if (current.value) {
+    if (sameCanonicalValue(current.value, receipt)) {
+      return { outcome: "unchanged", value: current.value, bypassed: false, reasons: [] };
+    }
+    if (current.value.status === receipt.status) {
+      return { outcome: "conflict", value: current.value, bypassed: true,
+        reasons: ["clean_receipt_status_content_conflict"] };
+    }
+    if (!canTransitionContextCleanStatus(current.value.status, receipt.status)) {
+      return bypassed(`clean_receipt_invalid_transition:${current.value.status}->${receipt.status}`);
+    }
+    const selectionCanBeApproved = current.value.status === "analyzed" && receipt.status === "approved";
+    if (current.value.hostId !== receipt.hostId || current.value.sessionId !== receipt.sessionId
+      || (!selectionCanBeApproved
+        && !sameCanonicalValue(current.value.selectedTaskIds, receipt.selectedTaskIds))) {
+      return { outcome: "conflict", value: current.value, bypassed: true,
+        reasons: ["clean_receipt_identity_conflict"] };
+    }
+  }
+  const entry: ContextCleanStoredReceipt = {
+    storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+    receipt,
+  };
+  try {
+    await writeJsonFileAtomic(contextCleanReceiptFilePath(params.stateDir, receipt.planId), entry);
+    return { outcome: current.value ? "transitioned" : "stored", value: receipt,
+      bypassed: false, reasons: [] };
+  } catch {
+    return bypassed("clean_receipt_store_write_failed");
+  }
+}

--- a/components/packages/features/cleaner/src/clean-state-coordinator.ts
+++ b/components/packages/features/cleaner/src/clean-state-coordinator.ts
@@ -1,0 +1,184 @@
+import { mkdir, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
+import {
+  CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+  canTransitionContextCleanStatus,
+  isContextCleanStatus,
+  type ContextCleanPlanRecord,
+  type ContextCleanReceipt,
+  type ContextCleanStoreWriteResult,
+} from "./contracts.js";
+import { readContextCleanPlan, transitionContextCleanPlanUnlocked } from "./clean-plan-store.js";
+import { readContextCleanReceipt, saveContextCleanReceiptUnlocked } from "./clean-receipt-store.js";
+import {
+  contextCleanTransactionFilePath,
+  isIsoTimestamp,
+  isNonBlankString,
+  isRecord,
+  parseContextCleanReceipt,
+  readStoredJson,
+  sameCanonicalValue,
+  withContextCleanStoreLock,
+  type ContextCleanTransactionIntent,
+} from "./clean-store-support.js";
+
+function bypassed(reason: string): ContextCleanStoreWriteResult<ContextCleanPlanRecord> {
+  return { outcome: "bypassed", bypassed: true, reasons: [reason] };
+}
+
+async function abortIntent(stateDir: string, planId: string): Promise<void> {
+  await unlink(contextCleanTransactionFilePath(stateDir, planId)).catch(() => undefined);
+}
+
+async function abortIntentAndBypass(
+  stateDir: string,
+  planId: string,
+  reason: string,
+): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  await abortIntent(stateDir, planId);
+  return bypassed(reason);
+}
+
+function parseIntent(value: unknown): ContextCleanTransactionIntent | undefined {
+  if (!isRecord(value) || value.storeSchemaVersion !== CONTEXT_CLEAN_STORE_SCHEMA_VERSION
+    || !isNonBlankString(value.planId) || !isContextCleanStatus(value.fromStatus)
+    || !isIsoTimestamp(value.createdAt)) return undefined;
+  const receipt = parseContextCleanReceipt(value.receipt);
+  if (!receipt || receipt.planId !== value.planId) return undefined;
+  return { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION, planId: value.planId,
+    fromStatus: value.fromStatus as ContextCleanTransactionIntent["fromStatus"], receipt,
+    createdAt: value.createdAt };
+}
+
+async function completeIntent(params: {
+  stateDir: string;
+  intent: ContextCleanTransactionIntent;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  const planRead = await readContextCleanPlan({ stateDir: params.stateDir, planId: params.intent.planId });
+  if (planRead.bypassed || !planRead.value) return bypassed("clean_transaction_plan_unavailable");
+  const { plan } = planRead.value;
+  const receipt = params.intent.receipt;
+  if (plan.hostId !== receipt.hostId || plan.sessionId !== receipt.sessionId) {
+    return abortIntentAndBypass(params.stateDir, params.intent.planId,
+      "clean_transaction_identity_conflict");
+  }
+  if (planRead.value.status !== params.intent.fromStatus
+    && planRead.value.status !== receipt.status) {
+    return abortIntentAndBypass(params.stateDir, params.intent.planId,
+      "clean_transaction_plan_status_conflict");
+  }
+  if (!canTransitionContextCleanStatus(params.intent.fromStatus, receipt.status)) {
+    return abortIntentAndBypass(params.stateDir, params.intent.planId,
+      "clean_transaction_transition_invalid");
+  }
+
+  const receiptRead = await readContextCleanReceipt({ stateDir: params.stateDir, planId: params.intent.planId });
+  if (receiptRead.bypassed) return bypassed("clean_transaction_receipt_unavailable");
+  if (receiptRead.value && receiptRead.value.status === receipt.status
+    && !sameCanonicalValue(receiptRead.value, receipt)) {
+    return abortIntentAndBypass(params.stateDir, params.intent.planId,
+      "clean_transaction_receipt_content_conflict");
+  }
+  if (receiptRead.value && receiptRead.value.status !== receipt.status) {
+    const save = await saveContextCleanReceiptUnlocked({ stateDir: params.stateDir, receipt });
+    if (save.bypassed) return bypassed(save.reasons[0] ?? "clean_transaction_receipt_conflict");
+  } else if (!receiptRead.value) {
+    const save = await saveContextCleanReceiptUnlocked({ stateDir: params.stateDir, receipt });
+    if (save.bypassed) return bypassed(save.reasons[0] ?? "clean_transaction_receipt_write_failed");
+  }
+
+  let result: ContextCleanStoreWriteResult<ContextCleanPlanRecord>;
+  if (planRead.value.status === receipt.status) {
+    result = { outcome: "unchanged", value: planRead.value, bypassed: false, reasons: [] };
+  } else {
+    result = await transitionContextCleanPlanUnlocked({ stateDir: params.stateDir, planId: params.intent.planId,
+      status: receipt.status, updatedAt: receipt.updatedAt });
+  }
+  if (result.bypassed) return result;
+  try {
+    await unlink(contextCleanTransactionFilePath(params.stateDir, params.intent.planId));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") return bypassed("clean_transaction_cleanup_failed");
+  }
+  return result;
+}
+
+export async function transitionContextCleanState(params: {
+  stateDir: string;
+  receipt: ContextCleanReceipt;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  try {
+    return await withContextCleanStoreLock({ stateDir: params.stateDir, planId: params.receipt.planId,
+      action: () => transitionContextCleanStateUnlocked(params) });
+  } catch {
+    return bypassed("clean_transaction_lock_failed");
+  }
+}
+
+async function transitionContextCleanStateUnlocked(params: {
+  stateDir: string;
+  receipt: ContextCleanReceipt;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  const receipt = parseContextCleanReceipt(params.receipt);
+  if (!receipt) return bypassed("clean_receipt_invalid");
+  const pending = await readStoredJson(contextCleanTransactionFilePath(params.stateDir, receipt.planId));
+  if (pending.kind === "unreadable") return bypassed("clean_transaction_unreadable");
+  if (pending.kind === "ok") {
+    const intent = parseIntent(pending.value);
+    if (!intent) return bypassed("clean_transaction_invalid");
+    if (JSON.stringify(intent.receipt) !== JSON.stringify(receipt)) {
+      return bypassed("clean_transaction_conflict");
+    }
+    return completeIntent({ stateDir: params.stateDir, intent });
+  }
+  const current = await readContextCleanPlan({ stateDir: params.stateDir, planId: receipt.planId });
+  if (current.bypassed || !current.value) return bypassed("clean_transaction_plan_unavailable");
+  if (current.value.plan.hostId !== receipt.hostId
+    || current.value.plan.sessionId !== receipt.sessionId) {
+    return bypassed("clean_transaction_identity_conflict");
+  }
+  if (!canTransitionContextCleanStatus(current.value.status, receipt.status)) {
+    return bypassed(`clean_plan_invalid_transition:${current.value.status}->${receipt.status}`);
+  }
+  const intent: ContextCleanTransactionIntent = {
+    storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+    planId: receipt.planId,
+    fromStatus: current.value.status,
+    receipt,
+    createdAt: receipt.updatedAt,
+  };
+  const path = contextCleanTransactionFilePath(params.stateDir, receipt.planId);
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeJsonFileAtomic(path, intent);
+  } catch {
+    return bypassed("clean_transaction_write_failed");
+  }
+  return completeIntent({ stateDir: params.stateDir, intent });
+}
+
+export async function recoverContextCleanState(params: {
+  stateDir: string;
+  planId: string;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  try {
+    return await withContextCleanStoreLock({ stateDir: params.stateDir, planId: params.planId,
+      action: () => recoverContextCleanStateUnlocked(params) });
+  } catch {
+    return bypassed("clean_transaction_lock_failed");
+  }
+}
+
+async function recoverContextCleanStateUnlocked(params: {
+  stateDir: string;
+  planId: string;
+}): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+  const stored = await readStoredJson(contextCleanTransactionFilePath(params.stateDir, params.planId));
+  if (stored.kind === "missing") return { outcome: "missing", bypassed: false, reasons: [] };
+  if (stored.kind === "unreadable") return bypassed("clean_transaction_unreadable");
+  const intent = parseIntent(stored.value);
+  if (!intent || intent.planId !== params.planId) return bypassed("clean_transaction_invalid");
+  return completeIntent({ stateDir: params.stateDir, intent });
+}

--- a/components/packages/features/cleaner/src/clean-store-support.ts
+++ b/components/packages/features/cleaner/src/clean-store-support.ts
@@ -1,0 +1,261 @@
+import { createHash } from "node:crypto";
+import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+  type ContextCleanPlan,
+  type ContextCleanPlanRecord,
+  type ContextCleanReceipt,
+  type ContextCleanStatus,
+} from "./contracts.js";
+
+export type ContextCleanStoredReceipt = {
+  storeSchemaVersion: typeof CONTEXT_CLEAN_STORE_SCHEMA_VERSION;
+  receipt: ContextCleanReceipt;
+};
+
+export type ContextCleanTransactionIntent = {
+  storeSchemaVersion: typeof CONTEXT_CLEAN_STORE_SCHEMA_VERSION;
+  planId: string;
+  fromStatus: ContextCleanStatus;
+  receipt: ContextCleanReceipt;
+  createdAt: string;
+};
+
+function fileKey(planId: string): string {
+  return createHash("sha256").update(planId).digest("hex");
+}
+
+export function contextCleanPlanFilePath(stateDir: string, planId: string): string {
+  return join(stateDir, "context-cleaner", "plans", `${fileKey(planId)}.json`);
+}
+
+export function contextCleanReceiptFilePath(stateDir: string, planId: string): string {
+  return join(stateDir, "context-cleaner", "receipts", `${fileKey(planId)}.json`);
+}
+
+export function contextCleanTransactionFilePath(stateDir: string, planId: string): string {
+  return join(stateDir, "context-cleaner", "transactions", `${fileKey(planId)}.json`);
+}
+
+export function contextCleanLockFilePath(stateDir: string, planId: string): string {
+  return join(stateDir, "context-cleaner", "locks", `${fileKey(planId)}.lock`);
+}
+
+const LOCK_TIMEOUT_MS = 1_000;
+const LOCK_RETRY_MS = 10;
+const LOCK_STALE_MS = 30 * 60 * 1_000;
+
+export async function withContextCleanStoreLock<T>(params: {
+  stateDir: string;
+  planId: string;
+  action: () => Promise<T>;
+}): Promise<T> {
+  const path = contextCleanLockFilePath(params.stateDir, params.planId);
+  const token = `${process.pid}:${Date.now()}:${Math.random()}`;
+  const startedAt = Date.now();
+  await mkdir(dirname(path), { recursive: true });
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  while (!handle) {
+    try {
+      handle = await open(path, "wx");
+      await handle.writeFile(token, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      try {
+        const info = await stat(path);
+        if (Date.now() - info.mtimeMs > LOCK_STALE_MS) await unlink(path);
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") throw statError;
+      }
+      if (Date.now() - startedAt >= LOCK_TIMEOUT_MS) throw new Error("clean_store_lock_timeout");
+      await delay(LOCK_RETRY_MS);
+    }
+  }
+  try {
+    return await params.action();
+  } finally {
+    await handle.close().catch(() => undefined);
+    try {
+      if (await readFile(path, "utf8") === token) await unlink(path);
+    } catch {
+      // A missing/replaced lock belongs to recovery or another owner.
+    }
+  }
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function isIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
+}
+
+function finiteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function nullableCount(value: unknown): value is number | null {
+  return value === null || finiteNonNegative(value);
+}
+
+function uniqueStrings(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every(isNonBlankString)
+    && new Set(value).size === value.length;
+}
+
+function optionalUniqueStrings(value: unknown): value is string[] | undefined {
+  return value === undefined || uniqueStrings(value);
+}
+
+const STATUSES = new Set<ContextCleanStatus>([
+  "analyzed", "approved", "scheduled", "applied", "stale", "cancelled", "failed",
+]);
+const COUNT_MODES = new Set(["exact", "estimated", "chars_only"]);
+
+function parseTask(value: unknown): ContextCleanPlan["tasks"][number] | undefined {
+  if (!isRecord(value) || !isNonBlankString(value.taskId)
+    || !isNonBlankString(value.label) || !isNonBlankString(value.description)
+    || !isNonBlankString(value.summary) || !uniqueStrings(value.itemIds)
+    || !isRecord(value.itemDigests) || !nullableCount(value.tokenCount)
+    || !finiteNonNegative(value.charCount) || !nullableCount(value.tokenPercent)
+    || !uniqueStrings(value.reasonCodes) || typeof value.selectable !== "boolean"
+    || !["active", "unresolved", "completed", "aborted", "unknown"].includes(String(value.lifecycleState))
+    || !["clean", "keep", "protected"].includes(String(value.recommendation))) return undefined;
+  const itemIds = value.itemIds;
+  const itemDigests = value.itemDigests;
+  if (itemIds.some((id) => !isNonBlankString(itemDigests[id]))) return undefined;
+  if (Object.keys(itemDigests).some((id) => !itemIds.includes(id))) return undefined;
+  if (value.recallCount !== undefined
+    && (!finiteNonNegative(value.recallCount) || !Number.isInteger(value.recallCount))) return undefined;
+  return {
+    taskId: value.taskId, label: value.label, description: value.description,
+    summary: value.summary, lifecycleState: value.lifecycleState as ContextCleanPlan["tasks"][number]["lifecycleState"],
+    itemIds: [...itemIds],
+    itemDigests: Object.fromEntries(itemIds.map((id) => [id, itemDigests[id] as string])),
+    tokenCount: value.tokenCount, charCount: value.charCount, tokenPercent: value.tokenPercent,
+    ...(value.recallCount !== undefined ? { recallCount: value.recallCount } : {}),
+    recommendation: value.recommendation as ContextCleanPlan["tasks"][number]["recommendation"],
+    reasonCodes: [...value.reasonCodes], selectable: value.selectable,
+  };
+}
+
+export function parseContextCleanPlan(value: unknown): ContextCleanPlan | undefined {
+  if (!isRecord(value) || value.schemaVersion !== CONTEXT_CLEAN_SCHEMA_VERSION
+    || !isNonBlankString(value.planId) || !isNonBlankString(value.hostId)
+    || !isNonBlankString(value.sessionId) || !isNonBlankString(value.baseRevision)
+    || !nullableCount(value.usedTokens) || !finiteNonNegative(value.usedChars)
+    || !nullableCount(value.protectedTokens) || !finiteNonNegative(value.protectedChars)
+    || !nullableCount(value.unassignedTokens) || !finiteNonNegative(value.unassignedChars)
+    || !COUNT_MODES.has(String(value.tokenCountMode)) || !isNonBlankString(value.tokenCountMethod)
+    || !Array.isArray(value.tasks) || !isIsoTimestamp(value.createdAt)) return undefined;
+  if (value.model !== undefined && !isNonBlankString(value.model)) return undefined;
+  if (value.contextWindowTokens !== undefined && !finiteNonNegative(value.contextWindowTokens)) return undefined;
+  const tasks = value.tasks.map(parseTask);
+  if (tasks.some((task) => task === undefined)) return undefined;
+  if (new Set(tasks.map((task) => task!.taskId)).size !== tasks.length) return undefined;
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION, planId: value.planId, hostId: value.hostId,
+    sessionId: value.sessionId, baseRevision: value.baseRevision,
+    ...(value.model !== undefined ? { model: value.model } : {}),
+    ...(value.contextWindowTokens !== undefined ? { contextWindowTokens: value.contextWindowTokens } : {}),
+    usedTokens: value.usedTokens, usedChars: value.usedChars,
+    protectedTokens: value.protectedTokens, protectedChars: value.protectedChars,
+    unassignedTokens: value.unassignedTokens, unassignedChars: value.unassignedChars,
+    tokenCountMode: value.tokenCountMode as ContextCleanPlan["tokenCountMode"],
+    tokenCountMethod: value.tokenCountMethod, tasks: tasks as ContextCleanPlan["tasks"],
+    createdAt: value.createdAt,
+  };
+}
+
+function parseEvidence(value: unknown, applied: boolean): ContextCleanReceipt["evidence"] | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) return undefined;
+  for (const field of ["operationIds", "itemIds", "eventIds", "archiveRefs"] as const) {
+    if (!optionalUniqueStrings(value[field])) return undefined;
+  }
+  for (const field of ["previousRevision", "nextRevision", "providerResponseId"] as const) {
+    if (value[field] !== undefined && !isNonBlankString(value[field])) return undefined;
+  }
+  if (applied && (!isNonBlankString(value.previousRevision) || !isNonBlankString(value.nextRevision)
+    || !uniqueStrings(value.operationIds) || !uniqueStrings(value.itemIds))) return undefined;
+  return {
+    ...(value.previousRevision ? { previousRevision: value.previousRevision as string } : {}),
+    ...(value.nextRevision ? { nextRevision: value.nextRevision as string } : {}),
+    ...(value.operationIds ? { operationIds: [...value.operationIds as string[]] } : {}),
+    ...(value.itemIds ? { itemIds: [...value.itemIds as string[]] } : {}),
+    ...(value.eventIds ? { eventIds: [...value.eventIds as string[]] } : {}),
+    ...(value.archiveRefs ? { archiveRefs: [...value.archiveRefs as string[]] } : {}),
+    ...(value.providerResponseId ? { providerResponseId: value.providerResponseId as string } : {}),
+  };
+}
+
+export function parseContextCleanReceipt(value: unknown): ContextCleanReceipt | undefined {
+  if (!isRecord(value) || value.schemaVersion !== CONTEXT_CLEAN_SCHEMA_VERSION
+    || !isNonBlankString(value.planId) || !isNonBlankString(value.hostId)
+    || !isNonBlankString(value.sessionId) || !STATUSES.has(value.status as ContextCleanStatus)
+    || !uniqueStrings(value.selectedTaskIds) || !nullableCount(value.estimatedSavedTokens)
+    || !finiteNonNegative(value.estimatedSavedChars) || !COUNT_MODES.has(String(value.tokenCountMode))
+    || !uniqueStrings(value.deferredTaskIds) || !uniqueStrings(value.reasons)
+    || typeof value.fallbackUsed !== "boolean" || !isIsoTimestamp(value.updatedAt)) return undefined;
+  const status = value.status as ContextCleanStatus;
+  const applied = status === "applied";
+  const hasAppliedTokens = Object.hasOwn(value, "appliedSavedTokens");
+  const hasAppliedChars = Object.hasOwn(value, "appliedSavedChars");
+  if (applied) {
+    if (!hasAppliedTokens || !hasAppliedChars || !nullableCount(value.appliedSavedTokens)
+      || !finiteNonNegative(value.appliedSavedChars) || value.fallbackUsed) return undefined;
+  } else if (hasAppliedTokens || hasAppliedChars) return undefined;
+  if (["analyzed", "approved", "scheduled"].includes(status) && value.fallbackUsed) return undefined;
+  const evidence = parseEvidence(value.evidence, applied);
+  if (value.evidence !== undefined && evidence === undefined) return undefined;
+  if (applied && evidence === undefined) return undefined;
+  const base = {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION, planId: value.planId, hostId: value.hostId,
+    sessionId: value.sessionId, status, selectedTaskIds: [...value.selectedTaskIds],
+    estimatedSavedTokens: value.estimatedSavedTokens, estimatedSavedChars: value.estimatedSavedChars,
+    tokenCountMode: value.tokenCountMode as ContextCleanReceipt["tokenCountMode"],
+    deferredTaskIds: [...value.deferredTaskIds], fallbackUsed: value.fallbackUsed,
+    reasons: [...value.reasons], updatedAt: value.updatedAt, ...(evidence ? { evidence } : {}),
+  };
+  return applied
+    ? { ...base, status: "applied", fallbackUsed: false, appliedSavedTokens: value.appliedSavedTokens as number | null,
+        appliedSavedChars: value.appliedSavedChars as number, evidence: evidence! as Extract<ContextCleanReceipt, {status:"applied"}>["evidence"] }
+    : base as ContextCleanReceipt;
+}
+
+export function parseContextCleanPlanRecord(value: unknown): ContextCleanPlanRecord | undefined {
+  if (!isRecord(value) || value.storeSchemaVersion !== CONTEXT_CLEAN_STORE_SCHEMA_VERSION
+    || !STATUSES.has(value.status as ContextCleanStatus) || !isIsoTimestamp(value.updatedAt)) return undefined;
+  const plan = parseContextCleanPlan(value.plan);
+  return plan ? { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+    status: value.status as ContextCleanStatus, plan, updatedAt: value.updatedAt } : undefined;
+}
+
+export function parseContextCleanStoredReceipt(value: unknown): ContextCleanStoredReceipt | undefined {
+  if (!isRecord(value) || value.storeSchemaVersion !== CONTEXT_CLEAN_STORE_SCHEMA_VERSION) return undefined;
+  const receipt = parseContextCleanReceipt(value.receipt);
+  return receipt ? { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION, receipt } : undefined;
+}
+
+export async function readStoredJson(path: string): Promise<
+  { kind: "ok"; value: unknown } | { kind: "missing" } | { kind: "unreadable" }
+> {
+  try { return { kind: "ok", value: JSON.parse(await readFile(path, "utf8")) as unknown }; }
+  catch (error) { return (error as NodeJS.ErrnoException).code === "ENOENT"
+    ? { kind: "missing" } : { kind: "unreadable" }; }
+}
+
+export function sameCanonicalValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/components/packages/features/cleaner/src/contracts.ts
+++ b/components/packages/features/cleaner/src/contracts.ts
@@ -4,6 +4,7 @@ import type {
 } from "@lightrsi/host-adapter";
 
 export const CONTEXT_CLEAN_SCHEMA_VERSION = 1 as const;
+export const CONTEXT_CLEAN_STORE_SCHEMA_VERSION = 1 as const;
 
 export type ContextCleanTokenCountMode = "exact" | "estimated" | "chars_only";
 
@@ -24,6 +25,42 @@ export type ContextCleanStatus =
   | "stale"
   | "cancelled"
   | "failed";
+
+export const TERMINAL_CONTEXT_CLEAN_STATUSES = [
+  "applied",
+  "stale",
+  "cancelled",
+  "failed",
+] as const satisfies readonly ContextCleanStatus[];
+
+export const CONTEXT_CLEAN_STATUS_TRANSITIONS = {
+  analyzed: ["approved", "cancelled", "failed"],
+  approved: ["scheduled", "stale", "cancelled", "failed"],
+  scheduled: ["applied", "stale", "cancelled", "failed"],
+  applied: [],
+  stale: [],
+  cancelled: [],
+  failed: [],
+} as const satisfies Record<ContextCleanStatus, readonly ContextCleanStatus[]>;
+
+export function isContextCleanStatus(value: unknown): value is ContextCleanStatus {
+  return typeof value === "string" && Object.hasOwn(CONTEXT_CLEAN_STATUS_TRANSITIONS, value);
+}
+
+export function isTerminalContextCleanStatus(
+  status: ContextCleanStatus,
+): boolean {
+  return (TERMINAL_CONTEXT_CLEAN_STATUSES as readonly ContextCleanStatus[])
+    .includes(status);
+}
+
+export function canTransitionContextCleanStatus(
+  from: ContextCleanStatus,
+  to: ContextCleanStatus,
+): boolean {
+  return from === to || (CONTEXT_CLEAN_STATUS_TRANSITIONS[from] as readonly ContextCleanStatus[])
+    .includes(to);
+}
 
 export type ContextCleanTaskBreakdown = {
   taskId: string;
@@ -80,6 +117,7 @@ type ContextCleanReceiptBase = {
   planId: string;
   hostId: string;
   sessionId: string;
+  /** Empty while analyzed; user approval freezes this selection for later states. */
   selectedTaskIds: string[];
   estimatedSavedTokens: number | null;
   estimatedSavedChars: number;
@@ -122,6 +160,34 @@ export type ContextCleanReceipt =
   | ContextCleanPendingReceipt
   | ContextCleanAppliedReceipt
   | ContextCleanTerminalReceipt;
+
+export type ContextCleanPlanRecord = {
+  storeSchemaVersion: typeof CONTEXT_CLEAN_STORE_SCHEMA_VERSION;
+  status: ContextCleanStatus;
+  plan: ContextCleanPlan;
+  updatedAt: string;
+};
+
+export type ContextCleanStoreOutcome =
+  | "stored"
+  | "transitioned"
+  | "unchanged"
+  | "missing"
+  | "conflict"
+  | "bypassed";
+
+export type ContextCleanStoreWriteResult<T> = {
+  outcome: ContextCleanStoreOutcome;
+  value?: T;
+  bypassed: boolean;
+  reasons: string[];
+};
+
+export type ContextCleanStoreReadResult<T> = {
+  value?: T;
+  bypassed: boolean;
+  reasons: string[];
+};
 
 export type ContextCleanSnapshot = ModelContextSnapshot & {
   capturedAt: string;

--- a/components/packages/features/cleaner/src/index.ts
+++ b/components/packages/features/cleaner/src/index.ts
@@ -1,1 +1,20 @@
 export * from "./contracts.js";
+export {
+  contextCleanPlanFilePath,
+  contextCleanReceiptFilePath,
+  contextCleanTransactionFilePath,
+  parseContextCleanPlan,
+  parseContextCleanPlanRecord,
+  parseContextCleanReceipt,
+} from "./clean-store-support.js";
+export {
+  readContextCleanPlan,
+  saveContextCleanPlan,
+} from "./clean-plan-store.js";
+export {
+  readContextCleanReceipt,
+} from "./clean-receipt-store.js";
+export {
+  recoverContextCleanState,
+  transitionContextCleanState,
+} from "./clean-state-coordinator.js";

--- a/components/packages/features/cleaner/tests/clean-plan-store.test.ts
+++ b/components/packages/features/cleaner/tests/clean-plan-store.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_STATUS_TRANSITIONS,
+  canTransitionContextCleanStatus,
+  contextCleanPlanFilePath,
+  isTerminalContextCleanStatus,
+  readContextCleanPlan,
+  saveContextCleanPlan,
+} from "../src/index.js";
+import { transitionContextCleanPlan } from "../src/clean-plan-store.js";
+import { samplePlan } from "./fixtures.js";
+
+async function stateDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "lightrsi-clean-plan-"));
+}
+
+test("status transition contract is frozen and terminal states cannot advance", () => {
+  assert.deepEqual(CONTEXT_CLEAN_STATUS_TRANSITIONS.analyzed, ["approved", "cancelled", "failed"]);
+  assert.equal(canTransitionContextCleanStatus("analyzed", "approved"), true);
+  assert.equal(canTransitionContextCleanStatus("analyzed", "applied"), false);
+  assert.equal(canTransitionContextCleanStatus("applied", "applied"), true);
+  assert.equal(isTerminalContextCleanStatus("applied"), true);
+  assert.equal(isTerminalContextCleanStatus("scheduled"), false);
+});
+
+test("plan store is idempotent and rejects plan id content conflicts", async () => {
+  const root = await stateDir();
+  try {
+    const plan = samplePlan();
+    assert.equal((await saveContextCleanPlan({ stateDir: root, plan })).outcome, "stored");
+    assert.equal((await saveContextCleanPlan({ stateDir: root, plan })).outcome, "unchanged");
+    const conflict = { ...plan, baseRevision: "different-revision" };
+    const result = await saveContextCleanPlan({ stateDir: root, plan: conflict });
+    assert.equal(result.outcome, "conflict");
+    assert.equal(result.bypassed, true);
+    assert.deepEqual((await readContextCleanPlan({ stateDir: root, planId: plan.planId })).value?.plan, plan);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("concurrent writers cannot overwrite one plan id with different content", async () => {
+  const root = await stateDir();
+  try {
+    const plan = samplePlan();
+    const other = { ...plan, baseRevision: "concurrent-revision" };
+    const results = await Promise.all([
+      saveContextCleanPlan({ stateDir: root, plan }),
+      saveContextCleanPlan({ stateDir: root, plan: other }),
+    ]);
+    assert.equal(results.filter((result) => result.outcome === "stored").length, 1);
+    assert.equal(results.filter((result) => result.outcome === "conflict").length, 1);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("plan store permits legal transitions and fails closed after a terminal state", async () => {
+  const root = await stateDir();
+  try {
+    const plan = samplePlan();
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const approved = await transitionContextCleanPlan({ stateDir: root, planId: plan.planId,
+      status: "approved", updatedAt: "2026-08-20T00:01:00.000Z" });
+    assert.equal(approved.value?.status, "approved");
+    const cancelled = await transitionContextCleanPlan({ stateDir: root, planId: plan.planId,
+      status: "cancelled", updatedAt: "2026-08-20T00:02:00.000Z" });
+    assert.equal(cancelled.value?.status, "cancelled");
+    const invalid = await transitionContextCleanPlan({ stateDir: root, planId: plan.planId,
+      status: "approved", updatedAt: "2026-08-20T00:03:00.000Z" });
+    assert.equal(invalid.bypassed, true);
+    assert.match(invalid.reasons[0] ?? "", /invalid_transition/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("plan store rejects a non-ISO update timestamp before writing", async () => {
+  const root = await stateDir();
+  try {
+    const plan = samplePlan();
+    assert.equal((await saveContextCleanPlan({ stateDir: root, plan, updatedAt: "not-a-time" })).bypassed, true);
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const result = await transitionContextCleanPlan({ stateDir: root, planId: plan.planId,
+      status: "approved", updatedAt: "not-a-time" });
+    assert.deepEqual(result.reasons, ["clean_plan_updated_at_invalid"]);
+    assert.equal((await readContextCleanPlan({ stateDir: root, planId: plan.planId })).value?.status, "analyzed");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("plan reader ignores unknown fields but fails closed for corrupt data and schema", async () => {
+  const root = await stateDir();
+  try {
+    const plan = samplePlan();
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const path = contextCleanPlanFilePath(root, plan.planId);
+    const stored = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    stored.futureField = { supportedBy: "newer-version" };
+    (stored.plan as Record<string, unknown>).futurePlanField = true;
+    await writeFile(path, JSON.stringify(stored), "utf8");
+    const compatible = await readContextCleanPlan({ stateDir: root, planId: plan.planId });
+    assert.equal(compatible.bypassed, false);
+    assert.equal("futurePlanField" in (compatible.value?.plan ?? {}), false);
+
+    await writeFile(path, "{broken", "utf8");
+    assert.equal((await readContextCleanPlan({ stateDir: root, planId: plan.planId })).bypassed, true);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify({ ...stored, storeSchemaVersion: 999 }), "utf8");
+    assert.equal((await readContextCleanPlan({ stateDir: root, planId: plan.planId })).bypassed, true);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});

--- a/components/packages/features/cleaner/tests/clean-receipt-store.test.ts
+++ b/components/packages/features/cleaner/tests/clean-receipt-store.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+  contextCleanReceiptFilePath,
+  readContextCleanReceipt,
+  saveContextCleanPlan,
+} from "../src/index.js";
+import { saveContextCleanReceipt } from "../src/clean-receipt-store.js";
+import { transitionContextCleanPlan } from "../src/clean-plan-store.js";
+import { samplePlan, sampleReceipt } from "./fixtures.js";
+
+test("receipt store persists transitions and rejects identity changes", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-receipt-"));
+  try {
+    await saveContextCleanPlan({ stateDir: root, plan: samplePlan() });
+    const analyzed = sampleReceipt("analyzed");
+    assert.equal((await saveContextCleanReceipt({ stateDir: root, receipt: analyzed })).outcome, "stored");
+    assert.equal((await saveContextCleanReceipt({ stateDir: root, receipt: analyzed })).outcome, "unchanged");
+    const approved = { ...sampleReceipt("approved"), updatedAt: "2026-08-20T00:01:00.000Z" };
+    assert.equal((await saveContextCleanReceipt({ stateDir: root, receipt: approved })).outcome, "transitioned");
+    await transitionContextCleanPlan({ stateDir: root, planId: samplePlan().planId,
+      status: "approved", updatedAt: approved.updatedAt });
+    const changedTargets = { ...sampleReceipt("scheduled"), selectedTaskIds: ["task-other"] };
+    assert.equal((await saveContextCleanReceipt({ stateDir: root, receipt: changedTargets })).outcome, "conflict");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("receipt reader rejects applied-field mixing and missing applied evidence at runtime", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-receipt-json-"));
+  try {
+    const receipt = sampleReceipt("scheduled");
+    const path = contextCleanReceiptFilePath(root, receipt.planId);
+    await mkdir(dirname(path), { recursive: true });
+    const stored = { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+      receipt: { ...receipt } as Record<string, unknown> };
+    stored.receipt.appliedSavedTokens = 10;
+    stored.receipt.appliedSavedChars = 40;
+    await writeFile(path, JSON.stringify(stored), "utf8");
+    assert.equal((await readContextCleanReceipt({ stateDir: root, planId: receipt.planId })).bypassed, true);
+
+    stored.receipt = { ...sampleReceipt("applied") } as unknown as Record<string, unknown>;
+    delete stored.receipt.evidence;
+    await writeFile(path, JSON.stringify(stored), "utf8");
+    assert.equal((await readContextCleanReceipt({ stateDir: root, planId: receipt.planId })).bypassed, true);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("receipt reader strips unknown fields", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-receipt-future-"));
+  try {
+    const receipt = sampleReceipt("applied");
+    const path = contextCleanReceiptFilePath(root, receipt.planId);
+    await mkdir(dirname(path), { recursive: true });
+    const stored = { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+      receipt: { ...receipt } as Record<string, unknown> };
+    stored.receipt.futureReceiptField = "ignored";
+    await writeFile(path, JSON.stringify(stored), "utf8");
+    const read = await readContextCleanReceipt({ stateDir: root, planId: receipt.planId });
+    assert.equal(read.bypassed, false);
+    assert.equal("futureReceiptField" in (read.value ?? {}), false);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("bare receipt writes require a matching non-terminal plan transition", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-receipt-plan-"));
+  try {
+    const missing = await saveContextCleanReceipt({ stateDir: root, receipt: sampleReceipt("approved") });
+    assert.deepEqual(missing.reasons, ["clean_receipt_plan_missing"]);
+
+    const plan = samplePlan();
+    await saveContextCleanPlan({ stateDir: root, plan });
+    await transitionContextCleanPlan({ stateDir: root, planId: plan.planId,
+      status: "cancelled", updatedAt: "2026-08-20T00:01:00.000Z" });
+    const applied = await saveContextCleanReceipt({ stateDir: root, receipt: sampleReceipt("applied") });
+    assert.equal(applied.bypassed, true);
+    assert.match(applied.reasons[0] ?? "", /plan_status_conflict/);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("analyzed to approved freezes the user's first selected task ids", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-receipt-selection-"));
+  try {
+    await saveContextCleanPlan({ stateDir: root, plan: samplePlan() });
+    assert.deepEqual(sampleReceipt("analyzed").selectedTaskIds, []);
+    await saveContextCleanReceipt({ stateDir: root, receipt: sampleReceipt("analyzed") });
+    const approved = await saveContextCleanReceipt({ stateDir: root, receipt: sampleReceipt("approved") });
+    assert.equal(approved.bypassed, false);
+    assert.deepEqual(approved.value?.selectedTaskIds, ["task-a"]);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});

--- a/components/packages/features/cleaner/tests/clean-state-coordinator.test.ts
+++ b/components/packages/features/cleaner/tests/clean-state-coordinator.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
+import {
+  CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+  contextCleanTransactionFilePath,
+  readContextCleanPlan,
+  readContextCleanReceipt,
+  recoverContextCleanState,
+  saveContextCleanPlan,
+  transitionContextCleanState,
+} from "../src/index.js";
+import { saveContextCleanReceipt } from "../src/clean-receipt-store.js";
+import { transitionContextCleanPlan } from "../src/clean-plan-store.js";
+import { samplePlan, sampleReceipt } from "./fixtures.js";
+
+test("coordinator advances plan and receipt through the normal lifecycle", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-state-"));
+  try {
+    await saveContextCleanPlan({ stateDir: root, plan: samplePlan() });
+    for (const status of ["approved", "scheduled", "applied"] as const) {
+      const result = await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt(status) });
+      assert.equal(result.bypassed, false);
+      assert.equal(result.value?.status, status);
+    }
+    assert.equal((await readContextCleanReceipt({ stateDir: root, planId: samplePlan().planId })).value?.status, "applied");
+    const duplicate = await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("applied") });
+    assert.equal(duplicate.outcome, "unchanged");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("recovery completes a receipt-first interrupted transition", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-recover-receipt-"));
+  try {
+    const plan = samplePlan();
+    const receipt = sampleReceipt("approved");
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const intent = { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION, planId: plan.planId,
+      fromStatus: "analyzed", receipt, createdAt: receipt.updatedAt };
+    const path = contextCleanTransactionFilePath(root, plan.planId);
+    await mkdir(dirname(path), { recursive: true });
+    await writeJsonFileAtomic(path, intent);
+    await saveContextCleanReceipt({ stateDir: root, receipt });
+    const recovered = await recoverContextCleanState({ stateDir: root, planId: plan.planId });
+    assert.equal(recovered.value?.status, "approved");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("recovery completes a plan-first interrupted transition and fails closed on conflicts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-recover-plan-"));
+  try {
+    const plan = samplePlan();
+    const receipt = sampleReceipt("approved");
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const intent = { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION, planId: plan.planId,
+      fromStatus: "analyzed", receipt, createdAt: receipt.updatedAt };
+    const path = contextCleanTransactionFilePath(root, plan.planId);
+    await mkdir(dirname(path), { recursive: true });
+    await writeJsonFileAtomic(path, intent);
+    await transitionContextCleanPlan({ stateDir: root, planId: plan.planId,
+      status: "approved", updatedAt: receipt.updatedAt });
+    const recovered = await recoverContextCleanState({ stateDir: root, planId: plan.planId });
+    assert.equal(recovered.value?.status, "approved");
+
+    await transitionContextCleanPlan({ stateDir: root, planId: plan.planId,
+      status: "scheduled", updatedAt: "2026-08-20T00:02:00.000Z" });
+    const staleIntent = { ...intent, receipt: sampleReceipt("failed") };
+    await writeJsonFileAtomic(path, staleIntent);
+    const conflict = await recoverContextCleanState({ stateDir: root, planId: plan.planId });
+    assert.equal(conflict.bypassed, true);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("recovery fails closed when an intent contains an unknown source status", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-recover-invalid-"));
+  try {
+    const plan = samplePlan();
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const path = contextCleanTransactionFilePath(root, plan.planId);
+    await mkdir(dirname(path), { recursive: true });
+    await writeJsonFileAtomic(path, { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+      planId: plan.planId, fromStatus: "future-status", receipt: sampleReceipt("approved"),
+      createdAt: "2026-08-20T00:00:00.000Z" });
+    const result = await recoverContextCleanState({ stateDir: root, planId: plan.planId });
+    assert.equal(result.bypassed, true);
+    assert.deepEqual(result.reasons, ["clean_transaction_invalid"]);
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("identity conflicts do not leave an intent that bricks later transitions", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-identity-"));
+  try {
+    const plan = samplePlan();
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const wrong = { ...sampleReceipt("approved"), hostId: "other-host" };
+    const rejected = await transitionContextCleanState({ stateDir: root, receipt: wrong });
+    assert.deepEqual(rejected.reasons, ["clean_transaction_identity_conflict"]);
+    const valid = await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("approved") });
+    assert.equal(valid.value?.status, "approved");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("recovery aborts a legacy identity-conflicting intent and permits a retry", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-identity-recover-"));
+  try {
+    const plan = samplePlan();
+    await saveContextCleanPlan({ stateDir: root, plan });
+    const receipt = { ...sampleReceipt("approved"), sessionId: "other-session" };
+    const path = contextCleanTransactionFilePath(root, plan.planId);
+    await mkdir(dirname(path), { recursive: true });
+    await writeJsonFileAtomic(path, { storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+      planId: plan.planId, fromStatus: "analyzed", receipt, createdAt: receipt.updatedAt });
+    const rejected = await recoverContextCleanState({ stateDir: root, planId: plan.planId });
+    assert.deepEqual(rejected.reasons, ["clean_transaction_identity_conflict"]);
+    const valid = await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("approved") });
+    assert.equal(valid.value?.status, "approved");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("coordinator aborts same-status receipt content conflicts without bricking the plan", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-content-conflict-"));
+  try {
+    await saveContextCleanPlan({ stateDir: root, plan: samplePlan() });
+    await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("approved") });
+    const conflicting = { ...sampleReceipt("approved"), reasons: ["different"] };
+    const rejected = await transitionContextCleanState({ stateDir: root, receipt: conflicting });
+    assert.deepEqual(rejected.reasons, ["clean_transaction_receipt_content_conflict"]);
+    const duplicate = await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("approved") });
+    assert.equal(duplicate.outcome, "unchanged");
+  } finally { await rm(root, { recursive: true, force: true }); }
+});
+
+test("coordinator supports stale from approved and scheduled", async () => {
+  for (const from of ["approved", "scheduled"] as const) {
+    const root = await mkdtemp(join(tmpdir(), `lightrsi-clean-stale-${from}-`));
+    try {
+      await saveContextCleanPlan({ stateDir: root, plan: samplePlan() });
+      await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("approved") });
+      if (from === "scheduled") {
+        await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("scheduled") });
+      }
+      const stale = await transitionContextCleanState({ stateDir: root, receipt: sampleReceipt("stale") });
+      assert.equal(stale.value?.status, "stale");
+    } finally { await rm(root, { recursive: true, force: true }); }
+  }
+});

--- a/components/packages/features/cleaner/tests/fixtures.ts
+++ b/components/packages/features/cleaner/tests/fixtures.ts
@@ -1,6 +1,7 @@
 import {
   CONTEXT_CLEAN_SCHEMA_VERSION,
   type ContextCleanPlan,
+  type ContextCleanReceipt,
 } from "../src/index.js";
 import {
   MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
@@ -37,6 +38,33 @@ export function sampleSnapshot(revision = "rev-1"): ModelContextSnapshot {
       },
     ],
   };
+}
+
+export function sampleReceipt(
+  status: ContextCleanReceipt["status"] = "analyzed",
+): ContextCleanReceipt {
+  const base = {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: "clean-plan-1",
+    hostId: "codex",
+    sessionId: "session-1",
+    selectedTaskIds: status === "analyzed" ? [] : ["task-a"],
+    estimatedSavedTokens: 50,
+    estimatedSavedChars: 200,
+    tokenCountMode: "estimated" as const,
+    deferredTaskIds: [],
+    reasons: [],
+    updatedAt: "2026-08-20T00:00:00.000Z",
+  };
+  if (status === "applied") {
+    return { ...base, status, fallbackUsed: false, appliedSavedTokens: 45,
+      appliedSavedChars: 180, evidence: { previousRevision: "rev-1", nextRevision: "rev-2",
+        operationIds: ["operation-1"], itemIds: ["item-a", "item-b"] } };
+  }
+  if (status === "stale" || status === "cancelled" || status === "failed") {
+    return { ...base, status, fallbackUsed: status === "failed" };
+  }
+  return { ...base, status, fallbackUsed: false };
 }
 
 export function samplePlan(): ContextCleanPlan {


### PR DESCRIPTION
## Summary

  - add persistent context-clean plan and receipt stores
  - define and enforce clean lifecycle transitions
  - add transaction-intent recovery for plan/receipt consistency
  - fail closed on corrupt state, invalid transitions, and identity conflicts
  - add runtime validation for estimated, scheduled, and applied savings
  - preserve forward compatibility by stripping unknown persisted fields

  ## Validation

  - Cleaner tests: 23/23 passed
  - Cleaner typecheck passed
  - Codex adapter typecheck passed
  - Package boundary check passed
  - `git diff --check` passed

  ## Scope

  This PR only completes section 7.1, Clean Contract and state machine. It does not include attribution, accounting,
  recommendation, safety filters, CLI, or Host adapter integration.