### PR TITLE
feat(claude-code): add context cleaner host bridge

### DIFF
--- a/components/adapters/claude-code/package.json
+++ b/components/adapters/claude-code/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@lightrsi/artifact-store": "workspace:*",
+    "@lightrsi/cleaner": "workspace:*",
     "@lightrsi/tokenpilot": "workspace:*",
     "@lightrsi/eviction": "workspace:*",
     "@lightrsi/history": "workspace:*",

--- a/components/adapters/claude-code/src/context-cleaner/bridge.ts
+++ b/components/adapters/claude-code/src/context-cleaner/bridge.ts
@@ -1,0 +1,193 @@
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  type ContextCleanerControlPlane,
+  type ContextCleanerHostBridge,
+  type ContextCleanReceipt,
+  type ExecuteApprovedContextCleanParams,
+} from "@lightrsi/cleaner";
+
+import { readLatestClaudeSnapshotRecord } from "../context-rewrite/snapshot-store.js";
+import { listClaudeCleanerSessions } from "./session-catalog.js";
+
+const CLAUDE_HOST_ID = "claude-code";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function normalizedUniqueStrings(values: unknown): string[] | undefined {
+  if (!Array.isArray(values)) return undefined;
+  const normalized = values.map((value) => (
+    typeof value === "string" ? value.trim() : ""
+  ));
+  return normalized.every(Boolean) && new Set(normalized).size === normalized.length
+    ? normalized
+    : undefined;
+}
+
+function nonNegativeInteger(value: unknown): boolean {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function nullableNonNegativeInteger(value: unknown): boolean {
+  return value === null || nonNegativeInteger(value);
+}
+
+function validReceiptState(receipt: ContextCleanReceipt): boolean {
+  if (!nullableNonNegativeInteger(receipt.estimatedSavedTokens)
+    || !nonNegativeInteger(receipt.estimatedSavedChars)
+    || !["exact", "estimated", "chars_only"].includes(receipt.tokenCountMode)) {
+    return false;
+  }
+  const record = receipt as unknown as Record<string, unknown>;
+  if (receipt.status === "applied") {
+    const evidence = receipt.evidence as unknown as Record<string, unknown> | undefined;
+    const operationIds = normalizedUniqueStrings(evidence?.operationIds);
+    const itemIds = normalizedUniqueStrings(evidence?.itemIds);
+    return receipt.fallbackUsed === false
+      && nullableNonNegativeInteger(receipt.appliedSavedTokens)
+      && nonNegativeInteger(receipt.appliedSavedChars)
+      && typeof evidence?.previousRevision === "string"
+      && Boolean(evidence.previousRevision.trim())
+      && typeof evidence?.nextRevision === "string"
+      && Boolean(evidence.nextRevision.trim())
+      && operationIds !== undefined
+      && operationIds.length > 0
+      && itemIds !== undefined
+      && itemIds.length > 0;
+  }
+  if (!["analyzed", "approved", "scheduled", "stale", "cancelled", "failed"].includes(receipt.status)) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(record, "appliedSavedTokens")
+    || Object.prototype.hasOwnProperty.call(record, "appliedSavedChars")) {
+    return false;
+  }
+  return !["analyzed", "approved", "scheduled"].includes(receipt.status)
+    || receipt.fallbackUsed === false;
+}
+
+function validateApprovedRequest(request: ExecuteApprovedContextCleanParams): string[] {
+  if (request.schemaVersion !== CONTEXT_CLEAN_SCHEMA_VERSION) {
+    throw new Error("claude_clean_approval_schema_mismatch");
+  }
+  if (request.hostId !== CLAUDE_HOST_ID) {
+    throw new Error("claude_clean_approval_host_mismatch");
+  }
+  if (typeof request.cleanPlanId !== "string"
+    || !request.cleanPlanId.trim()
+    || typeof request.sessionId !== "string"
+    || !request.sessionId.trim()
+    || typeof request.baseRevision !== "string"
+    || !request.baseRevision.trim()
+    || !canonicalTimestamp(request.approvedAt)
+    || !Array.isArray(request.selectedTasks)
+    || request.selectedTasks.length === 0) {
+    throw new Error("claude_clean_approval_invalid");
+  }
+  const taskIds = normalizedUniqueStrings(request.selectedTasks.map((task) => (
+    isRecord(task) ? task.taskId : undefined
+  )));
+  if (!taskIds) throw new Error("claude_clean_approval_invalid");
+  const claimedItemIds = new Set<string>();
+  for (const task of request.selectedTasks) {
+    if (!isRecord(task)) throw new Error("claude_clean_approval_targets_invalid");
+    const itemIds = normalizedUniqueStrings(task.itemIds);
+    const itemDigests = isRecord(task.itemDigests) ? task.itemDigests : undefined;
+    if (!itemIds
+      || itemIds.length === 0
+      || !itemDigests
+      || Object.keys(itemDigests).length !== itemIds.length) {
+      throw new Error("claude_clean_approval_targets_invalid");
+    }
+    for (const itemId of itemIds) {
+      if (claimedItemIds.has(itemId)
+        || typeof itemDigests[itemId] !== "string"
+        || !itemDigests[itemId]!.trim()) {
+        throw new Error("claude_clean_approval_targets_invalid");
+      }
+      claimedItemIds.add(itemId);
+    }
+  }
+  return taskIds;
+}
+
+function validateReceipt(params: {
+  receipt: ContextCleanReceipt;
+  planId: string;
+  sessionId?: string;
+  selectedTaskIds?: string[];
+}): ContextCleanReceipt {
+  if (!isRecord(params.receipt)) throw new Error("claude_clean_receipt_mismatch");
+  const { receipt } = params;
+  const selectedTaskIds = normalizedUniqueStrings(receipt.selectedTaskIds);
+  if (receipt.schemaVersion !== CONTEXT_CLEAN_SCHEMA_VERSION
+    || receipt.hostId !== CLAUDE_HOST_ID
+    || receipt.planId !== params.planId
+    || (params.sessionId !== undefined && receipt.sessionId !== params.sessionId)
+    || !canonicalTimestamp(receipt.updatedAt)
+    || !selectedTaskIds
+    || !validReceiptState(receipt)) {
+    throw new Error("claude_clean_receipt_mismatch");
+  }
+  if (params.selectedTaskIds) {
+    const expected = [...params.selectedTaskIds].sort();
+    const actual = [...selectedTaskIds].sort();
+    if (expected.length !== actual.length
+      || expected.some((taskId, index) => taskId !== actual[index])) {
+      throw new Error("claude_clean_receipt_mismatch");
+    }
+  }
+  return receipt;
+}
+
+export function createClaudeCodeContextCleanerBridge(params: {
+  stateDir: string;
+  controlPlane: ContextCleanerControlPlane;
+}): ContextCleanerHostBridge {
+  return {
+    hostId: CLAUDE_HOST_ID,
+    rewriteMode: "request_overlay",
+    async listSessions() {
+      return listClaudeCleanerSessions(params.stateDir);
+    },
+    async readCleanSnapshot(sessionId) {
+      const record = await readLatestClaudeSnapshotRecord(params.stateDir, sessionId);
+      if (!record) throw new Error("claude_clean_snapshot_unavailable");
+      return {
+        ...record.snapshot,
+        capturedAt: record.storedAt,
+        ...(record.model ? { model: record.model } : {}),
+        tokenCountMode: "chars_only",
+        tokenCountMethod: "utf16_chars",
+      };
+    },
+    async executeApprovedClean(request) {
+      const selectedTaskIds = validateApprovedRequest(request);
+      return validateReceipt({
+        receipt: await params.controlPlane.executeApprovedClean(request),
+        planId: request.cleanPlanId,
+        sessionId: request.sessionId,
+        selectedTaskIds,
+      });
+    },
+    async readCleanReceipt(planId) {
+      if (!planId.trim()) throw new Error("claude_clean_plan_id_invalid");
+      const receipt = await params.controlPlane.readCleanReceipt(planId);
+      return receipt ? validateReceipt({ receipt, planId }) : undefined;
+    },
+    async cancelCleanPlan(planId) {
+      if (!planId.trim()) throw new Error("claude_clean_plan_id_invalid");
+      return validateReceipt({
+        receipt: await params.controlPlane.cancelCleanPlan(planId),
+        planId,
+      });
+    },
+  };
+}

--- a/components/adapters/claude-code/src/context-cleaner/index.ts
+++ b/components/adapters/claude-code/src/context-cleaner/index.ts
@@ -1,0 +1,3 @@
+export * from "./bridge.js";
+export * from "./session-catalog.js";
+export * from "./snapshot.js";

--- a/components/adapters/claude-code/src/context-cleaner/session-catalog.ts
+++ b/components/adapters/claude-code/src/context-cleaner/session-catalog.ts
@@ -1,0 +1,90 @@
+import { readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import type { ContextCleanerSession } from "@lightrsi/cleaner";
+import { sessionStateRoot } from "@lightrsi/host-adapter";
+
+import { loadClaudeCodeSessionSnapshot } from "../session-state.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function optionalCount(value: unknown): boolean {
+  return value === undefined || (Number.isSafeInteger(value) && Number(value) >= 0);
+}
+
+function validSessionState(value: unknown, sessionId: string): value is {
+  sessionId: string;
+  updatedAt: string;
+} {
+  return isRecord(value)
+    && value.sessionId === sessionId
+    && canonicalTimestamp(value.updatedAt)
+    && optionalString(value.latestResponseId)
+    && optionalString(value.previousResponseId)
+    && optionalString(value.latestModel)
+    && optionalString(value.workspaceHint)
+    && optionalString(value.lastHookEvent)
+    && optionalString(value.lastToolName)
+    && (value.disclosedReadPaths === undefined
+      || (Array.isArray(value.disclosedReadPaths)
+        && value.disclosedReadPaths.every((path) => typeof path === "string")))
+    && optionalCount(value.lastToolInputChars)
+    && optionalCount(value.lastToolOutputChars)
+    && optionalCount(value.requestChars)
+    && optionalCount(value.responseChars)
+    && optionalCount(value.assistantChars)
+    && optionalCount(value.reductionSavedChars)
+    && optionalCount(value.evictionSavedChars);
+}
+
+export async function listClaudeCleanerSessions(
+  stateDir: string,
+): Promise<ContextCleanerSession[]> {
+  const directory = join(sessionStateRoot(stateDir), "sessions");
+  let names: string[];
+  try {
+    names = (await readdir(directory, { withFileTypes: true }))
+      .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+      .map((entry) => entry.name);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const sessions = await Promise.all(names.map(async (name): Promise<ContextCleanerSession | undefined> => {
+    let sessionId: string;
+    try {
+      sessionId = decodeURIComponent(basename(name, ".json"));
+    } catch {
+      return undefined;
+    }
+    if (!sessionId.trim() || `${encodeURIComponent(sessionId)}.json` !== name) return undefined;
+    try {
+      const snapshot = await loadClaudeCodeSessionSnapshot(stateDir, sessionId);
+      return validSessionState(snapshot, sessionId)
+        ? { sessionId, updatedAt: snapshot.updatedAt }
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }));
+
+  return sessions
+    .filter((session): session is ContextCleanerSession => session !== undefined)
+    .sort((left, right) => (
+      String(right.updatedAt ?? "").localeCompare(String(left.updatedAt ?? ""))
+      || left.sessionId.localeCompare(right.sessionId)
+    ));
+}

--- a/components/adapters/claude-code/src/context-cleaner/snapshot.ts
+++ b/components/adapters/claude-code/src/context-cleaner/snapshot.ts
@@ -1,0 +1,71 @@
+import type { SessionTaskRegistry } from "@lightrsi/history";
+import type { ContextItemRef, ModelContextSnapshot } from "@lightrsi/host-adapter";
+
+import { buildToolResultSegments } from "../eviction.js";
+
+function provenTaskIds(
+  registry: SessionTaskRegistry,
+  segmentId: string,
+): string[] | undefined {
+  const related = registry.blockToTaskIds[segmentId];
+  if (!related || related.length === 0) return undefined;
+  const normalized = related.map((taskId) => taskId.trim());
+  if (normalized.some((taskId) => !taskId || registry.tasks[taskId] === undefined)
+    || new Set(normalized).size !== normalized.length) return undefined;
+  return [...normalized].sort();
+}
+
+/**
+ * Add only registry-proven task ownership to a canonical Claude snapshot.
+ * Claude's stable item ids are positional, while the registry keys historical
+ * closed tool results by semantic segment id. buildToolResultSegments is the
+ * adapter-owned proof that connects those identities. Text and current-turn
+ * content deliberately remain unassigned.
+ */
+export function attributeClaudeSnapshotTasks(params: {
+  snapshot: ModelContextSnapshot;
+  messages: unknown[];
+  registry: SessionTaskRegistry;
+}): ModelContextSnapshot {
+  const cleanItems = params.snapshot.items.map(({ taskIds: _taskIds, ...item }) => item);
+  if (params.snapshot.hostId !== "claude-code"
+    || params.registry.sessionId !== params.snapshot.sessionId) {
+    return { ...params.snapshot, items: cleanItems };
+  }
+
+  const itemsByStableId = new Map(cleanItems.map((item) => [item.stableId, item] as const));
+  const itemsByCallId = new Map<string, ContextItemRef[]>();
+  for (const item of cleanItems) {
+    if (!item.callId) continue;
+    const related = itemsByCallId.get(item.callId) ?? [];
+    related.push(item);
+    itemsByCallId.set(item.callId, related);
+  }
+
+  const attributedTaskIds = new Map<string, string[]>();
+  const { bindings } = buildToolResultSegments(params.messages);
+  for (const binding of bindings.values()) {
+    const taskIds = provenTaskIds(params.registry, binding.segmentId);
+    if (!taskIds) continue;
+    const resultStableId = `${params.snapshot.sessionId}:${binding.messageIndex}:${binding.blockIndex}`;
+    const result = itemsByStableId.get(resultStableId);
+    const pairedItems = itemsByCallId.get(binding.toolUseId) ?? [];
+    const calls = pairedItems.filter((item) => item.kind === "tool_call");
+    const results = pairedItems.filter((item) => item.kind === "tool_result");
+    if (result?.kind !== "tool_result"
+      || result.callId !== binding.toolUseId
+      || calls.length !== 1
+      || results.length !== 1
+      || results[0]?.stableId !== resultStableId) continue;
+    attributedTaskIds.set(calls[0]!.stableId, taskIds);
+    attributedTaskIds.set(resultStableId, taskIds);
+  }
+
+  return {
+    ...params.snapshot,
+    items: cleanItems.map((item) => {
+      const taskIds = attributedTaskIds.get(item.stableId);
+      return taskIds ? { ...item, taskIds } : item;
+    }),
+  };
+}

--- a/components/adapters/claude-code/src/context-rewrite/snapshot-store.ts
+++ b/components/adapters/claude-code/src/context-rewrite/snapshot-store.ts
@@ -1,13 +1,38 @@
+import { createHash } from "node:crypto";
 import { mkdir, readFile } from "node:fs/promises";
-import { join } from "node:path";
-import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
-import type { ModelContextSnapshot } from "@lightrsi/host-adapter";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  writeJsonFileAtomic,
+  type ContextItemKind,
+  type ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
 
 const SNAPSHOT_STORE_SCHEMA_VERSION = 1 as const;
+const CLAUDE_HOST_ID = "claude-code";
 
 function sessionDir(stateDir: string, sessionId: string): string {
-  return join(stateDir, "claude-context", "sessions", sessionId);
+  const digest = createHash("sha256").update(sessionId).digest("hex");
+  return join(stateDir, "claude-context", "sessions", `session-${digest}`);
 }
+
+function legacySessionDir(stateDir: string, sessionId: string): string | undefined {
+  if (!sessionId
+    || sessionId === "."
+    || sessionId === ".."
+    || isAbsolute(sessionId)
+    || sessionId.includes("/")
+    || sessionId.includes("\\")) return undefined;
+  const sessionsRoot = resolve(stateDir, "claude-context", "sessions");
+  const candidate = resolve(sessionsRoot, sessionId);
+  const relativePath = relative(sessionsRoot, candidate);
+  if (!relativePath
+    || relativePath === ".."
+    || relativePath.startsWith(`..${sep}`)
+    || isAbsolute(relativePath)) return undefined;
+  return candidate;
+}
+
 function latestSnapshotPath(stateDir: string, sessionId: string): string {
   return join(sessionDir(stateDir, sessionId), "latest-snapshot.json");
 }
@@ -15,10 +40,11 @@ function itemFingerprintsPath(stateDir: string, sessionId: string): string {
   return join(sessionDir(stateDir, sessionId), "item-fingerprints.json");
 }
 
-type StoredSnapshotFile = {
+export type StoredClaudeSnapshotFile = {
   schemaVersion: typeof SNAPSHOT_STORE_SCHEMA_VERSION;
   storedAt: string;
   snapshot: ModelContextSnapshot;
+  model?: string;
 };
 
 type ItemFingerprintsFile = {
@@ -27,6 +53,126 @@ type ItemFingerprintsFile = {
   revision: string;
   fingerprints: Record<string, string>;
 };
+
+export type ClaudeSnapshotSaveResult =
+  | { saved: true }
+  | { saved: false; reason: "invalid_snapshot" | "write_failed" };
+
+const CONTEXT_ITEM_KINDS = new Set<ContextItemKind>([
+  "system",
+  "developer",
+  "user",
+  "assistant",
+  "reasoning",
+  "tool_call",
+  "tool_result",
+  "compaction",
+  "unknown",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function validTaskIds(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!Array.isArray(value)) return false;
+  const normalized = value.map((taskId) => (
+    typeof taskId === "string" ? taskId.trim() : ""
+  ));
+  return normalized.every(Boolean) && new Set(normalized).size === normalized.length;
+}
+
+function validSnapshot(value: unknown, sessionId: string): value is ModelContextSnapshot {
+  if (!sessionId.trim()
+    || !isRecord(value)
+    || value.schemaVersion !== MODEL_CONTEXT_REWRITE_SCHEMA_VERSION
+    || value.hostId !== CLAUDE_HOST_ID
+    || value.sessionId !== sessionId
+    || typeof value.revision !== "string"
+    || !value.revision.trim()
+    || Object.prototype.hasOwnProperty.call(value, "adapterMetadata")
+    || !Array.isArray(value.items)) return false;
+
+  const stableIds = new Set<string>();
+  for (const item of value.items) {
+    if (!isRecord(item)
+      || typeof item.stableId !== "string"
+      || !item.stableId.trim()
+      || stableIds.has(item.stableId)
+      || !CONTEXT_ITEM_KINDS.has(item.kind as ContextItemKind)
+      || !isOptionalString(item.role)
+      || !isOptionalString(item.callId)
+      || !isOptionalString(item.responseId)
+      || !validTaskIds(item.taskIds)
+      || typeof item.fingerprint !== "string"
+      || !item.fingerprint.trim()
+      || !Number.isSafeInteger(item.chars)
+      || Number(item.chars) < 0) return false;
+    stableIds.add(item.stableId);
+  }
+  return true;
+}
+
+function validStoredSnapshot(
+  value: unknown,
+  sessionId: string,
+): value is StoredClaudeSnapshotFile {
+  return isRecord(value)
+    && value.schemaVersion === SNAPSHOT_STORE_SCHEMA_VERSION
+    && canonicalTimestamp(value.storedAt)
+    && validSnapshot(value.snapshot, sessionId)
+    && (value.model === undefined
+      || (typeof value.model === "string" && Boolean(value.model.trim())));
+}
+
+function validFingerprintsFile(
+  value: unknown,
+  snapshotRecord: StoredClaudeSnapshotFile,
+): value is ItemFingerprintsFile {
+  if (!isRecord(value)
+    || value.schemaVersion !== SNAPSHOT_STORE_SCHEMA_VERSION
+    || !canonicalTimestamp(value.storedAt)
+    || value.storedAt !== snapshotRecord.storedAt
+    || value.revision !== snapshotRecord.snapshot.revision
+    || !isRecord(value.fingerprints)) return false;
+
+  const expected = new Map(
+    snapshotRecord.snapshot.items.map((item) => [item.stableId, item.fingerprint] as const),
+  );
+  const entries = Object.entries(value.fingerprints);
+  return entries.length === expected.size
+    && entries.every(([stableId, fingerprint]) => (
+      typeof fingerprint === "string"
+      && Boolean(fingerprint.trim())
+      && expected.get(stableId) === fingerprint
+    ));
+}
+
+async function readStoredFile(
+  stateDir: string,
+  sessionId: string,
+  filename: "latest-snapshot.json" | "item-fingerprints.json",
+): Promise<string> {
+  try {
+    return await readFile(join(sessionDir(stateDir, sessionId), filename), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    const legacyDirectory = legacySessionDir(stateDir, sessionId);
+    if (!legacyDirectory) throw error;
+    return readFile(join(legacyDirectory, filename), "utf8");
+  }
+}
 
 /**
  * Persist the latest complete snapshot for a session, overwriting any previous
@@ -39,7 +185,13 @@ export async function saveLatestClaudeSnapshot(
   stateDir: string,
   sessionId: string,
   snapshot: ModelContextSnapshot,
-): Promise<void> {
+  metadata?: { model?: string },
+): Promise<ClaudeSnapshotSaveResult> {
+  if (!validSnapshot(snapshot, sessionId)
+    || (metadata?.model !== undefined
+      && (typeof metadata.model !== "string" || !metadata.model.trim()))) {
+    return { saved: false, reason: "invalid_snapshot" };
+  }
   try {
     await mkdir(sessionDir(stateDir, sessionId), { recursive: true });
     const storedAt = new Date().toISOString();
@@ -47,19 +199,23 @@ export async function saveLatestClaudeSnapshot(
     for (const item of snapshot.items) {
       fingerprints[item.stableId] = item.fingerprint;
     }
-    await writeJsonFileAtomic(latestSnapshotPath(stateDir, sessionId), {
-      schemaVersion: SNAPSHOT_STORE_SCHEMA_VERSION,
-      storedAt,
-      snapshot,
-    } satisfies StoredSnapshotFile);
+    // Write the sidecar first and the snapshot last. The snapshot is the commit
+    // point; readers reject a sidecar that does not match its stored revision.
     await writeJsonFileAtomic(itemFingerprintsPath(stateDir, sessionId), {
       schemaVersion: SNAPSHOT_STORE_SCHEMA_VERSION,
       storedAt,
       revision: snapshot.revision,
       fingerprints,
     } satisfies ItemFingerprintsFile);
+    await writeJsonFileAtomic(latestSnapshotPath(stateDir, sessionId), {
+      schemaVersion: SNAPSHOT_STORE_SCHEMA_VERSION,
+      storedAt,
+      snapshot,
+      ...(metadata?.model ? { model: metadata.model } : {}),
+    } satisfies StoredClaudeSnapshotFile);
+    return { saved: true };
   } catch {
-    // fail-open: persistence errors must not affect request handling
+    return { saved: false, reason: "write_failed" };
   }
 }
 
@@ -71,17 +227,20 @@ export async function readLatestClaudeSnapshot(
   stateDir: string,
   sessionId: string,
 ): Promise<ModelContextSnapshot | undefined> {
+  return (await readLatestClaudeSnapshotRecord(stateDir, sessionId))?.snapshot;
+}
+
+export async function readLatestClaudeSnapshotRecord(
+  stateDir: string,
+  sessionId: string,
+): Promise<StoredClaudeSnapshotFile | undefined> {
   try {
-    const raw = await readFile(latestSnapshotPath(stateDir, sessionId), "utf8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (
-      !parsed
-      || typeof parsed !== "object"
-      || (parsed as StoredSnapshotFile).schemaVersion !== SNAPSHOT_STORE_SCHEMA_VERSION
-    ) {
-      return undefined;
-    }
-    return (parsed as StoredSnapshotFile).snapshot;
+    const parsed = JSON.parse(await readStoredFile(
+      stateDir,
+      sessionId,
+      "latest-snapshot.json",
+    )) as unknown;
+    return validStoredSnapshot(parsed, sessionId) ? parsed : undefined;
   } catch {
     return undefined;
   }
@@ -96,17 +255,15 @@ export async function readClaudeItemFingerprints(
   sessionId: string,
 ): Promise<Record<string, string>> {
   try {
-    const raw = await readFile(itemFingerprintsPath(stateDir, sessionId), "utf8");
+    const [raw, snapshotRecord] = await Promise.all([
+      readStoredFile(stateDir, sessionId, "item-fingerprints.json"),
+      readLatestClaudeSnapshotRecord(stateDir, sessionId),
+    ]);
+    if (!snapshotRecord) return {};
     const parsed = JSON.parse(raw) as unknown;
-    if (
-      !parsed
-      || typeof parsed !== "object"
-      || (parsed as ItemFingerprintsFile).schemaVersion !== SNAPSHOT_STORE_SCHEMA_VERSION
-    ) {
-      return {};
-    }
-    const fingerprints = (parsed as ItemFingerprintsFile).fingerprints;
-    return fingerprints && typeof fingerprints === "object" ? { ...fingerprints } : {};
+    return validFingerprintsFile(parsed, snapshotRecord)
+      ? { ...parsed.fingerprints }
+      : {};
   } catch {
     return {};
   }

--- a/components/adapters/claude-code/src/gateway-runtime.ts
+++ b/components/adapters/claude-code/src/gateway-runtime.ts
@@ -35,7 +35,7 @@ import {
   buildClaudeHistoryBlocks,
   type ClaudeEvictionApplySummary,
 } from "./eviction.js";
-import { persistSessionTaskRegistry } from "@lightrsi/history";
+import { loadSessionTaskRegistry, persistSessionTaskRegistry } from "@lightrsi/history";
 import { claudeContextRewriteBackend, relocateContextMutationPlan } from "./context-rewrite/backend.js";
 import { applyArchivePlan } from "./context-rewrite/archive.js";
 import { saveLatestClaudeSnapshot } from "./context-rewrite/snapshot-store.js";
@@ -64,6 +64,7 @@ import { buildAnthropicGatewayModelList, mapClaudeVisibleModelToUpstreamModel } 
 import { resolveLatestClaudeCodeSessionId } from "./session-state.js";
 import { lookupRealSessionId, recordSessionMapping } from "./context-rewrite/session-map.js";
 import { initializeClaudeCodeTokenPilotPreset } from "./preset.js";
+import { attributeClaudeSnapshotTasks } from "./context-cleaner/snapshot.js";
 
 export type ClaudeCodeGatewayRuntime = {
   baseUrl: string;
@@ -74,6 +75,7 @@ type ClaudeCodeGatewayRuntimeDependencies = {
   cloneRequestPayload?: typeof structuredClone;
   resolveEstimator?: typeof resolveClaudeTaskStateEstimator;
   persistTaskRegistry?: typeof persistSessionTaskRegistry;
+  saveSnapshot?: typeof saveLatestClaudeSnapshot;
 };
 
 const CLAUDE_LIFECYCLE_PLAN_SOURCE = "claude-lifecycle";
@@ -344,6 +346,10 @@ export async function startClaudeCodeGatewayRuntime(params: {
       const plannerMessages = Array.isArray((payload as Record<string, unknown>).messages)
         ? (payload as Record<string, unknown>).messages as unknown[]
         : [];
+      const cleanerSnapshotRevision = _createHash("sha256")
+        .update(JSON.stringify(plannerMessages))
+        .digest("hex")
+        .slice(0, 32);
 
       const evictionEnabled = config.modules.eviction && config.eviction.enabled;
       let evictionSummary: ClaudeEvictionApplySummary = {
@@ -457,6 +463,37 @@ export async function startClaudeCodeGatewayRuntime(params: {
         }
       }
 
+      // Persist the complete inbound history only after the lifecycle registry
+      // update attempt has settled, but before any eviction/reduction overlay.
+      // The store is side work: failure is visible in logs and never blocks the
+      // model request.
+      try {
+        const baseCleanerSnapshot = await claudeContextRewriteBackend.readSnapshot({
+          sessionId,
+          request: {
+            sessionId,
+            revision: cleanerSnapshotRevision,
+            messages: plannerMessages as unknown as RuntimeMessage[],
+          },
+        });
+        const cleanerRegistry = await loadSessionTaskRegistry(config.stateDir, sessionId);
+        const cleanerSnapshot = attributeClaudeSnapshotTasks({
+          snapshot: baseCleanerSnapshot,
+          messages: plannerMessages,
+          registry: cleanerRegistry,
+        });
+        const saveResult = await (
+          params.dependencies?.saveSnapshot ?? saveLatestClaudeSnapshot
+        )(config.stateDir, sessionId, cleanerSnapshot, { model: envelope.model });
+        if (!saveResult.saved) {
+          logger.warn(
+            `context cleaner snapshot persistence failed (ignored): ${saveResult.reason}`,
+          );
+        }
+      } catch (error) {
+        logger.warn(`context cleaner snapshot persistence failed (ignored): ${String(error)}`);
+      }
+
       if (evictionEnabled) {
         try {
           const candidatePayload = (
@@ -499,10 +536,6 @@ export async function startClaudeCodeGatewayRuntime(params: {
               sessionId,
               request: overlayRequest,
             });
-            // Persist the latest complete snapshot (+ item fingerprints) for this
-            // session so the overlay has a durable, restart-surviving view of the
-            // current turn (§4.5 claude-context). Fail-open, never blocks the request.
-            await saveLatestClaudeSnapshot(config.stateDir, sessionId, snapshot);
             const loaded = plannerPlan
               ? { plans: [], bypassed: false, reasons: [] }
               : await loadActiveContextMutationPlans({

--- a/components/adapters/claude-code/src/index.ts
+++ b/components/adapters/claude-code/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./config.js";
+export * from "./context-cleaner/index.js";
 export * from "./daemon.js";
 export * from "./doctor.js";
 export * from "./gateway-runtime.js";

--- a/components/adapters/claude-code/tests/context-cleaner-bridge.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-bridge.test.ts
@@ -1,0 +1,400 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  type ContextCleanerControlPlane,
+  type ContextCleanAppliedReceipt,
+  type ContextCleanPendingReceipt,
+  type ContextCleanTerminalReceipt,
+  type ExecuteApprovedContextCleanParams,
+} from "@lightrsi/cleaner";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  sessionSnapshotPath,
+} from "@lightrsi/host-adapter";
+
+import { createClaudeCodeContextCleanerBridge } from "../src/context-cleaner/index.js";
+import { saveLatestClaudeSnapshot } from "../src/context-rewrite/snapshot-store.js";
+import { upsertClaudeCodeSessionSnapshot } from "../src/session-state.js";
+
+const SESSION = "claude-cleaner-session";
+const PLAN = "clean-plan-1";
+
+function pendingReceipt(
+  status: ContextCleanPendingReceipt["status"],
+): ContextCleanPendingReceipt {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: PLAN,
+    hostId: "claude-code",
+    sessionId: SESSION,
+    status,
+    selectedTaskIds: ["task-1"],
+    estimatedSavedTokens: null,
+    estimatedSavedChars: 10,
+    tokenCountMode: "chars_only",
+    deferredTaskIds: [],
+    fallbackUsed: false,
+    reasons: [],
+    updatedAt: "2026-08-20T00:00:00.000Z",
+  };
+}
+
+function terminalReceipt(
+  status: ContextCleanTerminalReceipt["status"],
+): ContextCleanTerminalReceipt {
+  return {
+    ...pendingReceipt("scheduled"),
+    status,
+    fallbackUsed: status === "failed",
+  };
+}
+
+function appliedReceipt(): ContextCleanAppliedReceipt {
+  return {
+    ...pendingReceipt("scheduled"),
+    status: "applied",
+    appliedSavedTokens: null,
+    appliedSavedChars: 10,
+    evidence: {
+      previousRevision: "revision-before",
+      nextRevision: "revision-after",
+      operationIds: ["operation-1"],
+      itemIds: ["item-1"],
+    },
+  };
+}
+
+function approval(): ExecuteApprovedContextCleanParams {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    cleanPlanId: PLAN,
+    hostId: "claude-code",
+    sessionId: SESSION,
+    baseRevision: "revision-before",
+    approvedAt: "2026-08-21T00:00:00.000Z",
+    selectedTasks: [{
+      taskId: "task-1",
+      itemIds: ["item-1", "item-2"],
+      itemDigests: {
+        "item-1": "digest-1",
+        "item-2": "digest-2",
+      },
+    }],
+  };
+}
+
+function fakeControlPlane(): ContextCleanerControlPlane {
+  return {
+    async executeApprovedClean() { return pendingReceipt("scheduled"); },
+    async readCleanReceipt() { return pendingReceipt("scheduled"); },
+    async cancelCleanPlan() { return terminalReceipt("cancelled"); },
+  };
+}
+
+test("Claude cleaner bridge lists sessions and reads a chars-only canonical snapshot", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-bridge-"));
+  try {
+    await upsertClaudeCodeSessionSnapshot(stateDir, SESSION, {
+      latestModel: "claude-sonnet-4-6",
+    });
+    assert.deepEqual(await saveLatestClaudeSnapshot(stateDir, SESSION, {
+      schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+      hostId: "claude-code",
+      sessionId: SESSION,
+      revision: "revision-1",
+      items: [{
+        stableId: "item-1",
+        kind: "user",
+        fingerprint: "digest-1",
+        chars: 12,
+      }],
+    }, { model: "claude-sonnet-4-6" }), { saved: true });
+
+    const bridge = createClaudeCodeContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    assert.equal(bridge.hostId, "claude-code");
+    assert.equal(bridge.rewriteMode, "request_overlay");
+    assert.deepEqual((await bridge.listSessions()).map((session) => session.sessionId), [SESSION]);
+    const snapshot = await bridge.readCleanSnapshot(SESSION);
+    assert.equal(snapshot.hostId, "claude-code");
+    assert.equal(snapshot.sessionId, SESSION);
+    assert.equal(snapshot.revision, "revision-1");
+    assert.equal(snapshot.model, "claude-sonnet-4-6");
+    assert.equal(snapshot.tokenCountMode, "chars_only");
+    assert.equal(snapshot.tokenCountMethod, "utf16_chars");
+    assert.equal(snapshot.itemTokenCounts, undefined);
+    assert.ok(snapshot.capturedAt);
+    assert.equal("adapterMetadata" in snapshot, false);
+    assert.equal("messages" in snapshot, false);
+
+    const repeated = await bridge.readCleanSnapshot(SESSION);
+    assert.equal(repeated.revision, snapshot.revision);
+    assert.deepEqual(repeated.items, snapshot.items);
+    assert.equal(repeated.capturedAt, snapshot.capturedAt);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Claude cleaner bridge rejects a session without a canonical snapshot", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-missing-"));
+  try {
+    await upsertClaudeCodeSessionSnapshot(stateDir, SESSION, {
+      latestModel: "claude-sonnet-4-6",
+    });
+    const bridge = createClaudeCodeContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    await assert.rejects(
+      bridge.readCleanSnapshot(SESSION),
+      /claude_clean_snapshot_unavailable/,
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Claude cleaner bridge preserves approved targets and receipt evidence", async () => {
+  let captured: ExecuteApprovedContextCleanParams | undefined;
+  const applied = appliedReceipt();
+  const cancelled = terminalReceipt("cancelled");
+  const bridge = createClaudeCodeContextCleanerBridge({
+    stateDir: "unused-state-dir",
+    controlPlane: {
+      async executeApprovedClean(request) {
+        captured = request;
+        return pendingReceipt("scheduled");
+      },
+      async readCleanReceipt() { return applied; },
+      async cancelCleanPlan() { return cancelled; },
+    },
+  });
+  const request = approval();
+
+  const scheduled = await bridge.executeApprovedClean(request);
+  assert.strictEqual(captured, request);
+  assert.equal(scheduled.status, "scheduled");
+  assert.equal("appliedSavedChars" in scheduled, false);
+  assert.strictEqual(await bridge.readCleanReceipt(PLAN), applied);
+  assert.deepEqual(applied.evidence, {
+    previousRevision: "revision-before",
+    nextRevision: "revision-after",
+    operationIds: ["operation-1"],
+    itemIds: ["item-1"],
+  });
+  assert.strictEqual(await bridge.cancelCleanPlan(PLAN), cancelled);
+});
+
+test("Claude cleaner bridge rejects cross-host or mutated approvals before execution", async () => {
+  let executions = 0;
+  const bridge = createClaudeCodeContextCleanerBridge({
+    stateDir: "unused-state-dir",
+    controlPlane: {
+      ...fakeControlPlane(),
+      async executeApprovedClean() {
+        executions += 1;
+        return pendingReceipt("scheduled");
+      },
+    },
+  });
+  await assert.rejects(
+    bridge.executeApprovedClean({ ...approval(), hostId: "codex" }),
+    /claude_clean_approval_host_mismatch/,
+  );
+  await assert.rejects(
+    bridge.executeApprovedClean({
+      ...approval(),
+      selectedTasks: [{
+        taskId: "task-1",
+        itemIds: ["item-1"],
+        itemDigests: { "other-item": "digest-1" },
+      }],
+    }),
+    /claude_clean_approval_targets_invalid/,
+  );
+  assert.equal(executions, 0);
+});
+
+test("Claude cleaner bridge rejects mismatched or malformed receipts", async () => {
+  const malformedApplied = {
+    ...pendingReceipt("scheduled"),
+    status: "applied",
+    fallbackUsed: true,
+    appliedSavedTokens: null,
+    appliedSavedChars: 10,
+  } as unknown as ContextCleanAppliedReceipt;
+  const bridge = createClaudeCodeContextCleanerBridge({
+    stateDir: "unused-state-dir",
+    controlPlane: {
+      async executeApprovedClean() {
+        return { ...pendingReceipt("scheduled"), hostId: "codex" };
+      },
+      async readCleanReceipt(planId) {
+        return planId === "malformed" ? malformedApplied : {
+          ...pendingReceipt("scheduled"),
+          planId: "other-plan",
+        };
+      },
+      async cancelCleanPlan() {
+        return { ...terminalReceipt("cancelled"), hostId: "openclaw" };
+      },
+    },
+  });
+
+  await assert.rejects(bridge.executeApprovedClean(approval()), /claude_clean_receipt_mismatch/);
+  await assert.rejects(bridge.readCleanReceipt(PLAN), /claude_clean_receipt_mismatch/);
+  await assert.rejects(bridge.cancelCleanPlan(PLAN), /claude_clean_receipt_mismatch/);
+  await assert.rejects(bridge.readCleanReceipt("malformed"), /claude_clean_receipt_mismatch/);
+});
+
+test("Claude cleaner session catalog sorts valid state and isolates malformed records", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-sessions-"));
+  try {
+    const records = [
+      { sessionId: "session-older", updatedAt: "2026-08-20T00:00:00.000Z" },
+      { sessionId: "session-newer", updatedAt: "2026-08-21T00:00:00.000Z" },
+      { sessionId: "session-mismatch", updatedAt: "2026-08-22T00:00:00.000Z" },
+      { sessionId: "session-bad-time", updatedAt: "not-a-date" },
+    ];
+    for (const record of records) {
+      const path = sessionSnapshotPath(stateDir, record.sessionId);
+      await mkdir(join(path, ".."), { recursive: true });
+      await writeFile(path, JSON.stringify({
+        ...record,
+        ...(record.sessionId === "session-mismatch" ? { sessionId: "other-session" } : {}),
+      }), "utf8");
+    }
+    const corruptPath = sessionSnapshotPath(stateDir, "session-corrupt");
+    await writeFile(corruptPath, "{ not json", "utf8");
+    await writeFile(
+      join(corruptPath, "..", "bad%XX.json"),
+      JSON.stringify({ sessionId: "bad", updatedAt: "2026-08-23T00:00:00.000Z" }),
+      "utf8",
+    );
+
+    const bridge = createClaudeCodeContextCleanerBridge({
+      stateDir,
+      controlPlane: fakeControlPlane(),
+    });
+    assert.deepEqual(await bridge.listSessions(), [
+      { sessionId: "session-newer", updatedAt: "2026-08-21T00:00:00.000Z" },
+      { sessionId: "session-older", updatedAt: "2026-08-20T00:00:00.000Z" },
+    ]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("Claude cleaner bridge rejects malformed approval shapes and duplicate target scope", async () => {
+  let executions = 0;
+  const bridge = createClaudeCodeContextCleanerBridge({
+    stateDir: "unused-state-dir",
+    controlPlane: {
+      ...fakeControlPlane(),
+      async executeApprovedClean() {
+        executions += 1;
+        return pendingReceipt("scheduled");
+      },
+    },
+  });
+  const cases: Array<[string, ExecuteApprovedContextCleanParams, RegExp]> = [
+    ["schema", { ...approval(), schemaVersion: 999 as 1 }, /approval_schema_mismatch/],
+    ["timestamp", { ...approval(), approvedAt: "2026-08-21" }, /approval_invalid/],
+    ["selectedTasks", { ...approval(), selectedTasks: null as never }, /approval_invalid/],
+    ["digests", {
+      ...approval(),
+      selectedTasks: [{ taskId: "task-1", itemIds: ["item-1"], itemDigests: null as never }],
+    }, /approval_targets_invalid/],
+    ["duplicate task", {
+      ...approval(),
+      selectedTasks: [approval().selectedTasks[0]!, approval().selectedTasks[0]!],
+    }, /approval_invalid/],
+    ["duplicate item", {
+      ...approval(),
+      selectedTasks: [
+        { taskId: "task-1", itemIds: ["item-1"], itemDigests: { "item-1": "digest-1" } },
+        { taskId: "task-2", itemIds: ["item-1"], itemDigests: { "item-1": "digest-1" } },
+      ],
+    }, /approval_targets_invalid/],
+    ["extra digest", {
+      ...approval(),
+      selectedTasks: [{
+        taskId: "task-1",
+        itemIds: ["item-1"],
+        itemDigests: { "item-1": "digest-1", extra: "digest-extra" },
+      }],
+    }, /approval_targets_invalid/],
+  ];
+
+  for (const [label, request, pattern] of cases) {
+    await assert.rejects(bridge.executeApprovedClean(request), pattern, label);
+  }
+  assert.equal(executions, 0);
+});
+
+test("Claude cleaner bridge rejects invalid receipt accounting and state combinations", async () => {
+  const cases: Array<[string, ContextCleanPendingReceipt | ContextCleanAppliedReceipt]> = [
+    ["negative estimate", { ...pendingReceipt("scheduled"), estimatedSavedChars: -1 }],
+    ["invalid timestamp", { ...pendingReceipt("scheduled"), updatedAt: "2026-08-20" }],
+    ["duplicate tasks", { ...pendingReceipt("scheduled"), selectedTaskIds: ["task-1", "task-1"] }],
+    ["pending actual savings", {
+      ...pendingReceipt("scheduled"),
+      appliedSavedTokens: null,
+      appliedSavedChars: 1,
+    } as unknown as ContextCleanPendingReceipt],
+    ["applied fallback", {
+      ...appliedReceipt(),
+      fallbackUsed: true,
+    } as unknown as ContextCleanAppliedReceipt],
+    ["applied missing evidence", {
+      ...pendingReceipt("scheduled"),
+      status: "applied",
+      appliedSavedTokens: null,
+      appliedSavedChars: 1,
+    } as unknown as ContextCleanAppliedReceipt],
+    ["applied empty operations", {
+      ...appliedReceipt(),
+      evidence: { ...appliedReceipt().evidence, operationIds: [] },
+    }],
+  ];
+
+  for (const [label, candidate] of cases) {
+    const bridge = createClaudeCodeContextCleanerBridge({
+      stateDir: "unused-state-dir",
+      controlPlane: {
+        ...fakeControlPlane(),
+        async readCleanReceipt() { return candidate; },
+      },
+    });
+    await assert.rejects(
+      bridge.readCleanReceipt(PLAN),
+      /claude_clean_receipt_mismatch/,
+      label,
+    );
+  }
+});
+
+test("Claude cleaner bridge rejects blank plan ids without calling the control plane", async () => {
+  let reads = 0;
+  let cancels = 0;
+  const bridge = createClaudeCodeContextCleanerBridge({
+    stateDir: "unused-state-dir",
+    controlPlane: {
+      ...fakeControlPlane(),
+      async readCleanReceipt() { reads += 1; return undefined; },
+      async cancelCleanPlan() { cancels += 1; return terminalReceipt("cancelled"); },
+    },
+  });
+  await assert.rejects(bridge.readCleanReceipt(" "), /claude_clean_plan_id_invalid/);
+  await assert.rejects(bridge.cancelCleanPlan(" "), /claude_clean_plan_id_invalid/);
+  assert.equal(reads, 0);
+  assert.equal(cancels, 0);
+});

--- a/components/adapters/claude-code/tests/context-cleaner-snapshot.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-snapshot.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { SessionTaskRegistry } from "@lightrsi/history";
+
+import { attributeClaudeSnapshotTasks } from "../src/context-cleaner/snapshot.js";
+import { buildClaudeContextSnapshot } from "../src/context-rewrite/snapshot.js";
+
+const SESSION = "claude-task-attribution";
+
+function registry(
+  blockToTaskIds: Record<string, string[]>,
+  taskIds: string[] = ["task-read"],
+): SessionTaskRegistry {
+  return {
+    sessionId: SESSION,
+    version: 1,
+    tasks: Object.fromEntries(taskIds.map((taskId) => [taskId, {
+      taskId,
+      title: taskId,
+      objective: taskId,
+      lifecycle: "completed",
+      completionEvidence: [],
+      unresolvedQuestions: [],
+      span: {
+        firstTurnAbsId: `${SESSION}:t1`,
+        lastTurnAbsId: `${SESSION}:t1`,
+        supportingTurnAbsIds: [`${SESSION}:t1`],
+        lastEstimatorTurnAbsId: `${SESSION}:t1`,
+      },
+    }])),
+    activeTaskIds: [],
+    completedTaskIds: taskIds,
+    evictableTaskIds: [],
+    taskToBlockIds: {},
+    blockToTaskIds,
+    turnToTaskIds: {},
+    lastProcessedTurnSeq: 1,
+  };
+}
+
+function messages() {
+  return [
+    { role: "system", content: [{ type: "text", text: "stay safe" }] },
+    { role: "user", content: [{ type: "text", text: "read the file" }] },
+    {
+      role: "assistant",
+      content: [{
+        type: "tool_use",
+        id: "toolu_read",
+        name: "Read",
+        input: { file_path: "/repo/a.ts" },
+      }],
+    },
+    {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "toolu_read",
+        content: "file body",
+      }],
+    },
+    { role: "assistant", content: [{ type: "text", text: "done" }] },
+    { role: "user", content: [{ type: "text", text: "current request" }] },
+  ];
+}
+
+test("attributes a proven historical tool call/result pair from blockToTaskIds", () => {
+  const inbound = messages();
+  const snapshot = buildClaudeContextSnapshot({
+    sessionId: SESSION,
+    revision: "revision-1",
+    messages: inbound as any,
+  });
+  const attributed = attributeClaudeSnapshotTasks({
+    snapshot,
+    messages: inbound,
+    registry: registry({ "anthropic-tool-result:toolu_read": ["task-read"] }),
+  });
+
+  const call = attributed.items.find((item) => item.kind === "tool_call");
+  const result = attributed.items.find((item) => item.kind === "tool_result");
+  assert.deepEqual(call?.taskIds, ["task-read"]);
+  assert.deepEqual(result?.taskIds, ["task-read"]);
+  assert.equal(call?.callId, result?.callId);
+  assert.ok(
+    attributed.items
+      .filter((item) => item.kind !== "tool_call" && item.kind !== "tool_result")
+      .every((item) => item.taskIds === undefined),
+  );
+});
+
+test("leaves current-turn, ambiguous, and unknown-task mappings unassigned", () => {
+  const currentToolPair = [
+    ...messages().slice(0, -1),
+    {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_current", name: "Read", input: {} }],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_current", content: "current" }],
+    },
+  ];
+  const snapshot = buildClaudeContextSnapshot({
+    sessionId: SESSION,
+    revision: "revision-current",
+    messages: currentToolPair as any,
+  });
+  const attributed = attributeClaudeSnapshotTasks({
+    snapshot,
+    messages: currentToolPair,
+    registry: registry({
+      "anthropic-tool-result:toolu_read": ["missing-task"],
+      "anthropic-tool-result:toolu_current": ["task-read"],
+    }),
+  });
+
+  assert.ok(attributed.items.every((item) => item.taskIds === undefined));
+});
+
+test("rejects attribution from a registry for another session", () => {
+  const inbound = messages();
+  const snapshot = buildClaudeContextSnapshot({
+    sessionId: SESSION,
+    revision: "revision-mismatch",
+    messages: inbound as any,
+  });
+  const wrongRegistry = registry({ "anthropic-tool-result:toolu_read": ["task-read"] });
+  wrongRegistry.sessionId = "different-session";
+
+  const attributed = attributeClaudeSnapshotTasks({
+    snapshot,
+    messages: inbound,
+    registry: wrongRegistry,
+  });
+  assert.ok(attributed.items.every((item) => item.taskIds === undefined));
+});

--- a/components/adapters/claude-code/tests/context-rewrite-snapshot-store.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-snapshot-store.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile, mkdir } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -7,6 +7,7 @@ import { buildClaudeContextSnapshot } from "../src/context-rewrite/snapshot.js";
 import {
   saveLatestClaudeSnapshot,
   readLatestClaudeSnapshot,
+  readLatestClaudeSnapshotRecord,
   readClaudeItemFingerprints,
 } from "../src/context-rewrite/snapshot-store.js";
 
@@ -16,9 +17,9 @@ async function tempStateDir(): Promise<string> {
   return mkdtemp(join(tmpdir(), "lightrsi-snap-store-"));
 }
 
-function sampleSnapshot(revision: string) {
+function sampleSnapshot(revision: string, sessionId = SESSION) {
   return buildClaudeContextSnapshot({
-    sessionId: SESSION,
+    sessionId,
     revision,
     messages: [
       { role: "user", content: "read the file" },
@@ -30,6 +31,15 @@ function sampleSnapshot(revision: string) {
   });
 }
 
+async function hashedSessionDirectory(stateDir: string): Promise<string> {
+  const sessionsRoot = join(stateDir, "claude-context", "sessions");
+  const entries = (await readdir(sessionsRoot, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory() && /^session-[a-f0-9]{64}$/.test(entry.name));
+  assert.equal(entries.length, 1);
+  assert.match(entries[0]!.name, /^session-[a-f0-9]{64}$/);
+  return join(sessionsRoot, entries[0]!.name);
+}
+
 test("readLatestClaudeSnapshot returns undefined when nothing is stored", async () => {
   const stateDir = await tempStateDir();
   assert.equal(await readLatestClaudeSnapshot(stateDir, SESSION), undefined);
@@ -38,11 +48,17 @@ test("readLatestClaudeSnapshot returns undefined when nothing is stored", async 
 test("saveLatestClaudeSnapshot persists a snapshot that reads back identically", async () => {
   const stateDir = await tempStateDir();
   const snap = sampleSnapshot("rev-1");
-  await saveLatestClaudeSnapshot(stateDir, SESSION, snap);
+  assert.deepEqual(
+    await saveLatestClaudeSnapshot(stateDir, SESSION, snap, { model: "claude-sonnet-4-6" }),
+    { saved: true },
+  );
   const readBack = await readLatestClaudeSnapshot(stateDir, SESSION);
   assert.ok(readBack);
   assert.equal(readBack!.revision, "rev-1");
   assert.equal(readBack!.items.length, snap.items.length);
+  const record = await readLatestClaudeSnapshotRecord(stateDir, SESSION);
+  assert.equal(record?.model, "claude-sonnet-4-6");
+  assert.match(record?.storedAt ?? "", /^\d{4}-\d{2}-\d{2}T/);
 });
 
 test("snapshot survives a fresh read (persistence across restart)", async () => {
@@ -71,16 +87,186 @@ test("item fingerprints are persisted alongside the snapshot", async () => {
   }
 });
 
+test("snapshot session paths use stable hashes and cannot escape stateDir", async () => {
+  const root = await tempStateDir();
+  const hostileIds = [
+    "../../escape",
+    "..\\..\\escape",
+    "..",
+    join(root, "absolute-target"),
+  ];
+
+  for (const [index, sessionId] of hostileIds.entries()) {
+    const stateDir = join(root, `state-${index}`);
+    const result = await saveLatestClaudeSnapshot(
+      stateDir,
+      sessionId,
+      sampleSnapshot(`rev-hostile-${index}`, sessionId),
+    );
+    assert.deepEqual(result, { saved: true });
+    assert.equal(
+      (await readLatestClaudeSnapshot(stateDir, sessionId))?.revision,
+      `rev-hostile-${index}`,
+    );
+    await hashedSessionDirectory(stateDir);
+  }
+
+  assert.equal(await readLatestClaudeSnapshot(root, "../../escape"), undefined);
+  assert.deepEqual(await readClaudeItemFingerprints(root, "../../escape"), {});
+  assert.deepEqual(
+    (await readdir(root)).sort(),
+    hostileIds.map((_, index) => `state-${index}`),
+  );
+});
+
+test("safe legacy snapshot directories remain read-only compatible", async () => {
+  const stateDir = await tempStateDir();
+  const snapshot = sampleSnapshot("rev-legacy");
+  const legacyDirectory = join(stateDir, "claude-context", "sessions", SESSION);
+  const storedAt = "2026-08-20T00:00:00.000Z";
+  await mkdir(legacyDirectory, { recursive: true });
+  await writeFile(join(legacyDirectory, "latest-snapshot.json"), JSON.stringify({
+    schemaVersion: 1,
+    storedAt,
+    snapshot,
+  }), "utf8");
+  await writeFile(join(legacyDirectory, "item-fingerprints.json"), JSON.stringify({
+    schemaVersion: 1,
+    storedAt,
+    revision: snapshot.revision,
+    fingerprints: Object.fromEntries(snapshot.items.map((item) => [item.stableId, item.fingerprint])),
+  }), "utf8");
+
+  assert.equal((await readLatestClaudeSnapshot(stateDir, SESSION))?.revision, "rev-legacy");
+  assert.equal(
+    (await readClaudeItemFingerprints(stateDir, SESSION))[snapshot.items[0]!.stableId],
+    snapshot.items[0]!.fingerprint,
+  );
+  assert.equal(await readLatestClaudeSnapshot(stateDir, `alias/../${SESSION}`), undefined);
+
+  assert.deepEqual(
+    await saveLatestClaudeSnapshot(stateDir, SESSION, sampleSnapshot("rev-new")),
+    { saved: true },
+  );
+  assert.equal((await readLatestClaudeSnapshot(stateDir, SESSION))?.revision, "rev-new");
+  assert.deepEqual(
+    (await readdir(join(stateDir, "claude-context", "sessions"))).sort(),
+    [SESSION, (await hashedSessionDirectory(stateDir)).split(/[\\/]/).at(-1)!].sort(),
+  );
+  assert.equal(
+    JSON.parse(await readFile(join(legacyDirectory, "latest-snapshot.json"), "utf8")).snapshot.revision,
+    "rev-legacy",
+  );
+});
+
+test("invalid snapshots are rejected on save with an explicit result", async () => {
+  const stateDir = await tempStateDir();
+  const cases: Array<[string, (candidate: any) => void]> = [
+    ["schema", (candidate) => { candidate.schemaVersion = 999; }],
+    ["host", (candidate) => { candidate.hostId = "codex"; }],
+    ["session", (candidate) => { candidate.sessionId = "other-session"; }],
+    ["revision", (candidate) => { candidate.revision = " "; }],
+    ["duplicate stable id", (candidate) => { candidate.items[1].stableId = candidate.items[0].stableId; }],
+    ["stable id", (candidate) => { candidate.items[0].stableId = ""; }],
+    ["fingerprint", (candidate) => { candidate.items[0].fingerprint = 42; }],
+    ["chars", (candidate) => { candidate.items[0].chars = -1; }],
+    ["kind", (candidate) => { candidate.items[0].kind = "host-payload"; }],
+    ["role", (candidate) => { candidate.items[0].role = 42; }],
+    ["call id", (candidate) => { candidate.items[0].callId = {}; }],
+    ["response id", (candidate) => { candidate.items[0].responseId = []; }],
+    ["task ids", (candidate) => { candidate.items[0].taskIds = ["task-1", 42]; }],
+    ["adapter metadata", (candidate) => { candidate.adapterMetadata = { raw: "secret" }; }],
+  ];
+
+  for (const [label, mutate] of cases) {
+    const candidate = structuredClone(sampleSnapshot(`rev-${label}`)) as any;
+    mutate(candidate);
+    assert.deepEqual(
+      await saveLatestClaudeSnapshot(stateDir, SESSION, candidate),
+      { saved: false, reason: "invalid_snapshot" },
+      label,
+    );
+  }
+  assert.equal(await readLatestClaudeSnapshot(stateDir, SESSION), undefined);
+});
+
+test("invalid persisted snapshot structures fail open", async () => {
+  const stateDir = await tempStateDir();
+  await saveLatestClaudeSnapshot(stateDir, SESSION, sampleSnapshot("rev-structure"));
+  const directory = await hashedSessionDirectory(stateDir);
+  const path = join(directory, "latest-snapshot.json");
+  const baseline = JSON.parse(await readFile(path, "utf8")) as Record<string, any>;
+  const cases: Array<[string, (candidate: Record<string, any>) => void]> = [
+    ["wrong schema", (candidate) => { candidate.schemaVersion = 999; }],
+    ["invalid timestamp", (candidate) => { candidate.storedAt = "not-a-date"; }],
+    ["wrong host", (candidate) => { candidate.snapshot.hostId = "codex"; }],
+    ["wrong session", (candidate) => { candidate.snapshot.sessionId = "other-session"; }],
+    ["duplicate stable id", (candidate) => {
+      candidate.snapshot.items[1].stableId = candidate.snapshot.items[0].stableId;
+    }],
+    ["adapter metadata", (candidate) => { candidate.snapshot.adapterMetadata = { raw: "secret" }; }],
+    ["blank model", (candidate) => { candidate.model = " "; }],
+  ];
+
+  for (const [label, mutate] of cases) {
+    const candidate = structuredClone(baseline);
+    mutate(candidate);
+    await writeFile(path, JSON.stringify(candidate), "utf8");
+    assert.equal(await readLatestClaudeSnapshotRecord(stateDir, SESSION), undefined, label);
+  }
+});
+
+test("fingerprint sidecar must match the complete stored snapshot", async () => {
+  const stateDir = await tempStateDir();
+  const snapshot = sampleSnapshot("rev-fingerprints");
+  await saveLatestClaudeSnapshot(stateDir, SESSION, snapshot);
+  const directory = await hashedSessionDirectory(stateDir);
+  const path = join(directory, "item-fingerprints.json");
+  const baseline = JSON.parse(await readFile(path, "utf8")) as Record<string, any>;
+  const firstId = snapshot.items[0]!.stableId;
+  const cases: Array<[string, (candidate: Record<string, any>) => void]> = [
+    ["schema", (candidate) => { candidate.schemaVersion = 999; }],
+    ["timestamp", (candidate) => { candidate.storedAt = "not-a-date"; }],
+    ["revision", (candidate) => { candidate.revision = "different"; }],
+    ["missing item", (candidate) => { delete candidate.fingerprints[firstId]; }],
+    ["extra item", (candidate) => { candidate.fingerprints.extra = "digest"; }],
+    ["wrong digest", (candidate) => { candidate.fingerprints[firstId] = "different"; }],
+    ["invalid digest", (candidate) => { candidate.fingerprints[firstId] = 42; }],
+  ];
+
+  for (const [label, mutate] of cases) {
+    const candidate = structuredClone(baseline);
+    mutate(candidate);
+    await writeFile(path, JSON.stringify(candidate), "utf8");
+    assert.deepEqual(await readClaudeItemFingerprints(stateDir, SESSION), {}, label);
+  }
+});
+
+test("snapshot write failures return an explicit fail-open result", async () => {
+  const root = await tempStateDir();
+  const stateDir = join(root, "not-a-directory");
+  await writeFile(stateDir, "occupied", "utf8");
+  assert.deepEqual(
+    await saveLatestClaudeSnapshot(stateDir, SESSION, sampleSnapshot("rev-write-fail")),
+    { saved: false, reason: "write_failed" },
+  );
+  assert.equal(await readLatestClaudeSnapshot(stateDir, SESSION), undefined);
+});
+
 test("corrupted snapshot file is treated as absent (fail-open)", async () => {
   const stateDir = await tempStateDir();
-  await mkdir(join(stateDir, "claude-context", "sessions", SESSION), { recursive: true });
+  await saveLatestClaudeSnapshot(stateDir, SESSION, sampleSnapshot("rev-before-corruption"));
+  const directory = await hashedSessionDirectory(stateDir);
   await writeFile(
-    join(stateDir, "claude-context", "sessions", SESSION, "latest-snapshot.json"),
+    join(directory, "latest-snapshot.json"),
     "{ not json",
     "utf8",
   );
   assert.equal(await readLatestClaudeSnapshot(stateDir, SESSION), undefined);
   // and a save after corruption still works
-  await saveLatestClaudeSnapshot(stateDir, SESSION, sampleSnapshot("rev-ok"));
+  assert.deepEqual(
+    await saveLatestClaudeSnapshot(stateDir, SESSION, sampleSnapshot("rev-ok")),
+    { saved: true },
+  );
   assert.equal((await readLatestClaudeSnapshot(stateDir, SESSION))!.revision, "rev-ok");
 });

--- a/components/adapters/claude-code/tests/gateway-runtime.test.ts
+++ b/components/adapters/claude-code/tests/gateway-runtime.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { createServer } from "node:net";
@@ -16,6 +17,7 @@ import { normalizeTokenPilotClaudeCodeConfig } from "../src/config.js";
 import { startClaudeCodeGatewayRuntime } from "../src/gateway-runtime.js";
 import { createConsoleLogger } from "../src/logger.js";
 import { upsertClaudeCodeSessionSnapshot } from "../src/session-state.js";
+import { readLatestClaudeSnapshotRecord } from "../src/context-rewrite/snapshot-store.js";
 
 async function reserveUnusedPort(): Promise<number> {
   return await new Promise((resolve, reject) => {
@@ -146,6 +148,182 @@ test("gateway runtime serves health and forwards Claude Messages requests", asyn
     assert.equal(payload.id, "msg_test_1");
     assert.equal((seenPayloads as Record<string, unknown>[]).length, 1);
     assert.equal(((seenPayloads[0] as Record<string, unknown>).model), "claude-sonnet-4-6");
+    const cleanerSnapshot = await readLatestClaudeSnapshotRecord(
+      join(dir, "state"),
+      "sess-runtime-1",
+    );
+    assert.equal(cleanerSnapshot?.model, "claude-sonnet-4-6");
+    assert.equal(cleanerSnapshot?.snapshot.items.length, 1);
+    assert.equal(cleanerSnapshot?.snapshot.items[0]?.chars, "hello".length);
+  } finally {
+    await runtime.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("gateway snapshot persistence is fail-open and logs only reported failures", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightrsi-claude-gateway-snapshot-result-"));
+  const proxyPort = await reserveUnusedPort();
+  const warnings: string[] = [];
+  let saveCount = 0;
+  const runtime = await startClaudeCodeGatewayRuntime({
+    config: normalizeTokenPilotClaudeCodeConfig({
+      stateDir: join(dir, "state"),
+      proxyPort,
+      modules: { stabilizer: false, reduction: false, eviction: false },
+    }),
+    logger: {
+      debug() {},
+      info() {},
+      warn(message) { warnings.push(message); },
+      error() {},
+    },
+    forwarder: {
+      async request() {
+        return {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          text: JSON.stringify({
+            id: "msg_snapshot_result",
+            type: "message",
+            role: "assistant",
+            content: [],
+            stop_reason: "end_turn",
+          }),
+        };
+      },
+      async requestStream() { throw new Error("stream not used"); },
+    },
+    dependencies: {
+      async saveSnapshot() {
+        saveCount += 1;
+        return saveCount === 1
+          ? { saved: true as const }
+          : { saved: false as const, reason: "write_failed" as const };
+      },
+    },
+  });
+
+  async function send(label: string): Promise<void> {
+    const response = await fetch(`${runtime.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-session-id": "sess-snapshot-result" },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        stream: false,
+        messages: [{ role: "user", content: [{ type: "text", text: label }] }],
+        max_tokens: 32,
+      }),
+    });
+    assert.equal(response.status, 200);
+    await response.text();
+  }
+
+  try {
+    await send("first");
+    await send("second");
+    assert.equal(saveCount, 2);
+    assert.deepEqual(
+      warnings.filter((message) => message.includes("snapshot persistence failed")),
+      ["context cleaner snapshot persistence failed (ignored): write_failed"],
+    );
+  } finally {
+    await runtime.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("gateway publishes only block-proven task attribution from the persisted registry", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightrsi-claude-gateway-snapshot-tasks-"));
+  const stateDir = join(dir, "state");
+  const sessionId = "sess-snapshot-tasks";
+  const proxyPort = await reserveUnusedPort();
+  const seeded = await loadSessionTaskRegistry(stateDir, sessionId);
+  seeded.version = 1;
+  seeded.tasks["task-proven"] = {
+    taskId: "task-proven",
+    title: "proven task",
+    objective: "read the file",
+    lifecycle: "completed",
+    completionEvidence: ["done"],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${sessionId}:t1`,
+      lastTurnAbsId: `${sessionId}:t1`,
+      supportingTurnAbsIds: [`${sessionId}:t1`],
+      lastEstimatorTurnAbsId: `${sessionId}:t1`,
+    },
+  };
+  seeded.completedTaskIds = ["task-proven"];
+  seeded.blockToTaskIds = {
+    "anthropic-tool-result:toolu_proven": ["task-proven"],
+  };
+  seeded.taskToBlockIds = {
+    "task-proven": ["anthropic-tool-result:toolu_proven"],
+  };
+  await persistSessionTaskRegistry(stateDir, seeded, { expectedVersion: 0 });
+
+  const runtime = await startClaudeCodeGatewayRuntime({
+    config: normalizeTokenPilotClaudeCodeConfig({
+      stateDir,
+      proxyPort,
+      modules: { stabilizer: false, reduction: false, eviction: false },
+    }),
+    logger: createConsoleLogger(false),
+    forwarder: {
+      async request() {
+        return {
+          status: 200,
+          headers: { "content-type": "application/json" },
+          text: JSON.stringify({
+            id: "msg_snapshot_tasks",
+            type: "message",
+            role: "assistant",
+            content: [],
+            stop_reason: "end_turn",
+          }),
+        };
+      },
+      async requestStream() { throw new Error("stream not used"); },
+    },
+  });
+  const messages = [
+    { role: "user", content: [{ type: "text", text: "read" }] },
+    {
+      role: "assistant",
+      content: [{ type: "tool_use", id: "toolu_proven", name: "Read", input: {} }],
+    },
+    {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: "toolu_proven", content: "body" }],
+    },
+    { role: "assistant", content: [{ type: "text", text: "done" }] },
+    { role: "user", content: [{ type: "text", text: "current" }] },
+  ];
+
+  try {
+    const response = await fetch(`${runtime.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-session-id": sessionId },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        stream: false,
+        messages,
+        max_tokens: 32,
+      }),
+    });
+    assert.equal(response.status, 200);
+    await response.text();
+
+    const snapshot = await readLatestClaudeSnapshotRecord(stateDir, sessionId);
+    const toolPair = snapshot?.snapshot.items.filter(
+      (item) => item.callId === "toolu_proven",
+    ) ?? [];
+    assert.equal(toolPair.length, 2);
+    assert.ok(toolPair.every((item) => (
+      JSON.stringify(item.taskIds) === JSON.stringify(["task-proven"])
+    )));
+    assert.equal(snapshot?.snapshot.items.at(-1)?.taskIds, undefined);
   } finally {
     await runtime.close();
     await rm(dir, { recursive: true, force: true });
@@ -1203,6 +1381,28 @@ test("gateway eviction preserves tool closure and the active user turn", async (
     forwarder,
   });
 
+  const originalMessages = [
+    { role: "user", content: [{ type: "text", text: "read the file" }] },
+    {
+      role: "assistant",
+      content: [{
+        type: "tool_use",
+        id: "toolu_eviction_1",
+        name: "Read",
+        input: { file_path: "/repo/large.txt" },
+      }],
+    },
+    {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "toolu_eviction_1",
+        content: "EVICT_ME_" + "x".repeat(5000),
+      }],
+    },
+    { role: "assistant", content: [{ type: "text", text: "previous task complete" }] },
+    { role: "user", content: [{ type: "text", text: "KEEP_ME_current_user_turn" }] },
+  ];
   try {
     const response = await fetch(`${runtime.baseUrl}/v1/messages`, {
       method: "POST",
@@ -1213,28 +1413,7 @@ test("gateway eviction preserves tool closure and the active user turn", async (
       body: JSON.stringify({
         model: "claude-sonnet-4-6",
         stream: false,
-        messages: [
-          { role: "user", content: [{ type: "text", text: "read the file" }] },
-          {
-            role: "assistant",
-            content: [{
-              type: "tool_use",
-              id: "toolu_eviction_1",
-              name: "Read",
-              input: { file_path: "/repo/large.txt" },
-            }],
-          },
-          {
-            role: "user",
-            content: [{
-              type: "tool_result",
-              tool_use_id: "toolu_eviction_1",
-              content: "EVICT_ME_" + "x".repeat(5000),
-            }],
-          },
-          { role: "assistant", content: [{ type: "text", text: "previous task complete" }] },
-          { role: "user", content: [{ type: "text", text: "KEEP_ME_current_user_turn" }] },
-        ],
+        messages: originalMessages,
         max_tokens: 256,
       }),
     });
@@ -1260,6 +1439,21 @@ test("gateway eviction preserves tool closure and the active user turn", async (
     assert.equal(beforeCall?.evictionApplied, true);
     assert.equal(beforeCall?.evictionChangedToolResults, 1);
     assert.ok(Number(beforeCall?.evictionSavedChars) > 0);
+
+    const cleanerSnapshot = await readLatestClaudeSnapshotRecord(
+      join(dir, "state"),
+      "sess-eviction-1",
+    );
+    const originalRevision = createHash("sha256")
+      .update(JSON.stringify(originalMessages))
+      .digest("hex")
+      .slice(0, 32);
+    assert.equal(cleanerSnapshot?.snapshot.revision, originalRevision);
+    assert.equal(cleanerSnapshot?.snapshot.items.length, 5);
+    assert.equal(
+      cleanerSnapshot?.snapshot.items.find((item) => item.kind === "tool_result")?.chars,
+      ("EVICT_ME_" + "x".repeat(5000)).length,
+    );
   } finally {
     await runtime.close();
     await rm(dir, { recursive: true, force: true });
@@ -1617,6 +1811,21 @@ test("lifecycle estimator rewrites the real Claude upstream payload", async () =
     const beforeCall = trace.filter((entry) => entry.stage === "gateway_before_call").at(-1);
     assert.equal(beforeCall?.evictionPlanSource, "lifecycle");
     assert.equal(beforeCall?.evictionApplied, true);
+
+    const cleanerSnapshot = await readLatestClaudeSnapshotRecord(
+      join(dir, "state"),
+      "sess-lifecycle-e2e",
+    );
+    const attributedPair = cleanerSnapshot?.snapshot.items.filter(
+      (item) => item.callId === "toolu_lifecycle_e2e",
+    ) ?? [];
+    assert.equal(attributedPair.length, 2);
+    // turnToTaskIds alone is not enough proof for Cleaner item ownership.
+    assert.ok(attributedPair.every((item) => item.taskIds === undefined));
+    assert.equal(
+      cleanerSnapshot?.snapshot.items.at(-1)?.taskIds,
+      undefined,
+    );
   } finally {
     await runtime.close();
     await rm(dir, { recursive: true, force: true });
@@ -1646,7 +1855,7 @@ test("lifecycle registry persistence failure bypasses the plan and heuristic fal
       return {
         baseVersion: registry.version,
         taskUpdates: [{
-          taskId: "task-cas-e2e",
+          taskId: estimateCount > 1 ? "task-cas-uncommitted" : "task-cas-e2e",
           lifecycle: estimateCount > 1 ? "evictable" : "completed",
           objective: "finish the file task",
           completionEvidence: ["done"],
@@ -1708,6 +1917,14 @@ test("lifecycle registry persistence failure bypasses the plan and heuristic fal
     assert.equal(beforeCall?.evictionApplied, false);
     const registry = await loadSessionTaskRegistry(join(dir, "state"), "sess-cas-e2e");
     assert.equal(registry.tasks["task-cas-e2e"]?.lifecycle, "completed");
+    assert.equal(registry.tasks["task-cas-uncommitted"], undefined);
+    const cleanerSnapshot = await readLatestClaudeSnapshotRecord(
+      join(dir, "state"),
+      "sess-cas-e2e",
+    );
+    assert.ok(cleanerSnapshot?.snapshot.items.every(
+      (item) => !item.taskIds?.includes("task-cas-uncommitted"),
+    ));
   } finally {
     await runtime.close();
     await rm(dir, { recursive: true, force: true });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@lightrsi/artifact-store':
         specifier: workspace:*
         version: link:../../packages/foundation/artifact-store
+      '@lightrsi/cleaner':
+        specifier: workspace:*
+        version: link:../../packages/features/cleaner
       '@lightrsi/eviction':
         specifier: workspace:*
         version: link:../../packages/features/eviction


### PR DESCRIPTION
## Summary

- Add the Claude Code Context Cleaner Host bridge and session catalog.
- Persist canonical snapshots from complete pre-rewrite inbound messages.
- Attribute task ownership only from committed registry block evidence.
- Preserve identical ownership for paired tool calls and tool results.
- Forward approved clean requests, receipt reads, and cancellation to the shared control plane.

## Safety and contract boundaries

- Use stable hashed session directories and atomic snapshot writes.
- Validate snapshot schema, host ID, session ID, revision, stable IDs, fingerprints, chars, kinds, and optional fields.
- Keep legacy safe snapshot directories read-only.
- Treat missing or corrupt persisted snapshots as fail-open for model requests.
- Reject Cleaner reads when no canonical snapshot exists.
- Never persist or return raw Anthropic messages or `adapterMetadata`.
- Return `chars_only` because no exact Anthropic tokenizer is available.
- Freeze approvals to the exact task IDs, item IDs, and item digests supplied by the user.
- Validate Host, plan, session, approval scope, receipt accounting, and applied evidence at runtime.
- Do not persist Cleaner plans or receipts inside the adapter.
- Do not modify the Codex or OpenClaw implementations.

## Testing

- `pnpm --dir components/adapters/claude-code typecheck`
- Claude Cleaner/Snapshot/Gateway focused tests: 45/45 passed
- Shared Cleaner tests: 24/24 passed
- `pnpm check:boundaries`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

The complete Windows adapter suite still contains existing platform-specific failures involving WSL, symlinks, user-directory permissions, and Windows path assertions. Cleaner-focused tests are green; Linux CI remains authoritative for the full adapter suite.