### PR TITLE
feat(cleaner): add host execution bridge

### DIFF
--- a/components/packages/features/cleaner/src/contracts.ts
+++ b/components/packages/features/cleaner/src/contracts.ts
@@ -1,4 +1,5 @@
 import type {
+  ContextMutationPlan,
   ModelContextRewriteMode,
   ModelContextSnapshot,
 } from "@lightrsi/host-adapter";
@@ -135,6 +136,13 @@ export type ContextCleanPendingReceipt = ContextCleanReceiptBase & {
   fallbackUsed: false;
 };
 
+export type ContextCleanScheduledReceipt = Omit<
+  ContextCleanPendingReceipt,
+  "status"
+> & {
+  status: "scheduled";
+};
+
 export type ContextCleanAppliedReceipt = ContextCleanReceiptBase & {
   status: "applied";
   appliedSavedTokens: number | null;
@@ -218,6 +226,62 @@ export type ExecuteApprovedContextCleanParams = {
   selectedTasks: ApprovedContextCleanTask[];
 };
 
+/**
+ * The only user-approved values accepted at a Host request boundary. Exact
+ * item ids and digests are recovered from the immutable stored plan rather
+ * than accepted again from a caller.
+ */
+export type ContextCleanExecutionRequest = {
+  cleanPlanId: string;
+  sessionId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+};
+
+/** Canonical, Host-neutral state used to validate a scheduled clean. */
+export type ContextCleanExecutionSnapshot = {
+  snapshot: ModelContextSnapshot;
+  activeTaskIds: readonly string[];
+  evictableTaskIds: readonly string[];
+};
+
+export type ContextCleanPreparedExecution = {
+  cleanPlanId: string;
+  hostId: string;
+  sessionId: string;
+  baseRevision: string;
+  selectedTasks: ApprovedContextCleanTask[];
+  mutationPlan: ContextMutationPlan;
+  scheduledReceipt: ContextCleanScheduledReceipt;
+};
+
+export type ContextCleanExecutionPrepareResult =
+  | {
+      outcome: "ready";
+      execution: ContextCleanPreparedExecution;
+      bypassed: false;
+      reasons: [];
+    }
+  | {
+      /** A terminal receipt is replayed without preparing another mutation. */
+      outcome: "terminal";
+      receipt: ContextCleanReceipt;
+      bypassed: false;
+      reasons: [];
+    }
+  | {
+      outcome: "missing";
+      bypassed: false;
+      reasons: string[];
+    }
+  | {
+      /** The original Host request must be preserved for this outcome. */
+      outcome: "bypassed";
+      receipt?: ContextCleanReceipt;
+      bypassed: true;
+      reasons: string[];
+    };
+
 export function isAppliedContextCleanReceipt(
   receipt: ContextCleanReceipt,
 ): receipt is ContextCleanAppliedReceipt {
@@ -244,3 +308,17 @@ export type ContextCleanerControlPlane = Pick<
   ContextCleanerHostBridge,
   "executeApprovedClean" | "readCleanReceipt" | "cancelCleanPlan"
 >;
+
+/**
+ * Shared scheduled-plan consumer used inside a Host's existing request lock.
+ * Host-specific request payloads and actual rewrite commits stay in adapters.
+ */
+export interface ContextCleanerHostExecutionBridge {
+  readonly hostId: string;
+  prepareScheduledClean(
+    params: ContextCleanExecutionRequest,
+  ): Promise<ContextCleanExecutionPrepareResult>;
+  recordCleanReceipt(
+    receipt: ContextCleanReceipt,
+  ): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>>;
+}

--- a/components/packages/features/cleaner/src/host-execution-bridge.ts
+++ b/components/packages/features/cleaner/src/host-execution-bridge.ts
@@ -1,0 +1,413 @@
+import { createHash } from "node:crypto";
+
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  revalidateContextMutationPlan,
+  validateContextMutationProtocolClosure,
+  type ContextMutationOperation,
+  type ContextMutationPlan,
+} from "@lightrsi/host-adapter";
+import {
+  isTerminalContextCleanStatus,
+  type ApprovedContextCleanTask,
+  type ContextCleanExecutionPrepareResult,
+  type ContextCleanExecutionRequest,
+  type ContextCleanExecutionSnapshot,
+  type ContextCleanPlanRecord,
+  type ContextCleanReceipt,
+  type ContextCleanScheduledReceipt,
+  type ContextCleanStoreWriteResult,
+  type ContextCleanerHostExecutionBridge,
+} from "./contracts.js";
+import { readContextCleanPlan } from "./clean-plan-store.js";
+import { readContextCleanReceipt } from "./clean-receipt-store.js";
+import {
+  recoverContextCleanState,
+  transitionContextCleanState,
+} from "./clean-state-coordinator.js";
+import { sameCanonicalValue } from "./clean-store-support.js";
+
+const EXECUTION_ID_VERSION = 1 as const;
+const CONTEXT_ITEM_KINDS = new Set([
+  "system",
+  "developer",
+  "user",
+  "assistant",
+  "reasoning",
+  "tool_call",
+  "tool_result",
+  "compaction",
+  "unknown",
+]);
+
+export type CreateContextCleanerHostExecutionBridgeParams = {
+  stateDir: string;
+  hostId: string;
+  /** Reads the canonical snapshot and lifecycle state inside the Host request lock. */
+  readExecutionSnapshot(
+    sessionId: string,
+  ): Promise<ContextCleanExecutionSnapshot>;
+};
+
+function bypassed(
+  reasons: string[],
+  receipt?: ContextCleanReceipt,
+): ContextCleanExecutionPrepareResult {
+  return {
+    outcome: "bypassed",
+    bypassed: true,
+    reasons,
+    ...(receipt ? { receipt } : {}),
+  };
+}
+
+function uniqueNonBlankStringArray(value: unknown): value is string[] {
+  return Array.isArray(value)
+    && value.every((item) => typeof item === "string" && item.trim().length > 0)
+    && new Set(value).size === value.length;
+}
+
+function uniqueNonBlankStrings(value: unknown): value is string[] {
+  return uniqueNonBlankStringArray(value) && value.length > 0;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
+}
+
+function isScheduledReceipt(
+  receipt: ContextCleanReceipt,
+): receipt is ContextCleanScheduledReceipt {
+  return receipt.status === "scheduled";
+}
+
+function digestId(prefix: string, value: unknown): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify(value))
+    .digest("hex");
+  return `${prefix}-v${EXECUTION_ID_VERSION}-${digest}`;
+}
+
+function validExecutionSnapshot(value: ContextCleanExecutionSnapshot): boolean {
+  const { snapshot } = value;
+  if (snapshot.schemaVersion !== MODEL_CONTEXT_REWRITE_SCHEMA_VERSION
+    || !snapshot.hostId.trim()
+    || !snapshot.sessionId.trim()
+    || !snapshot.revision.trim()
+    || Object.hasOwn(snapshot, "adapterMetadata")
+    || !uniqueNonBlankStringArray([...value.activeTaskIds])
+    || !uniqueNonBlankStringArray([...value.evictableTaskIds])) return false;
+  const activeTaskIds = new Set(value.activeTaskIds);
+  if (value.evictableTaskIds.some((taskId) => activeTaskIds.has(taskId))) return false;
+
+  const stableIds = new Set<string>();
+  for (const item of snapshot.items) {
+    if (!item || !item.stableId.trim()
+      || stableIds.has(item.stableId)
+      || !CONTEXT_ITEM_KINDS.has(item.kind)
+      || !item.fingerprint.trim()
+      || !Number.isSafeInteger(item.chars)
+      || item.chars < 0
+      || (item.taskIds !== undefined
+        && !uniqueNonBlankStringArray(item.taskIds))) return false;
+    stableIds.add(item.stableId);
+  }
+  return true;
+}
+
+function selectedTasksFromPlan(
+  record: ContextCleanPlanRecord,
+  selectedTaskIds: readonly string[],
+): ApprovedContextCleanTask[] | undefined {
+  const selectedSet = new Set(selectedTaskIds);
+  const selectedTasks = record.plan.tasks
+    .filter((task) => selectedSet.has(task.taskId));
+  if (selectedTasks.length !== selectedTaskIds.length
+    || selectedTasks.some((task) => !task.selectable || task.itemIds.length === 0)) {
+    return undefined;
+  }
+
+  const claimedItemIds = new Set<string>();
+  const result: ApprovedContextCleanTask[] = [];
+  for (const task of selectedTasks) {
+    if (task.itemIds.some((itemId) => claimedItemIds.has(itemId))) return undefined;
+    for (const itemId of task.itemIds) claimedItemIds.add(itemId);
+    result.push({
+      taskId: task.taskId,
+      itemIds: [...task.itemIds],
+      itemDigests: Object.fromEntries(
+        task.itemIds.map((itemId) => [itemId, task.itemDigests[itemId]!]),
+      ),
+    });
+  }
+  return result;
+}
+
+function buildMutationPlan(params: {
+  record: ContextCleanPlanRecord;
+  selectedTasks: ApprovedContextCleanTask[];
+}): ContextMutationPlan {
+  const tasksById = new Map(
+    params.record.plan.tasks.map((task) => [task.taskId, task]),
+  );
+  const operations: ContextMutationOperation[] = params.selectedTasks.map((task) => {
+    const planTask = tasksById.get(task.taskId)!;
+    const targetItemFingerprints = Object.fromEntries(
+      task.itemIds.map((itemId) => [itemId, task.itemDigests[itemId]!]),
+    );
+    return {
+      id: digestId("ctxcleanop", {
+        cleanPlanId: params.record.plan.planId,
+        taskId: task.taskId,
+        targetItemIds: task.itemIds,
+        targetItemFingerprints,
+      }),
+      type: "remove",
+      targetItemIds: [...task.itemIds],
+      targetItemFingerprints,
+      taskIds: [task.taskId],
+      rationale: "user_approved_context_clean",
+      estimatedSavedChars: planTask.charCount,
+    };
+  });
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    planId: digestId("ctxcleanplan", {
+      cleanPlanId: params.record.plan.planId,
+      operationIds: operations.map((operation) => operation.id),
+    }),
+    hostId: params.record.plan.hostId,
+    sessionId: params.record.plan.sessionId,
+    baseRevision: params.record.plan.baseRevision,
+    sourceModuleId: "cleaner_manual",
+    operations,
+    createdAt: params.record.plan.createdAt,
+  };
+}
+
+async function readStoredExecutionState(params: {
+  stateDir: string;
+  planId: string;
+}): Promise<{
+  record?: ContextCleanPlanRecord;
+  receipt?: ContextCleanReceipt;
+  reasons: string[];
+}> {
+  const recovery = await recoverContextCleanState(params);
+  if (recovery.bypassed) {
+    return { reasons: ["clean_execution_recovery_failed", ...recovery.reasons] };
+  }
+  const [planRead, receiptRead] = await Promise.all([
+    readContextCleanPlan(params),
+    readContextCleanReceipt(params),
+  ]);
+  if (planRead.bypassed) {
+    return { reasons: ["clean_execution_plan_unavailable", ...planRead.reasons] };
+  }
+  if (receiptRead.bypassed) {
+    return { reasons: ["clean_execution_receipt_unavailable", ...receiptRead.reasons] };
+  }
+  return { record: planRead.value, receipt: receiptRead.value, reasons: [] };
+}
+
+function validateStoredIdentity(params: {
+  bridgeHostId: string;
+  request: ContextCleanExecutionRequest;
+  record: ContextCleanPlanRecord;
+  receipt: ContextCleanReceipt;
+}): string[] {
+  const { request, record, receipt } = params;
+  if (record.plan.hostId !== params.bridgeHostId
+    || receipt.hostId !== params.bridgeHostId) return ["clean_execution_host_mismatch"];
+  if (record.plan.sessionId !== request.sessionId
+    || receipt.sessionId !== request.sessionId) return ["clean_execution_session_mismatch"];
+  if (record.plan.baseRevision !== request.baseRevision) {
+    return ["clean_execution_base_revision_mismatch"];
+  }
+  if (record.status !== receipt.status) return ["clean_execution_state_conflict"];
+  if (!sameStringSet(receipt.selectedTaskIds, request.selectedTaskIds)) {
+    return ["clean_execution_selection_mismatch"];
+  }
+  return [];
+}
+
+async function prepareScheduledClean(params: {
+  config: CreateContextCleanerHostExecutionBridgeParams;
+  request: ContextCleanExecutionRequest;
+}): Promise<ContextCleanExecutionPrepareResult> {
+  const { request, config } = params;
+  if (!request.cleanPlanId.trim()
+    || !request.sessionId.trim()
+    || !request.baseRevision.trim()
+    || !uniqueNonBlankStrings(request.selectedTaskIds)) {
+    return bypassed(["clean_execution_request_invalid"]);
+  }
+
+  const stored = await readStoredExecutionState({
+    stateDir: config.stateDir,
+    planId: request.cleanPlanId,
+  });
+  if (stored.reasons.length > 0) return bypassed(stored.reasons);
+  if (!stored.record) {
+    return {
+      outcome: "missing",
+      bypassed: false,
+      reasons: ["clean_execution_missing"],
+    };
+  }
+  if (!stored.receipt) return bypassed(["clean_execution_receipt_missing"]);
+
+  const identityReasons = validateStoredIdentity({
+    bridgeHostId: config.hostId,
+    request,
+    record: stored.record,
+    receipt: stored.receipt,
+  });
+  if (identityReasons.length > 0) return bypassed(identityReasons, stored.receipt);
+  if (isTerminalContextCleanStatus(stored.receipt.status)) {
+    return {
+      outcome: "terminal",
+      receipt: stored.receipt,
+      bypassed: false,
+      reasons: [],
+    };
+  }
+  if (!isScheduledReceipt(stored.receipt)) {
+    return bypassed(["clean_execution_not_scheduled"], stored.receipt);
+  }
+
+  const selectedTasks = selectedTasksFromPlan(stored.record, request.selectedTaskIds);
+  if (!selectedTasks) {
+    return bypassed(["clean_execution_plan_selection_invalid"], stored.receipt);
+  }
+
+  let current: ContextCleanExecutionSnapshot;
+  try {
+    current = await config.readExecutionSnapshot(request.sessionId);
+  } catch {
+    return bypassed(["clean_execution_snapshot_unavailable"], stored.receipt);
+  }
+  let snapshotValid = false;
+  try {
+    snapshotValid = validExecutionSnapshot(current);
+  } catch {
+    // Treat malformed Host callback data like any other unavailable snapshot.
+  }
+  if (!snapshotValid) {
+    return bypassed(["clean_execution_snapshot_invalid"], stored.receipt);
+  }
+  if (current.snapshot.hostId !== config.hostId
+    || current.snapshot.sessionId !== request.sessionId) {
+    return bypassed(["clean_execution_snapshot_identity_mismatch"], stored.receipt);
+  }
+  if (current.snapshot.revision !== request.baseRevision) {
+    return bypassed(["clean_execution_revision_stale"], stored.receipt);
+  }
+
+  const activeTaskIds = new Set(current.activeTaskIds);
+  const evictableTaskIds = new Set(current.evictableTaskIds);
+  if (selectedTasks.some((task) => activeTaskIds.has(task.taskId)
+    || !evictableTaskIds.has(task.taskId))) {
+    return bypassed(["clean_execution_task_not_evictable"], stored.receipt);
+  }
+  const currentItems = new Map(
+    current.snapshot.items.map((item) => [item.stableId, item]),
+  );
+  for (const task of selectedTasks) {
+    for (const itemId of task.itemIds) {
+      const item = currentItems.get(itemId);
+      if (!item || item.fingerprint !== task.itemDigests[itemId]) {
+        return bypassed(["clean_execution_item_stale"], stored.receipt);
+      }
+      if (!item.taskIds?.includes(task.taskId)) {
+        return bypassed(["clean_execution_task_attribution_stale"], stored.receipt);
+      }
+    }
+  }
+
+  const mutationPlan = buildMutationPlan({ record: stored.record, selectedTasks });
+  const revalidation = revalidateContextMutationPlan({
+    snapshot: current.snapshot,
+    plan: mutationPlan,
+  });
+  if (!revalidation.valid
+    || revalidation.deferredOperationIds.length > 0
+    || revalidation.applicableOperationIds.length !== mutationPlan.operations.length) {
+    return bypassed(["clean_execution_revalidation_failed"], stored.receipt);
+  }
+  const closure = validateContextMutationProtocolClosure({
+    snapshot: current.snapshot,
+    plan: mutationPlan,
+    activeTaskIds: current.activeTaskIds,
+    evictableTaskIds: current.evictableTaskIds,
+    candidateOperationIds: revalidation.applicableOperationIds,
+  });
+  if (!closure.valid
+    || closure.deferredOperationIds.length > 0
+    || closure.applicableOperationIds.length !== mutationPlan.operations.length) {
+    return bypassed(["clean_execution_protocol_closure_failed"], stored.receipt);
+  }
+
+  const rechecked = await readStoredExecutionState({
+    stateDir: config.stateDir,
+    planId: request.cleanPlanId,
+  });
+  if (rechecked.reasons.length > 0) return bypassed(rechecked.reasons);
+  if (!rechecked.record || !rechecked.receipt) {
+    return bypassed(["clean_execution_state_changed"]);
+  }
+  if (isTerminalContextCleanStatus(rechecked.receipt.status)) {
+    return {
+      outcome: "terminal",
+      receipt: rechecked.receipt,
+      bypassed: false,
+      reasons: [],
+    };
+  }
+  if (!sameCanonicalValue(stored.record, rechecked.record)
+    || !sameCanonicalValue(stored.receipt, rechecked.receipt)) {
+    return bypassed(["clean_execution_state_changed"], rechecked.receipt);
+  }
+
+  return {
+    outcome: "ready",
+    execution: {
+      cleanPlanId: stored.record.plan.planId,
+      hostId: stored.record.plan.hostId,
+      sessionId: stored.record.plan.sessionId,
+      baseRevision: stored.record.plan.baseRevision,
+      selectedTasks,
+      mutationPlan,
+      scheduledReceipt: stored.receipt,
+    },
+    bypassed: false,
+    reasons: [],
+  };
+}
+
+export function createContextCleanerHostExecutionBridge(
+  params: CreateContextCleanerHostExecutionBridgeParams,
+): ContextCleanerHostExecutionBridge {
+  if (!params.stateDir.trim()) throw new TypeError("clean execution stateDir must not be empty");
+  if (!params.hostId.trim()) throw new TypeError("clean execution hostId must not be empty");
+  return {
+    hostId: params.hostId,
+    async prepareScheduledClean(request) {
+      return prepareScheduledClean({ config: params, request });
+    },
+    async recordCleanReceipt(
+      receipt: ContextCleanReceipt,
+    ): Promise<ContextCleanStoreWriteResult<ContextCleanPlanRecord>> {
+      if (receipt.hostId !== params.hostId) {
+        return {
+          outcome: "bypassed",
+          bypassed: true,
+          reasons: ["clean_execution_receipt_host_mismatch"],
+        };
+      }
+      return transitionContextCleanState({ stateDir: params.stateDir, receipt });
+    },
+  };
+}

--- a/components/packages/features/cleaner/src/index.ts
+++ b/components/packages/features/cleaner/src/index.ts
@@ -18,3 +18,7 @@ export {
   recoverContextCleanState,
   transitionContextCleanState,
 } from "./clean-state-coordinator.js";
+export {
+  createContextCleanerHostExecutionBridge,
+  type CreateContextCleanerHostExecutionBridgeParams,
+} from "./host-execution-bridge.js";

--- a/components/packages/features/cleaner/tests/contracts.test.ts
+++ b/components/packages/features/cleaner/tests/contracts.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   CONTEXT_CLEAN_SCHEMA_VERSION,
+  type ContextCleanExecutionRequest,
+  type ContextCleanerHostExecutionBridge,
   type ContextCleanerHostBridge,
   type ContextCleanPendingReceipt,
   type ContextCleanReceipt,
@@ -219,3 +221,37 @@ const appliedWithFallback: ContextCleanReceipt = {
   },
 };
 void appliedWithFallback;
+
+const executionRequest: ContextCleanExecutionRequest = {
+  cleanPlanId: "clean-plan-1",
+  sessionId: "session-1",
+  baseRevision: "rev-1",
+  selectedTaskIds: ["task-a"],
+};
+void executionRequest;
+
+const fakeExecutionBridge: ContextCleanerHostExecutionBridge = {
+  hostId: "fake-host",
+  async prepareScheduledClean() {
+    return {
+      outcome: "missing",
+      bypassed: false,
+      reasons: ["clean_execution_missing"],
+    };
+  },
+  async recordCleanReceipt() {
+    return {
+      outcome: "missing",
+      bypassed: true,
+      reasons: ["clean_execution_missing"],
+    };
+  },
+};
+void fakeExecutionBridge;
+
+const executionRequestWithCallerSelectedItems: ContextCleanExecutionRequest = {
+  ...executionRequest,
+  // @ts-expect-error Runtime callers cannot replace the item scope frozen in the stored plan.
+  itemIds: ["item-a"],
+};
+void executionRequestWithCallerSelectedItems;

--- a/components/packages/features/cleaner/tests/host-execution-bridge.test.ts
+++ b/components/packages/features/cleaner/tests/host-execution-bridge.test.ts
@@ -1,0 +1,486 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
+import {
+  CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+  contextCleanReceiptFilePath,
+  contextCleanTransactionFilePath,
+  createContextCleanerHostExecutionBridge,
+  readContextCleanReceipt,
+  saveContextCleanPlan,
+  transitionContextCleanState,
+} from "../src/index.js";
+import { samplePlan, sampleReceipt, sampleSnapshot } from "./fixtures.js";
+
+async function saveScheduledPlan(stateDir: string): Promise<void> {
+  await saveContextCleanPlan({ stateDir, plan: samplePlan() });
+  await transitionContextCleanState({
+    stateDir,
+    receipt: sampleReceipt("approved"),
+  });
+  await transitionContextCleanState({
+    stateDir,
+    receipt: sampleReceipt("scheduled"),
+  });
+}
+
+function request() {
+  return {
+    cleanPlanId: "clean-plan-1",
+    sessionId: "session-1",
+    baseRevision: "rev-1",
+    selectedTaskIds: ["task-a"],
+  };
+}
+
+test("execution bridge expands only the frozen scheduled task scope", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-"));
+  try {
+    await saveScheduledPlan(root);
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: ["task-current"],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+
+    const first = await bridge.prepareScheduledClean(request());
+    const second = await bridge.prepareScheduledClean(request());
+    assert.equal(first.outcome, "ready");
+    assert.equal(second.outcome, "ready");
+    if (first.outcome !== "ready" || second.outcome !== "ready") return;
+    assert.deepEqual(first.execution.selectedTasks, [{
+      taskId: "task-a",
+      itemIds: ["item-a", "item-b"],
+      itemDigests: { "item-a": "digest-a", "item-b": "digest-b" },
+    }]);
+    assert.equal(first.execution.mutationPlan.sourceModuleId, "cleaner_manual");
+    assert.equal(first.execution.mutationPlan.operations.length, 1);
+    assert.deepEqual(
+      first.execution.mutationPlan.operations[0]?.targetItemIds,
+      ["item-a", "item-b"],
+    );
+    assert.deepEqual(
+      first.execution.mutationPlan.operations[0]?.targetItemFingerprints,
+      { "item-a": "digest-a", "item-b": "digest-b" },
+    );
+    assert.equal(
+      first.execution.mutationPlan.planId,
+      second.execution.mutationPlan.planId,
+    );
+    assert.equal("adapterMetadata" in first.execution.mutationPlan, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("execution bridge records a real terminal receipt through the shared coordinator", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-receipt-"));
+  try {
+    await saveScheduledPlan(root);
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: ["task-current"],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const recorded = await bridge.recordCleanReceipt(sampleReceipt("applied"));
+    assert.equal(recorded.bypassed, false);
+    assert.equal(recorded.value?.status, "applied");
+    assert.equal(
+      (await readContextCleanReceipt({ stateDir: root, planId: "clean-plan-1" }))
+        .value?.status,
+      "applied",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("terminal plans replay their receipt without reading or mutating Host state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-terminal-"));
+  try {
+    await saveScheduledPlan(root);
+    await transitionContextCleanState({
+      stateDir: root,
+      receipt: sampleReceipt("applied"),
+    });
+    let snapshotReads = 0;
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        snapshotReads += 1;
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: ["task-current"],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const result = await bridge.prepareScheduledClean(request());
+    assert.equal(result.outcome, "terminal");
+    assert.equal(result.outcome === "terminal" ? result.receipt.status : undefined, "applied");
+    assert.equal(snapshotReads, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("execution bridge rejects identity, approval, and selection mismatches before reading Host state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-identity-"));
+  try {
+    await saveScheduledPlan(root);
+    let snapshotReads = 0;
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        snapshotReads += 1;
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+
+    const selection = await bridge.prepareScheduledClean({
+      ...request(),
+      selectedTaskIds: ["task-current"],
+    });
+    assert.deepEqual(selection.reasons, ["clean_execution_selection_mismatch"]);
+    const revision = await bridge.prepareScheduledClean({
+      ...request(),
+      baseRevision: "other-revision",
+    });
+    assert.deepEqual(revision.reasons, ["clean_execution_base_revision_mismatch"]);
+    const session = await bridge.prepareScheduledClean({
+      ...request(),
+      sessionId: "other-session",
+    });
+    assert.deepEqual(session.reasons, ["clean_execution_session_mismatch"]);
+
+    const otherHost = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "claude-code",
+      async readExecutionSnapshot() {
+        snapshotReads += 1;
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const host = await otherHost.prepareScheduledClean(request());
+    assert.deepEqual(host.reasons, ["clean_execution_host_mismatch"]);
+    assert.equal(snapshotReads, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("approved plans cannot execute until a scheduler records the scheduled state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-approved-"));
+  try {
+    await saveContextCleanPlan({ stateDir: root, plan: samplePlan() });
+    await transitionContextCleanState({
+      stateDir: root,
+      receipt: sampleReceipt("approved"),
+    });
+    let snapshotReads = 0;
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        snapshotReads += 1;
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const result = await bridge.prepareScheduledClean(request());
+    assert.deepEqual(result.reasons, ["clean_execution_not_scheduled"]);
+    assert.equal(snapshotReads, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("revision, digest, lifecycle, and task attribution drift preserve the Host request", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-stale-"));
+  try {
+    await saveScheduledPlan(root);
+    const prepareWith = async (params: {
+      snapshot?: ReturnType<typeof sampleSnapshot>;
+      activeTaskIds?: string[];
+      evictableTaskIds?: string[];
+    }) => createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return {
+          snapshot: params.snapshot ?? sampleSnapshot(),
+          activeTaskIds: params.activeTaskIds ?? [],
+          evictableTaskIds: params.evictableTaskIds ?? ["task-a"],
+        };
+      },
+    }).prepareScheduledClean(request());
+
+    const revision = await prepareWith({ snapshot: sampleSnapshot("rev-2") });
+    assert.deepEqual(revision.reasons, ["clean_execution_revision_stale"]);
+
+    const digestSnapshot = sampleSnapshot();
+    digestSnapshot.items[0] = {
+      ...digestSnapshot.items[0]!,
+      fingerprint: "changed-digest",
+    };
+    const digest = await prepareWith({ snapshot: digestSnapshot });
+    assert.deepEqual(digest.reasons, ["clean_execution_item_stale"]);
+
+    const attributionSnapshot = sampleSnapshot();
+    attributionSnapshot.items[0] = {
+      ...attributionSnapshot.items[0]!,
+      taskIds: ["task-other"],
+    };
+    const attribution = await prepareWith({ snapshot: attributionSnapshot });
+    assert.deepEqual(attribution.reasons, ["clean_execution_task_attribution_stale"]);
+
+    const lifecycle = await prepareWith({
+      activeTaskIds: ["task-a"],
+      evictableTaskIds: ["task-a"],
+    });
+    assert.deepEqual(lifecycle.reasons, ["clean_execution_snapshot_invalid"]);
+
+    const noLongerEvictable = await prepareWith({ evictableTaskIds: [] });
+    assert.deepEqual(noLongerEvictable.reasons, ["clean_execution_task_not_evictable"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("protocol closure failure does not expose a partially applicable mutation plan", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-closure-"));
+  try {
+    await saveScheduledPlan(root);
+    const snapshot = sampleSnapshot();
+    snapshot.items[0] = {
+      ...snapshot.items[0]!,
+      kind: "tool_call",
+      callId: "call-without-result",
+    };
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return {
+          snapshot,
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const result = await bridge.prepareScheduledClean(request());
+    assert.equal(result.outcome, "bypassed");
+    assert.deepEqual(result.reasons, ["clean_execution_protocol_closure_failed"]);
+    assert.equal("execution" in result, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("execution bridge recovers an interrupted scheduled transition after restart", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-recovery-"));
+  try {
+    await saveContextCleanPlan({ stateDir: root, plan: samplePlan() });
+    await transitionContextCleanState({
+      stateDir: root,
+      receipt: sampleReceipt("approved"),
+    });
+    const scheduled = sampleReceipt("scheduled");
+    const intentPath = contextCleanTransactionFilePath(root, scheduled.planId);
+    await mkdir(dirname(intentPath), { recursive: true });
+    await writeJsonFileAtomic(intentPath, {
+      storeSchemaVersion: CONTEXT_CLEAN_STORE_SCHEMA_VERSION,
+      planId: scheduled.planId,
+      fromStatus: "approved",
+      receipt: scheduled,
+      createdAt: scheduled.updatedAt,
+    });
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    assert.equal((await bridge.prepareScheduledClean(request())).outcome, "ready");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("missing and corrupt stores fail without reading Host state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-store-"));
+  try {
+    let snapshotReads = 0;
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        snapshotReads += 1;
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const missing = await bridge.prepareScheduledClean(request());
+    assert.equal(missing.outcome, "missing");
+
+    await saveScheduledPlan(root);
+    const receiptPath = contextCleanReceiptFilePath(root, request().cleanPlanId);
+    await writeFile(receiptPath, "{not-json", "utf8");
+    const corrupt = await bridge.prepareScheduledClean(request());
+    assert.equal(corrupt.outcome, "bypassed");
+    assert.equal(corrupt.reasons[0], "clean_execution_receipt_unavailable");
+    assert.equal(snapshotReads, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("cross-host receipt evidence is rejected without changing scheduled state", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-record-host-"));
+  try {
+    await saveScheduledPlan(root);
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const rejected = await bridge.recordCleanReceipt({
+      ...sampleReceipt("applied"),
+      hostId: "claude-code",
+    });
+    assert.deepEqual(rejected.reasons, ["clean_execution_receipt_host_mismatch"]);
+    assert.equal(
+      (await readContextCleanReceipt({ stateDir: root, planId: request().cleanPlanId }))
+        .value?.status,
+      "scheduled",
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("malformed canonical snapshots fail closed without exposing Host payload", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-snapshot-invalid-"));
+  try {
+    await saveScheduledPlan(root);
+    const malformed = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return null as never;
+      },
+    });
+    const malformedResult = await malformed.prepareScheduledClean(request());
+    assert.deepEqual(malformedResult.reasons, ["clean_execution_snapshot_invalid"]);
+
+    const withAdapterPayload = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        return {
+          snapshot: {
+            ...sampleSnapshot(),
+            adapterMetadata: { rawRequest: "must-not-cross-shared-boundary" },
+          } as never,
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a"],
+        };
+      },
+    });
+    const payloadResult = await withAdapterPayload.prepareScheduledClean(request());
+    assert.deepEqual(payloadResult.reasons, ["clean_execution_snapshot_invalid"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("overlapping selected task item scopes are rejected instead of double targeting", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-overlap-"));
+  try {
+    const plan = samplePlan();
+    plan.planId = "clean-plan-overlap";
+    plan.tasks[1] = {
+      ...plan.tasks[1]!,
+      taskId: "task-b",
+      lifecycleState: "completed",
+      itemIds: ["item-b"],
+      itemDigests: { "item-b": "digest-b" },
+      recommendation: "clean",
+      selectable: true,
+    };
+    const receipt = (status: "approved" | "scheduled") => ({
+      ...sampleReceipt(status),
+      planId: plan.planId,
+      selectedTaskIds: ["task-a", "task-b"],
+    });
+    await saveContextCleanPlan({ stateDir: root, plan });
+    await transitionContextCleanState({ stateDir: root, receipt: receipt("approved") });
+    await transitionContextCleanState({ stateDir: root, receipt: receipt("scheduled") });
+    let snapshotReads = 0;
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: root,
+      hostId: "codex",
+      async readExecutionSnapshot() {
+        snapshotReads += 1;
+        return {
+          snapshot: sampleSnapshot(),
+          activeTaskIds: [],
+          evictableTaskIds: ["task-a", "task-b"],
+        };
+      },
+    });
+    const result = await bridge.prepareScheduledClean({
+      cleanPlanId: plan.planId,
+      sessionId: plan.sessionId,
+      baseRevision: plan.baseRevision,
+      selectedTaskIds: ["task-a", "task-b"],
+    });
+    assert.deepEqual(result.reasons, ["clean_execution_plan_selection_invalid"]);
+    assert.equal(snapshotReads, 0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Add the shared Context Cleaner Host execution bridge used by adapters at a safe Host request boundary.

- Recover the exact approved item scope from the immutable stored clean plan.
- Build deterministic `ContextMutationPlan` operations for selected tasks.
- Revalidate Host/session identity, revision, item fingerprints, task attribution, lifecycle state, and protocol closure before execution.
- Replay terminal receipts idempotently and recover interrupted shared-state transitions.
- Record terminal receipts through the shared clean-state coordinator.

## Safety boundaries

- Runtime callers provide only `cleanPlanId`, `sessionId`, `baseRevision`, and `selectedTaskIds`.
- Callers cannot replace the frozen approval scope with new item IDs or digests.
- Missing, corrupt, stale, conflicting, or partially applicable state fails closed and preserves the original Host request.
- `adapterMetadata` and raw Host request payloads cannot cross the shared bridge boundary.
- The shared bridge does not apply Host-native rewrites or claim actual savings; those remain adapter responsibilities.

## Tests

- `pnpm --dir components/packages/features/cleaner test` — 36/36 passed
- `pnpm --dir components/packages/features/cleaner typecheck`
- `pnpm --dir components/adapters/codex test` — 403/403 passed
- `pnpm check:boundaries`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

## Scope

This PR contains only the shared Cleaner Host execution bridge.

Codex approved-plan scheduling, applied receipt evidence, Claude Code overlays, and doctor/report integration remain separate follow-up PRs.