### PR TITLE
feat(cleaner): add task token accounting

### DIFF
--- a/components/packages/features/cleaner/package.json
+++ b/components/packages/features/cleaner/package.json
@@ -12,6 +12,7 @@
     "test": "node --import tsx --test tests/*.test.ts"
   },
   "dependencies": {
+    "@lightrsi/history": "workspace:*",
     "@lightrsi/host-adapter": "workspace:*"
   }
 }

--- a/components/packages/features/cleaner/src/index.ts
+++ b/components/packages/features/cleaner/src/index.ts
@@ -18,3 +18,22 @@ export {
   recoverContextCleanState,
   transitionContextCleanState,
 } from "./clean-state-coordinator.js";
+export {
+  attributeItems,
+  mapTaskLifecycle,
+} from "./task-attribution.js";
+export type {
+  AttributedItem,
+  ContextCleanItemBucket,
+  TaskAttributionInput,
+} from "./task-attribution.js";
+export {
+  aggregateTaskAccounting,
+  buildContextCleanBreakdown,
+  buildItemTokenCounts,
+} from "./token-accounting.js";
+export type {
+  ContextCleanBreakdown,
+  ItemTokenCounts,
+  TokenAccountingBreakdown,
+} from "./token-accounting.js";

--- a/components/packages/features/cleaner/src/task-attribution.ts
+++ b/components/packages/features/cleaner/src/task-attribution.ts
@@ -1,0 +1,160 @@
+import type {
+  ContextItemRef,
+  ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+import type {
+  SessionTaskRegistry,
+  TaskLifecycle,
+} from "@lightrsi/history";
+import type { ContextCleanLifecycleState } from "./contracts.js";
+
+/**
+ * Attribution inputs. Snapshot items may already carry taskIds (host bridges
+ * populate them when the registry proves the mapping); when they do not, the
+ * caller supplies host-specific join tables so the feature layer never needs
+ * adapter-internal turn logic. Both tables are optional; items that resolve to
+ * nothing become unassigned (or protected for system/developer content).
+ */
+export type TaskAttributionInput = {
+  snapshot: ModelContextSnapshot;
+  /** Shared session task registry; missing/empty registry degrades to unassigned. */
+  registry?: SessionTaskRegistry;
+  /** Host-provided stable item id -> task ids, used when snapshot items lack taskIds. */
+  taskIdsByStableId?: Record<string, string[]>;
+  /** Host-provided tool call id -> turn id, joined through registry.turnToTaskIds. */
+  callIdToTurnAbsId?: ReadonlyMap<string, string>;
+};
+
+export type ContextCleanItemBucket = "task" | "protected" | "unassigned";
+
+export type AttributedItem = {
+  stableId: string;
+  /** Resolved task ids after tool-pair union; empty means nothing could be attributed. */
+  taskIds: string[];
+  bucket: ContextCleanItemBucket;
+  /** Present when bucket === "protected". */
+  protectedReason?: "shared" | "system_developer";
+};
+
+const SYSTEM_DEVELOPER_KINDS = new Set(["system", "developer"]);
+
+function isSystemOrDeveloper(item: ContextItemRef): boolean {
+  return SYSTEM_DEVELOPER_KINDS.has(item.kind)
+    || item.role === "system"
+    || item.role === "developer";
+}
+
+function dedupeNonBlank(taskIds: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of taskIds) {
+    const trimmed = id.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function resolveItemTaskIds(item: ContextItemRef, input: TaskAttributionInput): string[] {
+  if (item.taskIds && item.taskIds.length > 0) return item.taskIds;
+  const injected = input.taskIdsByStableId?.[item.stableId];
+  if (injected && injected.length > 0) return injected;
+  if (item.callId && input.callIdToTurnAbsId?.has(item.callId)) {
+    const turnAbsId = input.callIdToTurnAbsId.get(item.callId) as string;
+    const fromTurn = input.registry?.turnToTaskIds[turnAbsId];
+    if (fromTurn && fromTurn.length > 0) return fromTurn;
+  }
+  return [];
+}
+
+/**
+ * Tool call/result pairs must stay in the same task. Items sharing a callId get
+ * the union of their resolved task ids, so a pair split across tasks becomes a
+ * shared item and lands in the protected bucket instead of being split. Items
+ * whose ids were unresolved inherit the pair's task ids (the pair belongs
+ * together); a fully unresolved pair stays unresolved.
+ */
+function pairByCallId(
+  resolved: Map<string, { callId?: string; taskIds: string[] }>,
+): void {
+  const unionByCallId = new Map<string, string[]>();
+  for (const info of resolved.values()) {
+    if (info.callId) {
+      unionByCallId.set(info.callId, dedupeNonBlank([
+        ...(unionByCallId.get(info.callId) ?? []),
+        ...info.taskIds,
+      ]));
+    }
+  }
+  for (const info of resolved.values()) {
+    if (info.callId) info.taskIds = unionByCallId.get(info.callId) as string[];
+  }
+}
+
+/**
+ * Resolves every snapshot item to a single accounting bucket:
+ *
+ * - task: exactly one task id after tool-pair union.
+ * - protected: system/developer content, or items shared by multiple tasks
+ *   (including pairs split across tasks). Only content NOT attributed to a
+ *   single task may land here, so task + protected + unassigned never
+ *   double-count an item.
+ * - unassigned: nothing could be attributed and the item is not protected.
+ */
+export function attributeItems(input: TaskAttributionInput): AttributedItem[] {
+  const resolved = new Map<string, { callId?: string; taskIds: string[] }>();
+  for (const item of input.snapshot.items) {
+    resolved.set(item.stableId, {
+      callId: item.callId,
+      taskIds: dedupeNonBlank(resolveItemTaskIds(item, input)),
+    });
+  }
+  pairByCallId(resolved);
+
+  const attributed: AttributedItem[] = [];
+  for (const item of input.snapshot.items) {
+    const info = resolved.get(item.stableId) as { callId?: string; taskIds: string[] };
+    let bucket: ContextCleanItemBucket;
+    let protectedReason: AttributedItem["protectedReason"];
+    if (info.taskIds.length === 0) {
+      if (isSystemOrDeveloper(item)) {
+        bucket = "protected";
+        protectedReason = "system_developer";
+      } else {
+        bucket = "unassigned";
+      }
+    } else if (info.taskIds.length > 1) {
+      bucket = "protected";
+      protectedReason = "shared";
+    } else {
+      bucket = "task";
+    }
+    attributed.push({
+      stableId: item.stableId,
+      taskIds: info.taskIds,
+      bucket,
+      ...(protectedReason ? { protectedReason } : {}),
+    });
+  }
+  return attributed;
+}
+
+/**
+ * Maps the shared history lifecycle vocabulary onto the clean contract's.
+ * Unresolved questions win over the lifecycle so a completed task with open
+ * questions stays protected by later selection rules.
+ */
+export function mapTaskLifecycle(
+  lifecycle: TaskLifecycle,
+  unresolvedQuestions: string[],
+): ContextCleanLifecycleState {
+  if (unresolvedQuestions.length > 0) return "unresolved";
+  switch (lifecycle) {
+    case "active": return "active";
+    case "blocked": return "unresolved";
+    case "completed": return "completed";
+    case "evictable": return "completed";
+    default: return "unknown";
+  }
+}

--- a/components/packages/features/cleaner/src/token-accounting.ts
+++ b/components/packages/features/cleaner/src/token-accounting.ts
@@ -1,0 +1,270 @@
+import {
+  countTextWithPreciseTokens,
+  type ContextItemRef,
+} from "@lightrsi/host-adapter";
+import type {
+  ContextCleanTaskBreakdown,
+  ContextCleanTokenCountMode,
+} from "./contracts.js";
+import {
+  attributeItems,
+  mapTaskLifecycle,
+  type AttributedItem,
+  type TaskAttributionInput,
+} from "./task-attribution.js";
+
+export const CHARS_PER_TOKEN_ESTIMATE = 4;
+
+export const TOKEN_COUNT_METHOD_EXACT = "openai_tokenizer";
+export const TOKEN_COUNT_METHOD_ESTIMATED = "chars_estimate";
+export const TOKEN_COUNT_METHOD_CHARS_ONLY = "utf16_chars";
+
+export type ItemTokenCounts = {
+  /** null for every item in chars_only mode; non-null otherwise. */
+  tokensByStableId: Record<string, number | null>;
+  charsByStableId: Record<string, number>;
+  tokenCountMode: ContextCleanTokenCountMode;
+  tokenCountMethod: string;
+};
+
+function isNonNegativeFinite(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * Per-item token counts with an explicit degradation chain:
+ *
+ * 1. itemTokenCounts — precomputed by the host bridge (e.g. Codex counts each
+ *    serialized item with the model tokenizer) are authoritative.
+ * 2. itemTextByStableId + model — exact tiktoken count when the model is
+ *    known; otherwise an estimated chars/4 count (never passes raw char
+ *    counts off as provider tokens).
+ * 3. Neither — chars_only: token counts stay null and only chars conserve.
+ *
+ * Mode is the worst observed: any null -> chars_only, any estimate ->
+ * estimated, all exact -> exact.
+ */
+export function buildItemTokenCounts(input: {
+  items: ContextItemRef[];
+  model?: string;
+  itemTextByStableId?: Record<string, string>;
+  itemTokenCounts?: Record<string, number>;
+}): ItemTokenCounts {
+  if (input.items.length === 0) {
+    return { tokensByStableId: {}, charsByStableId: {}, tokenCountMode: "chars_only",
+      tokenCountMethod: TOKEN_COUNT_METHOD_CHARS_ONLY };
+  }
+  const tokensByStableId: Record<string, number | null> = {};
+  const charsByStableId: Record<string, number> = {};
+  let allExact = true;
+  for (const item of input.items) {
+    charsByStableId[item.stableId] = item.chars;
+    const precomputed = input.itemTokenCounts?.[item.stableId];
+    if (isNonNegativeFinite(precomputed)) {
+      tokensByStableId[item.stableId] = precomputed;
+      continue;
+    }
+    const text = input.itemTextByStableId?.[item.stableId];
+    if (typeof text === "string") {
+      const counted = countTextWithPreciseTokens(input.model ?? "", text);
+      tokensByStableId[item.stableId] = counted.mode === "openai_tokens"
+        ? counted.count
+        : Math.round(counted.count / CHARS_PER_TOKEN_ESTIMATE);
+      if (counted.mode !== "openai_tokens") allExact = false;
+      continue;
+    }
+    tokensByStableId[item.stableId] = null;
+  }
+  const anyNull = Object.values(tokensByStableId).some((tokens) => tokens === null);
+  const tokenCountMode: ContextCleanTokenCountMode = anyNull
+    ? "chars_only"
+    : allExact ? "exact" : "estimated";
+  const tokenCountMethod = tokenCountMode === "exact"
+    ? TOKEN_COUNT_METHOD_EXACT
+    : tokenCountMode === "estimated" ? TOKEN_COUNT_METHOD_ESTIMATED : TOKEN_COUNT_METHOD_CHARS_ONLY;
+  return { tokensByStableId, charsByStableId, tokenCountMode, tokenCountMethod };
+}
+
+export type TokenAccountingBreakdown = {
+  /** null in chars_only mode; otherwise sums over the items of each task. */
+  tokensByTaskId: Record<string, number | null>;
+  charsByTaskId: Record<string, number>;
+  protectedTokens: number | null;
+  protectedChars: number;
+  unassignedTokens: number | null;
+  unassignedChars: number;
+  usedTokens: number | null;
+  usedChars: number;
+  tokenCountMode: ContextCleanTokenCountMode;
+  tokenCountMethod: string;
+};
+
+/**
+ * Sums every item into exactly one accounting bucket. Each item is attributed
+ * to exactly one of {task, protected, unassigned} (shared items only ever
+ * count in protected), so conservation holds in both units:
+ *
+ *   task tokens + protected + unassigned === usedTokens
+ *   task chars + protected + unassigned === usedChars
+ *
+ * Token sums are null in chars_only mode because no item carries a token count.
+ */
+export function aggregateTaskAccounting(
+  attributed: AttributedItem[],
+  counts: ItemTokenCounts,
+): TokenAccountingBreakdown {
+  const tokensByTaskId: Record<string, number> = {};
+  const charsByTaskId: Record<string, number> = {};
+  let protectedTokens = 0;
+  let protectedChars = 0;
+  let unassignedTokens = 0;
+  let unassignedChars = 0;
+  for (const item of attributed) {
+    const tokens = counts.tokensByStableId[item.stableId] ?? 0;
+    const chars = counts.charsByStableId[item.stableId] ?? 0;
+    if (item.bucket === "task") {
+      for (const taskId of item.taskIds) {
+        tokensByTaskId[taskId] = (tokensByTaskId[taskId] ?? 0) + tokens;
+        charsByTaskId[taskId] = (charsByTaskId[taskId] ?? 0) + chars;
+      }
+    } else if (item.bucket === "protected") {
+      protectedTokens += tokens;
+      protectedChars += chars;
+    } else {
+      unassignedTokens += tokens;
+      unassignedChars += chars;
+    }
+  }
+  let usedTokens = 0;
+  let usedChars = 0;
+  for (const item of attributed) {
+    usedTokens += counts.tokensByStableId[item.stableId] ?? 0;
+    usedChars += counts.charsByStableId[item.stableId] ?? 0;
+  }
+  const nullable = (value: number): number | null =>
+    counts.tokenCountMode === "chars_only" ? null : value;
+  return {
+    tokensByTaskId: Object.fromEntries(
+      Object.entries(tokensByTaskId).map(([taskId, value]) => [taskId, nullable(value)]),
+    ),
+    charsByTaskId,
+    protectedTokens: nullable(protectedTokens),
+    protectedChars,
+    unassignedTokens: nullable(unassignedTokens),
+    unassignedChars,
+    usedTokens: nullable(usedTokens),
+    usedChars,
+    tokenCountMode: counts.tokenCountMode,
+    tokenCountMethod: counts.tokenCountMethod,
+  };
+}
+
+function roundTo2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function tokenPercentOf(
+  tokens: number | null,
+  usedTokens: number | null,
+  mode: ContextCleanTokenCountMode,
+): number | null {
+  if (mode === "chars_only" || tokens === null || usedTokens === null || usedTokens <= 0) {
+    return null;
+  }
+  return roundTo2((tokens / usedTokens) * 100);
+}
+
+export type ContextCleanBreakdown = {
+  tasks: ContextCleanTaskBreakdown[];
+  usedTokens: number | null;
+  usedChars: number;
+  protectedTokens: number | null;
+  protectedChars: number;
+  unassignedTokens: number | null;
+  unassignedChars: number;
+  tokenCountMode: ContextCleanTokenCountMode;
+  tokenCountMethod: string;
+};
+
+/**
+ * Combined 7.2 pipeline: attribution -> counting -> accounting -> task
+ * breakdown. Produces everything a ContextCleanPlan needs except identity
+ * (planId/hostId/sessionId/baseRevision/createdAt), which the orchestrator
+ * supplies. label/description/summary fall back to registry fields or
+ * deterministic placeholders; the recommendation analyzer (7.3) replaces
+ * description/summary/recommendation later.
+ *
+ * selectable is deterministic: registry.evictableTaskIds membership, hardened
+ * so active/unresolved tasks can never be offered for cleaning even if the
+ * registry claims otherwise.
+ */
+export function buildContextCleanBreakdown(input: TaskAttributionInput & {
+  model?: string;
+  itemTextByStableId?: Record<string, string>;
+  itemTokenCounts?: Record<string, number>;
+}): ContextCleanBreakdown {
+  const attributed = attributeItems(input);
+  const counts = buildItemTokenCounts({
+    items: input.snapshot.items,
+    model: input.model,
+    itemTextByStableId: input.itemTextByStableId,
+    itemTokenCounts: input.itemTokenCounts,
+  });
+  const accounting = aggregateTaskAccounting(attributed, counts);
+
+  const fingerprintByStableId = new Map(
+    input.snapshot.items.map((item) => [item.stableId, item.fingerprint]),
+  );
+  const taskOrder = [...new Set(
+    attributed.filter((item) => item.bucket === "task")
+      .map((item) => item.taskIds[0]),
+  )];
+
+  const tasks: ContextCleanTaskBreakdown[] = [];
+  for (const taskId of taskOrder) {
+    const itemIds = attributed
+      .filter((item) => item.bucket === "task" && item.taskIds[0] === taskId)
+      .map((item) => item.stableId);
+    const state = input.registry?.tasks[taskId];
+    const lifecycleState = state
+      ? mapTaskLifecycle(state.lifecycle, state.unresolvedQuestions)
+      : "unknown";
+    const selectable = (input.registry?.evictableTaskIds.includes(taskId) ?? false)
+      && lifecycleState !== "active"
+      && lifecycleState !== "unresolved";
+    tasks.push({
+      taskId,
+      label: state?.title ?? taskId,
+      description: state?.objective ?? `${taskId} task (${lifecycleState})`,
+      summary: state?.objective ?? `${taskId} task (${lifecycleState})`,
+      lifecycleState,
+      itemIds,
+      itemDigests: Object.fromEntries(
+        itemIds.map((id) => [id, fingerprintByStableId.get(id) ?? ""]),
+      ),
+      tokenCount: accounting.tokensByTaskId[taskId] ?? null,
+      charCount: accounting.charsByTaskId[taskId] ?? 0,
+      tokenPercent: tokenPercentOf(
+        accounting.tokensByTaskId[taskId] ?? null,
+        accounting.usedTokens,
+        accounting.tokenCountMode,
+      ),
+      // Deterministic safe default until the 7.3 recommendation analyzer runs.
+      recommendation: "keep",
+      reasonCodes: [],
+      selectable,
+    });
+  }
+
+  return {
+    tasks,
+    usedTokens: accounting.usedTokens,
+    usedChars: accounting.usedChars,
+    protectedTokens: accounting.protectedTokens,
+    protectedChars: accounting.protectedChars,
+    unassignedTokens: accounting.unassignedTokens,
+    unassignedChars: accounting.unassignedChars,
+    tokenCountMode: accounting.tokenCountMode,
+    tokenCountMethod: accounting.tokenCountMethod,
+  };
+}

--- a/components/packages/features/cleaner/tests/task-attribution.test.ts
+++ b/components/packages/features/cleaner/tests/task-attribution.test.ts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applySessionTaskRegistryPatch,
+  createEmptySessionTaskRegistry,
+  type SessionTaskRegistry,
+} from "@lightrsi/history";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextItemRef,
+  type ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+
+import {
+  attributeItems,
+  mapTaskLifecycle,
+  type TaskAttributionInput,
+} from "../src/task-attribution.js";
+
+function item(
+  stableId: string,
+  overrides: Partial<ContextItemRef> = {},
+): ContextItemRef {
+  return {
+    stableId,
+    kind: "user",
+    fingerprint: `digest-${stableId}`,
+    chars: 100,
+    ...overrides,
+  };
+}
+
+function snapshot(items: ContextItemRef[]): ModelContextSnapshot {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    hostId: "codex",
+    sessionId: "session-1",
+    revision: "rev-1",
+    items,
+  };
+}
+
+function span(first: string, last: string) {
+  return { firstTurnAbsId: first, lastTurnAbsId: last, supportingTurnAbsIds: [],
+    lastEstimatorTurnAbsId: last };
+}
+
+function sampleRegistry(): SessionTaskRegistry {
+  return applySessionTaskRegistryPatch(createEmptySessionTaskRegistry("session-1"), {
+    upsertTasks: {
+      "task-a": {
+        taskId: "task-a", title: "finished task", objective: "finished task objective",
+        lifecycle: "completed", completionEvidence: ["evidence-a"], unresolvedQuestions: [],
+        span: span("t1", "t2"),
+      },
+      "task-current": {
+        taskId: "task-current", title: "current task", objective: "current task objective",
+        lifecycle: "active", completionEvidence: [], unresolvedQuestions: [],
+        span: span("t3", "t4"),
+      },
+    },
+    activeTaskIds: ["task-current"],
+    evictableTaskIds: ["task-a"],
+    upsertTurnToTaskIds: { "turn-5": ["task-a"] },
+  });
+}
+
+function attribute(input: TaskAttributionInput) {
+  return attributeItems(input);
+}
+
+test("snapshot taskIds attribute items to tasks and unresolvable items fall to unassigned", () => {
+  const attributed = attribute({
+    snapshot: snapshot([
+      item("item-a", { taskIds: ["task-a"] }),
+      item("item-orphan"),
+    ]),
+    registry: sampleRegistry(),
+  });
+  assert.deepEqual(attributed, [
+    { stableId: "item-a", taskIds: ["task-a"], bucket: "task" },
+    { stableId: "item-orphan", taskIds: [], bucket: "unassigned" },
+  ]);
+});
+
+test("system and developer items without task ids are protected", () => {
+  const attributed = attribute({
+    snapshot: snapshot([
+      item("item-sys", { kind: "system" }),
+      item("item-dev", { kind: "developer" }),
+      item("item-unknown", { kind: "unknown" }),
+    ]),
+  });
+  assert.deepEqual(attributed.map((entry) => entry.bucket), [
+    "protected", "protected", "unassigned",
+  ]);
+  assert.equal(attributed[0]?.protectedReason, "system_developer");
+  assert.equal(attributed[1]?.protectedReason, "system_developer");
+  assert.equal("protectedReason" in (attributed[2] ?? {}), false);
+});
+
+test("items shared by multiple tasks are protected once and never double-counted", () => {
+  const attributed = attribute({
+    snapshot: snapshot([
+      item("item-shared", { taskIds: ["task-a", "task-current"] }),
+    ]),
+    registry: sampleRegistry(),
+  });
+  assert.equal(attributed[0]?.bucket, "protected");
+  assert.equal(attributed[0]?.protectedReason, "shared");
+  assert.deepEqual(attributed[0]?.taskIds, ["task-a", "task-current"]);
+});
+
+test("tool call/result pairs share one task and split pairs become protected", () => {
+  const sameTask = attribute({
+    snapshot: snapshot([
+      item("call-1", { kind: "tool_call", callId: "call-1", taskIds: ["task-a"] }),
+      item("result-1", { kind: "tool_result", callId: "call-1", taskIds: ["task-a"] }),
+    ]),
+    registry: sampleRegistry(),
+  });
+  assert.deepEqual(sameTask.map((entry) => entry.bucket), ["task", "task"]);
+  assert.deepEqual(sameTask[1]?.taskIds, ["task-a"]);
+
+  const split = attribute({
+    snapshot: snapshot([
+      item("call-2", { kind: "tool_call", callId: "call-2", taskIds: ["task-a"] }),
+      item("result-2", { kind: "tool_result", callId: "call-2", taskIds: ["task-current"] }),
+    ]),
+    registry: sampleRegistry(),
+  });
+  assert.deepEqual(split.map((entry) => entry.bucket), ["protected", "protected"]);
+  assert.deepEqual(split[0]?.taskIds, ["task-a", "task-current"]);
+
+  const unresolvedInherits = attribute({
+    snapshot: snapshot([
+      item("call-3", { kind: "tool_call", callId: "call-3", taskIds: ["task-a"] }),
+      item("result-3", { kind: "tool_result", callId: "call-3" }),
+    ]),
+    registry: sampleRegistry(),
+  });
+  assert.deepEqual(unresolvedInherits.map((entry) => entry.bucket), ["task", "task"]);
+  assert.deepEqual(unresolvedInherits[1]?.taskIds, ["task-a"]);
+});
+
+test("taskIdsByStableId fallback attributes items whose snapshot lacks taskIds", () => {
+  const attributed = attribute({
+    snapshot: snapshot([item("item-a"), item("item-b")]),
+    registry: sampleRegistry(),
+    taskIdsByStableId: { "item-a": ["task-a"] },
+  });
+  assert.equal(attributed[0]?.bucket, "task");
+  assert.deepEqual(attributed[0]?.taskIds, ["task-a"]);
+  assert.equal(attributed[1]?.bucket, "unassigned");
+});
+
+test("callIdToTurnAbsId joins through registry.turnToTaskIds", () => {
+  const attributed = attribute({
+    snapshot: snapshot([
+      item("call-4", { kind: "tool_call", callId: "call-4" }),
+    ]),
+    registry: sampleRegistry(),
+    callIdToTurnAbsId: new Map([["call-4", "turn-5"]]),
+  });
+  assert.deepEqual(attributed[0]?.taskIds, ["task-a"]);
+  assert.equal(attributed[0]?.bucket, "task");
+});
+
+test("duplicate task ids are deduplicated and blank ids dropped", () => {
+  const attributed = attribute({
+    snapshot: snapshot([
+      item("item-a", { taskIds: ["task-a", "task-a", "  "], callId: "pair" }),
+      item("item-b", { taskIds: [], callId: "pair" }),
+    ]),
+    registry: sampleRegistry(),
+  });
+  assert.deepEqual(attributed[0]?.taskIds, ["task-a"]);
+  assert.deepEqual(attributed[1]?.taskIds, ["task-a"]);
+});
+
+test("mapTaskLifecycle maps history lifecycle onto the clean contract", () => {
+  assert.equal(mapTaskLifecycle("active", []), "active");
+  assert.equal(mapTaskLifecycle("blocked", []), "unresolved");
+  assert.equal(mapTaskLifecycle("completed", []), "completed");
+  assert.equal(mapTaskLifecycle("evictable", []), "completed");
+  assert.equal(mapTaskLifecycle("completed", ["open question"]), "unresolved");
+});
+
+test("missing registry degrades gracefully without throwing", () => {
+  const attributed = attribute({
+    snapshot: snapshot([
+      item("item-a", { taskIds: ["task-a"] }),
+      item("item-orphan"),
+      item("item-sys", { kind: "system" }),
+    ]),
+  });
+  assert.deepEqual(attributed.map((entry) => entry.bucket), ["task", "unassigned", "protected"]);
+});

--- a/components/packages/features/cleaner/tests/token-accounting.test.ts
+++ b/components/packages/features/cleaner/tests/token-accounting.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applySessionTaskRegistryPatch,
+  createEmptySessionTaskRegistry,
+  type SessionTaskRegistry,
+} from "@lightrsi/history";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextItemRef,
+  type ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  parseContextCleanPlan,
+  type ContextCleanPlan,
+} from "../src/index.js";
+import { attributeItems } from "../src/task-attribution.js";
+import {
+  TOKEN_COUNT_METHOD_CHARS_ONLY,
+  TOKEN_COUNT_METHOD_ESTIMATED,
+  TOKEN_COUNT_METHOD_EXACT,
+  aggregateTaskAccounting,
+  buildContextCleanBreakdown,
+  buildItemTokenCounts,
+} from "../src/token-accounting.js";
+
+function item(
+  stableId: string,
+  overrides: Partial<ContextItemRef> = {},
+): ContextItemRef {
+  return {
+    stableId,
+    kind: "user",
+    fingerprint: `digest-${stableId}`,
+    chars: 100,
+    ...overrides,
+  };
+}
+
+function snapshot(items: ContextItemRef[]): ModelContextSnapshot {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    hostId: "codex",
+    sessionId: "session-1",
+    revision: "rev-1",
+    items,
+  };
+}
+
+function span(first: string, last: string) {
+  return { firstTurnAbsId: first, lastTurnAbsId: last, supportingTurnAbsIds: [],
+    lastEstimatorTurnAbsId: last };
+}
+
+function sampleRegistry(): SessionTaskRegistry {
+  return applySessionTaskRegistryPatch(createEmptySessionTaskRegistry("session-1"), {
+    upsertTasks: {
+      "task-a": {
+        taskId: "task-a", title: "finished task", objective: "finished task objective",
+        lifecycle: "completed", completionEvidence: ["evidence-a"], unresolvedQuestions: [],
+        span: span("t1", "t2"),
+      },
+      "task-current": {
+        taskId: "task-current", title: "current task", objective: "current task objective",
+        lifecycle: "active", completionEvidence: [], unresolvedQuestions: [],
+        span: span("t3", "t4"),
+      },
+    },
+    activeTaskIds: ["task-current"],
+    evictableTaskIds: ["task-a"],
+  });
+}
+
+test("precomputed item counts produce exact mode", () => {
+  const counts = buildItemTokenCounts({
+    items: [item("item-a", { chars: 120 }), item("item-b", { chars: 80 })],
+    model: "gpt-5.4",
+    itemTokenCounts: { "item-a": 30, "item-b": 20 },
+  });
+  assert.deepEqual(counts.tokensByStableId, { "item-a": 30, "item-b": 20 });
+  assert.deepEqual(counts.charsByStableId, { "item-a": 120, "item-b": 80 });
+  assert.equal(counts.tokenCountMode, "exact");
+  assert.equal(counts.tokenCountMethod, TOKEN_COUNT_METHOD_EXACT);
+});
+
+test("known model counts text exactly with the model tokenizer", () => {
+  const counts = buildItemTokenCounts({
+    items: [item("item-a")],
+    model: "gpt-5.4",
+    itemTextByStableId: { "item-a": "hello world" },
+  });
+  assert.equal(counts.tokenCountMode, "exact");
+  assert.equal(typeof counts.tokensByStableId["item-a"], "number");
+  assert.ok((counts.tokensByStableId["item-a"] as number) >= 0);
+});
+
+test("unknown model degrades to estimated chars/4 and never fakes provider tokens", () => {
+  const counts = buildItemTokenCounts({
+    items: [item("item-a")],
+    model: "unknown-model",
+    itemTextByStableId: { "item-a": "a".repeat(121) },
+  });
+  assert.equal(counts.tokenCountMode, "estimated");
+  assert.equal(counts.tokenCountMethod, TOKEN_COUNT_METHOD_ESTIMATED);
+  assert.equal(counts.tokensByStableId["item-a"], Math.round(121 / 4));
+});
+
+test("no text and no precomputed counts yields chars_only with null tokens", () => {
+  const counts = buildItemTokenCounts({
+    items: [item("item-a"), item("item-b")],
+    model: "gpt-5.4",
+  });
+  assert.equal(counts.tokenCountMode, "chars_only");
+  assert.equal(counts.tokenCountMethod, TOKEN_COUNT_METHOD_CHARS_ONLY);
+  assert.deepEqual(counts.tokensByStableId, { "item-a": null, "item-b": null });
+});
+
+test("mixed precomputed and estimated counts keep the whole plan estimated", () => {
+  const counts = buildItemTokenCounts({
+    items: [item("item-a"), item("item-b")],
+    model: "unknown-model",
+    itemTokenCounts: { "item-a": 30 },
+    itemTextByStableId: { "item-b": "b".repeat(40) },
+  });
+  assert.equal(counts.tokenCountMode, "estimated");
+  assert.equal(counts.tokensByStableId["item-a"], 30);
+  assert.equal(counts.tokensByStableId["item-b"], 10);
+});
+
+test("conservation holds in both tokens and chars with shared items counted once", () => {
+  const input = {
+    snapshot: snapshot([
+      item("item-a1", { taskIds: ["task-a"], chars: 120 }),
+      item("item-a2", { taskIds: ["task-a"], chars: 80 }),
+      item("item-current", { taskIds: ["task-current"], chars: 40 }),
+      item("item-sys", { kind: "system", chars: 20 }),
+      item("item-shared", { taskIds: ["task-a", "task-current"], chars: 30 }),
+      item("item-orphan", { chars: 10 }),
+    ]),
+    registry: sampleRegistry(),
+    itemTokenCounts: {
+      "item-a1": 30, "item-a2": 20, "item-current": 10,
+      "item-sys": 5, "item-shared": 7, "item-orphan": 3,
+    },
+  };
+  const accounting = aggregateTaskAccounting(
+    attributeItems(input),
+    buildItemTokenCounts({ items: input.snapshot.items, itemTokenCounts: input.itemTokenCounts }),
+  );
+  assert.equal(accounting.tokensByTaskId["task-a"], 50);
+  assert.equal(accounting.tokensByTaskId["task-current"], 10);
+  assert.equal(accounting.protectedTokens, 12); // system 5 + shared 7, no double count
+  assert.equal(accounting.unassignedTokens, 3);
+  assert.equal(accounting.usedTokens, 75);
+  assert.equal(accounting.tokensByTaskId["task-a"]! + accounting.tokensByTaskId["task-current"]!
+    + accounting.protectedTokens! + accounting.unassignedTokens!, accounting.usedTokens!);
+
+  assert.equal(accounting.charsByTaskId["task-a"], 200);
+  assert.equal(accounting.charsByTaskId["task-current"], 40);
+  assert.equal(accounting.protectedChars, 50);
+  assert.equal(accounting.unassignedChars, 10);
+  assert.equal(accounting.usedChars, 300);
+  assert.equal(accounting.charsByTaskId["task-a"] + accounting.charsByTaskId["task-current"]
+    + accounting.protectedChars + accounting.unassignedChars, accounting.usedChars);
+});
+
+test("chars_only accounting nulls every token sum but conserves chars", () => {
+  const input = {
+    snapshot: snapshot([
+      item("item-a", { taskIds: ["task-a"], chars: 120 }),
+      item("item-orphan", { chars: 10 }),
+    ]),
+    registry: sampleRegistry(),
+  };
+  const accounting = aggregateTaskAccounting(
+    attributeItems(input),
+    buildItemTokenCounts({ items: input.snapshot.items }),
+  );
+  assert.equal(accounting.usedTokens, null);
+  assert.equal(accounting.tokensByTaskId["task-a"], null);
+  assert.equal(accounting.protectedTokens, null);
+  assert.equal(accounting.usedChars, 130);
+  assert.equal(accounting.charsByTaskId["task-a"] + accounting.protectedChars
+    + accounting.unassignedChars, accounting.usedChars);
+});
+
+test("breakdown computes percents and hardens selectable against active tasks", () => {
+  const registry = applySessionTaskRegistryPatch(sampleRegistry(), {
+    evictableTaskIds: ["task-a", "task-current"], // registry claims current is evictable
+  });
+  const breakdown = buildContextCleanBreakdown({
+    snapshot: snapshot([
+      item("item-a1", { taskIds: ["task-a"], chars: 120 }),
+      item("item-a2", { taskIds: ["task-a"], chars: 80 }),
+      item("item-current", { taskIds: ["task-current"], chars: 40 }),
+    ]),
+    registry,
+    itemTokenCounts: { "item-a1": 30, "item-a2": 20, "item-current": 10 },
+  });
+  assert.equal(breakdown.tasks.length, 2);
+  const taskA = breakdown.tasks.find((task) => task.taskId === "task-a");
+  const current = breakdown.tasks.find((task) => task.taskId === "task-current");
+  assert.equal(taskA?.tokenCount, 50);
+  assert.equal(taskA?.tokenPercent, 83.33); // 50 / 60 total
+  assert.equal(taskA?.selectable, true);
+  assert.equal(current?.selectable, false); // active task never selectable
+  assert.equal(current?.lifecycleState, "active");
+  assert.deepEqual(taskA?.itemIds, ["item-a1", "item-a2"]);
+  assert.deepEqual(taskA?.itemDigests, { "item-a1": "digest-item-a1", "item-a2": "digest-item-a2" });
+  assert.equal(breakdown.usedTokens, 60);
+  assert.equal(breakdown.tokenCountMode, "exact");
+});
+
+test("chars_only breakdown keeps token fields null and percents null", () => {
+  const breakdown = buildContextCleanBreakdown({
+    snapshot: snapshot([
+      item("item-a", { taskIds: ["task-a"], chars: 120 }),
+    ]),
+    registry: sampleRegistry(),
+  });
+  assert.equal(breakdown.tokenCountMode, "chars_only");
+  assert.equal(breakdown.usedTokens, null);
+  assert.equal(breakdown.usedChars, 120);
+  assert.equal(breakdown.tasks[0]?.tokenCount, null);
+  assert.equal(breakdown.tasks[0]?.tokenPercent, null);
+});
+
+test("breakdown output round-trips through the canonical plan parser", () => {
+  const breakdown = buildContextCleanBreakdown({
+    snapshot: snapshot([
+      item("item-a1", { taskIds: ["task-a"], chars: 120 }),
+      item("item-current", { taskIds: ["task-current"], chars: 40 }),
+    ]),
+    registry: sampleRegistry(),
+    itemTokenCounts: { "item-a1": 30, "item-current": 10 },
+  });
+  const plan: ContextCleanPlan = {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: "clean-plan-7",
+    hostId: "codex",
+    sessionId: "session-1",
+    baseRevision: "rev-1",
+    model: "gpt-5.4",
+    usedTokens: breakdown.usedTokens,
+    usedChars: breakdown.usedChars,
+    protectedTokens: breakdown.protectedTokens,
+    protectedChars: breakdown.protectedChars,
+    unassignedTokens: breakdown.unassignedTokens,
+    unassignedChars: breakdown.unassignedChars,
+    tokenCountMode: breakdown.tokenCountMode,
+    tokenCountMethod: breakdown.tokenCountMethod,
+    tasks: breakdown.tasks,
+    createdAt: "2026-08-20T00:00:00.000Z",
+  };
+  const parsed = parseContextCleanPlan(plan);
+  assert.ok(parsed);
+  assert.equal(parsed.tasks.length, 2);
+  assert.deepEqual(parsed.tasks[0]?.itemDigests, { "item-a1": "digest-item-a1" });
+  assert.equal(parsed.tasks[0]?.selectable, true);
+  assert.equal(parsed.tasks[1]?.selectable, false);
+  assert.equal(parsed.usedTokens, 40);
+});
+
+test("empty snapshot produces an empty chars_only breakdown without division by zero", () => {
+  const breakdown = buildContextCleanBreakdown({
+    snapshot: snapshot([]),
+    registry: sampleRegistry(),
+  });
+  assert.deepEqual(breakdown.tasks, []);
+  assert.equal(breakdown.usedChars, 0);
+  assert.equal(breakdown.usedTokens, null);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
 
   components/packages/features/cleaner:
     dependencies:
+      '@lightrsi/history':
+        specifier: workspace:*
+        version: link:../../foundation/history
       '@lightrsi/host-adapter':
         specifier: workspace:*
         version: link:../../foundation/host-adapter


### PR DESCRIPTION
## Summary

- attribute snapshot items to tasks from item taskIds, bridge-provided join tables, and registry turn mapping
- pair tool call/result items by callId so split pairs defer into the protected bucket instead of being split
- add token accounting with exact (tiktoken), estimated (chars/4), and chars-only degradation
- enforce conservation in both units: task + protected + unassigned = used (tokens and chars)
- count shared items exactly once in the protected bucket, never in task buckets
- expose buildContextCleanBreakdown so later plan assembly round-trips through the canonical plan parser
- harden selectable against active and unresolved tasks even when the registry claims they are evictable
- add @lightrsi/history workspace dependency (lockfile +3 lines)

## Validation

- Cleaner tests: 44/44 passed (17 new attribution/accounting tests, no regressions)
- Cleaner typecheck passed
- Codex adapter typecheck passed
- Package boundary check passed (18 packages, 66 edges)
- `git diff --check` passed

## Scope

This PR only completes section 7.2, Task Attribution and Token Accounting. It does not include the
recommendation analyzer (7.3), CLI/TUI (7.4), OpenClaw apply, or Host adapter integration. The shared
contract (contracts.ts) is unchanged; the cleaner package only gains new modules, exports, and one
dependency.