### PR TITLE
feat(codex): schedule approved context clean plans

### DIFF
--- a/components/adapters/codex/src/context-cleaner/bridge.ts
+++ b/components/adapters/codex/src/context-cleaner/bridge.ts
@@ -18,6 +18,7 @@ import { buildCodexLifecycleBackendRequest } from "../context-rewrite/lifecycle-
 import {
   loadCodexSessionSnapshot,
 } from "../session-state.js";
+import { scheduleCodexCleanerPlan } from "./scheduler.js";
 import { listCodexCleanerSessions } from "./session-catalog.js";
 
 const CODEX_HOST_ID = "codex";
@@ -256,12 +257,26 @@ export function createCodexContextCleanerBridge(params: {
     },
     async executeApprovedClean(request) {
       const selectedTaskIds = validateApprovedRequest(request);
-      return validateReceipt({
+      const receipt = validateReceipt({
         receipt: await params.controlPlane.executeApprovedClean(request),
         planId: request.cleanPlanId,
         sessionId: request.sessionId,
         selectedTaskIds,
       });
+      if (receipt.status === "scheduled") {
+        const scheduled = await scheduleCodexCleanerPlan({
+          stateDir: params.stateDir,
+          sessionId: request.sessionId,
+          cleanPlanId: request.cleanPlanId,
+          baseRevision: request.baseRevision,
+          selectedTaskIds,
+          scheduledAt: receipt.updatedAt,
+        });
+        if (scheduled.outcome !== "stored" && scheduled.outcome !== "unchanged") {
+          throw new Error(`codex_clean_schedule_failed:${scheduled.reasons.join(",")}`);
+        }
+      }
+      return receipt;
     },
     async readCleanReceipt(planId) {
       if (!planId.trim()) throw new Error("codex_clean_plan_id_invalid");

--- a/components/adapters/codex/src/context-cleaner/runtime.ts
+++ b/components/adapters/codex/src/context-cleaner/runtime.ts
@@ -1,0 +1,540 @@
+import {
+  createContextCleanerHostExecutionBridge,
+  type ContextCleanPreparedExecution,
+  type ContextCleanReceipt,
+  type ContextCleanScheduledReceipt,
+  type ContextCleanTerminalReceipt,
+} from "@lightrsi/cleaner";
+import { loadSessionTaskRegistry } from "@lightrsi/history";
+import type {
+  ContextRewriteResult,
+  ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+
+import type { CodexEffectiveHistoryView } from "../context-history/types.js";
+import {
+  codexSharedContextRewriteBackend,
+  type CodexSharedBackendDetails,
+  type CodexSharedBackendMetadata,
+  type CodexSharedBackendRequest,
+} from "../context-rewrite/backend.js";
+import {
+  buildCodexLifecycleBackendRequest,
+  type CodexLifecycleBackendRequestBase,
+} from "../context-rewrite/lifecycle-input.js";
+import {
+  acquireCodexRebaseSessionLock,
+  readCodexRebaseEpochJournal,
+} from "../context-rewrite/rebase-epoch.js";
+import type { CodexRebaseRequestResult } from "../context-rewrite/types.js";
+import {
+  appendCodexCleanerCommitted,
+  appendCodexCleanerTerminal,
+  readCodexCleanerSchedule,
+  type CodexCleanerScheduledRecord,
+} from "./scheduler.js";
+
+const STALE_REASONS = new Set([
+  "clean_execution_revision_stale",
+  "clean_execution_item_stale",
+  "clean_execution_protected_item_targeted",
+  "clean_execution_task_attribution_stale",
+  "clean_execution_task_not_evictable",
+  "clean_execution_revalidation_failed",
+  "clean_execution_protocol_closure_failed",
+  "cleaner_runtime_snapshot_changed",
+  "cleaner_runtime_plan_invalid",
+]);
+
+export type CodexCleanerPreparedRebase = {
+  schedule: CodexCleanerScheduledRecord;
+  execution: ContextCleanPreparedExecution;
+  backendRequest: CodexSharedBackendRequest;
+  snapshot: ModelContextSnapshot<CodexSharedBackendMetadata>;
+  rewriteResult: ContextRewriteResult<CodexSharedBackendDetails>;
+  rebaseRequest: CodexRebaseRequestResult;
+};
+
+export type CodexCleanerRuntimeResult =
+  | { outcome: "absent"; reasonCodes: [] }
+  | { outcome: "ready"; prepared: CodexCleanerPreparedRebase; reasonCodes: [] }
+  | { outcome: "reserved"; reasonCodes: string[] }
+  | { outcome: "stale"; receipt: ContextCleanTerminalReceipt; reasonCodes: string[] }
+  | { outcome: "terminal"; receipt?: ContextCleanReceipt; reasonCodes: string[] }
+  | { outcome: "committed"; reasonCodes: string[] };
+
+export type CodexCleanerHandoffValidation = {
+  valid: boolean;
+  reasonCodes: string[];
+};
+
+function uniqueStrings(values: Iterable<string>): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result;
+}
+
+function sameCanonicalValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function fullyApplied(
+  execution: ContextCleanPreparedExecution,
+  result: ContextRewriteResult<CodexSharedBackendDetails>,
+): boolean {
+  const operationIds = execution.mutationPlan.operations.map((operation) => operation.id);
+  return result.applied
+    && result.changed
+    && result.fallbackUsed === false
+    && result.details?.rebasePrepared === true
+    && result.deferredOperationIds.length === 0
+    && result.appliedOperationIds.length === operationIds.length
+    && operationIds.every((operationId) => result.appliedOperationIds.includes(operationId));
+}
+
+async function executionContext(params: {
+  stateDir: string;
+  sessionId: string;
+  view: CodexEffectiveHistoryView;
+  backendRequest: CodexLifecycleBackendRequestBase;
+}): Promise<{
+  backendRequest: CodexSharedBackendRequest;
+  snapshot: ModelContextSnapshot<CodexSharedBackendMetadata>;
+}> {
+  const registry = await loadSessionTaskRegistry(params.stateDir, params.sessionId);
+  if (registry.sessionId !== params.sessionId) {
+    throw new Error("cleaner_runtime_registry_session_mismatch");
+  }
+  const backendRequest = buildCodexLifecycleBackendRequest({
+    view: params.view,
+    registry,
+    request: params.backendRequest,
+  });
+  const snapshot = await codexSharedContextRewriteBackend.readSnapshot({
+    sessionId: params.sessionId,
+    request: backendRequest,
+  });
+  return { backendRequest, snapshot };
+}
+
+function executionBridge(params: {
+  stateDir: string;
+  sessionId: string;
+  backendRequest: CodexSharedBackendRequest;
+  snapshot: ModelContextSnapshot<CodexSharedBackendMetadata>;
+}) {
+  return createContextCleanerHostExecutionBridge({
+    stateDir: params.stateDir,
+    hostId: "codex",
+    async readExecutionSnapshot(sessionId) {
+      if (sessionId !== params.sessionId) {
+        throw new Error("cleaner_runtime_snapshot_session_mismatch");
+      }
+      const { adapterMetadata: _adapterMetadata, ...canonicalSnapshot } = params.snapshot;
+      return {
+        snapshot: canonicalSnapshot,
+        activeTaskIds: params.backendRequest.activeTaskIds ?? [],
+        evictableTaskIds: params.backendRequest.evictableTaskIds ?? [],
+      };
+    },
+  });
+}
+
+function staleReasonCodes(reasonCodes: readonly string[]): string[] | undefined {
+  const stale = uniqueStrings(reasonCodes.filter((reason) => STALE_REASONS.has(reason)));
+  return stale.length > 0 ? stale : undefined;
+}
+
+export function isCodexCleanerStaleReasonCode(reason: string | undefined): boolean {
+  return typeof reason === "string" && STALE_REASONS.has(reason);
+}
+
+function isScheduledReceipt(
+  receipt: ContextCleanReceipt | undefined,
+): receipt is ContextCleanScheduledReceipt {
+  return receipt?.status === "scheduled";
+}
+
+async function persistTerminalSchedule(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  receiptStatus: "stale" | "cancelled" | "failed";
+  reasons: string[];
+  updatedAt: string;
+}): Promise<string[]> {
+  const local = await appendCodexCleanerTerminal(params);
+  return local.outcome === "transitioned" || local.outcome === "unchanged"
+    ? []
+    : uniqueStrings(local.reasons);
+}
+
+async function persistStale(params: {
+  stateDir: string;
+  sessionId: string;
+  scheduledReceipt: ContextCleanScheduledReceipt;
+  reasonCodes: string[];
+  updatedAt: string;
+}): Promise<CodexCleanerRuntimeResult> {
+  const receipt: ContextCleanTerminalReceipt = {
+    ...params.scheduledReceipt,
+    status: "stale",
+    deferredTaskIds: [...params.scheduledReceipt.selectedTaskIds],
+    fallbackUsed: false,
+    reasons: [...params.reasonCodes],
+    updatedAt: params.updatedAt,
+  };
+  const bridge = createContextCleanerHostExecutionBridge({
+    stateDir: params.stateDir,
+    hostId: "codex",
+    async readExecutionSnapshot() {
+      throw new Error("cleaner_runtime_stale_does_not_read_host_state");
+    },
+  });
+  const stored = await bridge.recordCleanReceipt(receipt);
+  if (stored.bypassed) {
+    return {
+      outcome: "reserved",
+      reasonCodes: uniqueStrings([
+        ...params.reasonCodes,
+        "cleaner_runtime_stale_receipt_write_failed",
+        ...stored.reasons,
+      ]),
+    };
+  }
+  const localReasons = await persistTerminalSchedule({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+    cleanPlanId: receipt.planId,
+    receiptStatus: "stale",
+    reasons: params.reasonCodes,
+    updatedAt: params.updatedAt,
+  });
+  return localReasons.length === 0
+    ? { outcome: "stale", receipt, reasonCodes: params.reasonCodes }
+    : {
+        outcome: "reserved",
+        reasonCodes: uniqueStrings([
+          ...params.reasonCodes,
+          "cleaner_runtime_terminal_schedule_write_failed",
+          ...localReasons,
+        ]),
+      };
+}
+
+export async function finalizeCodexCleanerHandoffFailure(params: {
+  stateDir: string;
+  sessionId: string;
+  prepared: CodexCleanerPreparedRebase;
+  reasonCodes: string[];
+  now?: string;
+}): Promise<CodexCleanerRuntimeResult> {
+  const stale = staleReasonCodes(params.reasonCodes);
+  if (!stale) {
+    return { outcome: "reserved", reasonCodes: uniqueStrings(params.reasonCodes) };
+  }
+  return persistStale({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+    scheduledReceipt: params.prepared.execution.scheduledReceipt,
+    reasonCodes: stale,
+    updatedAt: params.now ?? new Date().toISOString(),
+  });
+}
+
+async function persistExistingTerminal(params: {
+  stateDir: string;
+  sessionId: string;
+  receipt: ContextCleanReceipt;
+  now: string;
+}): Promise<CodexCleanerRuntimeResult> {
+  if (params.receipt.status !== "stale"
+    && params.receipt.status !== "cancelled"
+    && params.receipt.status !== "failed") {
+    return {
+      outcome: "terminal",
+      receipt: params.receipt,
+      reasonCodes: ["cleaner_runtime_terminal_receipt"],
+    };
+  }
+  const reasons = params.receipt.reasons.length > 0
+    ? params.receipt.reasons
+    : ["cleaner_runtime_terminal_receipt"];
+  const localReasons = await persistTerminalSchedule({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+    cleanPlanId: params.receipt.planId,
+    receiptStatus: params.receipt.status,
+    reasons,
+    updatedAt: params.now,
+  });
+  return {
+    outcome: "terminal",
+    receipt: params.receipt,
+    reasonCodes: uniqueStrings([...reasons, ...localReasons]),
+  };
+}
+
+export async function prepareCodexCleanerRebase(params: {
+  stateDir: string;
+  sessionId: string;
+  view: CodexEffectiveHistoryView;
+  backendRequest: CodexLifecycleBackendRequestBase;
+  now?: string;
+}): Promise<CodexCleanerRuntimeResult> {
+  const now = params.now ?? new Date().toISOString();
+  const initial = await readCodexCleanerSchedule(params);
+  if (initial.outcome === "missing") return { outcome: "absent", reasonCodes: [] };
+  if (initial.outcome === "bypassed") {
+    return { outcome: "reserved", reasonCodes: initial.reasons };
+  }
+  if (initial.outcome === "committed") {
+    return { outcome: "committed", reasonCodes: ["cleaner_runtime_already_committed"] };
+  }
+  if (initial.outcome === "terminal") {
+    return { outcome: "terminal", reasonCodes: initial.record.reasons };
+  }
+
+  const lock = await acquireCodexRebaseSessionLock({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+  });
+  if (!lock) return { outcome: "reserved", reasonCodes: ["cleaner_runtime_lock_busy"] };
+
+  let decision: CodexCleanerRuntimeResult;
+  let scheduledReceipt: ContextCleanScheduledReceipt | undefined;
+  let recoveredCommit: {
+    cleanPlanId: string;
+    mutationPlanId: string;
+    epochId: string;
+    updatedAt: string;
+  } | undefined;
+  try {
+    const currentSchedule = await readCodexCleanerSchedule(params);
+    if (currentSchedule.outcome !== "ready") {
+      decision = currentSchedule.outcome === "missing"
+        ? { outcome: "reserved", reasonCodes: ["cleaner_runtime_schedule_changed"] }
+        : currentSchedule.outcome === "bypassed"
+          ? { outcome: "reserved", reasonCodes: currentSchedule.reasons }
+          : currentSchedule.outcome === "committed"
+            ? { outcome: "committed", reasonCodes: ["cleaner_runtime_already_committed"] }
+            : { outcome: "terminal", reasonCodes: currentSchedule.record.reasons };
+    } else if (!sameCanonicalValue(initial.record, currentSchedule.record)) {
+      decision = { outcome: "reserved", reasonCodes: ["cleaner_runtime_schedule_changed"] };
+    } else {
+      let context;
+      try {
+        context = await executionContext(params);
+      } catch {
+        decision = {
+          outcome: "reserved",
+          reasonCodes: ["cleaner_runtime_execution_context_unavailable"],
+        };
+        return decision;
+      }
+      const bridge = executionBridge({
+        ...params,
+        backendRequest: context.backendRequest,
+        snapshot: context.snapshot,
+      });
+      const prepared = await bridge.prepareScheduledClean({
+        cleanPlanId: currentSchedule.record.cleanPlanId,
+        sessionId: currentSchedule.record.sessionId,
+        baseRevision: currentSchedule.record.baseRevision,
+        selectedTaskIds: currentSchedule.record.selectedTaskIds,
+      });
+      if (prepared.outcome === "terminal") {
+        decision = {
+          outcome: "terminal",
+          receipt: prepared.receipt,
+          reasonCodes: prepared.receipt.reasons.length > 0
+            ? prepared.receipt.reasons
+            : ["cleaner_runtime_terminal_receipt"],
+        };
+      } else if (prepared.outcome !== "ready") {
+        const stale = prepared.outcome === "bypassed"
+          ? staleReasonCodes(prepared.reasons)
+          : undefined;
+        if (stale && prepared.outcome === "bypassed"
+          && isScheduledReceipt(prepared.receipt)) {
+          scheduledReceipt = prepared.receipt;
+          decision = { outcome: "reserved", reasonCodes: stale };
+        } else {
+          decision = { outcome: "reserved", reasonCodes: prepared.reasons };
+        }
+      } else {
+        scheduledReceipt = prepared.execution.scheduledReceipt;
+        const epochs = await readCodexRebaseEpochJournal(params.stateDir, params.sessionId);
+        const committedEpoch = epochs.epochs.find((epoch) => (
+          epoch.status === "committed"
+          && epoch.planId === prepared.execution.mutationPlan.planId
+        ));
+        if (epochs.readError || epochs.malformedLineCount > 0) {
+          decision = {
+            outcome: "reserved",
+            reasonCodes: ["cleaner_runtime_epoch_journal_unavailable"],
+          };
+        } else if (committedEpoch) {
+          recoveredCommit = {
+            cleanPlanId: prepared.execution.cleanPlanId,
+            mutationPlanId: prepared.execution.mutationPlan.planId,
+            epochId: committedEpoch.epochId,
+            updatedAt: committedEpoch.updatedAt,
+          };
+          decision = {
+            outcome: "committed",
+            reasonCodes: ["cleaner_runtime_already_committed"],
+          };
+        } else {
+          const applied = await codexSharedContextRewriteBackend.apply({
+            snapshot: context.snapshot,
+            plan: prepared.execution.mutationPlan,
+            request: context.backendRequest,
+          });
+          if (!fullyApplied(prepared.execution, applied.result)) {
+            decision = {
+              outcome: "reserved",
+              reasonCodes: ["cleaner_runtime_rebase_prepare_failed"],
+            };
+          } else {
+            decision = {
+              outcome: "ready",
+              prepared: {
+                schedule: currentSchedule.record,
+                execution: prepared.execution,
+                backendRequest: context.backendRequest,
+                snapshot: context.snapshot,
+                rewriteResult: applied.result,
+                rebaseRequest: {
+                  payload: applied.request.payload,
+                  oldRevision: applied.result.previousRevision,
+                  rebaseRevision: applied.result.nextRevision,
+                  accounting: applied.result.details!.accounting,
+                },
+              },
+              reasonCodes: [],
+            };
+          }
+        }
+      }
+    }
+  } finally {
+    await lock.release();
+  }
+
+  if (decision.outcome === "reserved" && scheduledReceipt) {
+    const stale = staleReasonCodes(decision.reasonCodes);
+    if (stale) {
+      return persistStale({
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        scheduledReceipt,
+        reasonCodes: stale,
+        updatedAt: now,
+      });
+    }
+  }
+  if (decision.outcome === "committed" && recoveredCommit) {
+    const local = await appendCodexCleanerCommitted({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      ...recoveredCommit,
+    });
+    if (local.outcome !== "transitioned" && local.outcome !== "unchanged") {
+      return {
+        outcome: "reserved",
+        reasonCodes: uniqueStrings([
+          "cleaner_runtime_commit_recovery_failed",
+          ...local.reasons,
+        ]),
+      };
+    }
+  }
+  if (decision.outcome === "terminal" && decision.receipt) {
+    return persistExistingTerminal({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      receipt: decision.receipt,
+      now,
+    });
+  }
+  return decision;
+}
+
+export async function revalidateCodexCleanerPreparedRebase(params: {
+  stateDir: string;
+  sessionId: string;
+  prepared: CodexCleanerPreparedRebase;
+  view: CodexEffectiveHistoryView;
+  backendRequest: CodexLifecycleBackendRequestBase;
+}): Promise<CodexCleanerHandoffValidation> {
+  const schedule = await readCodexCleanerSchedule(params);
+  if (schedule.outcome !== "ready") {
+    return {
+      valid: false,
+      reasonCodes: schedule.outcome === "bypassed"
+        ? schedule.reasons
+        : [`cleaner_runtime_schedule_${schedule.outcome}`],
+    };
+  }
+  if (!sameCanonicalValue(schedule.record, params.prepared.schedule)) {
+    return { valid: false, reasonCodes: ["cleaner_runtime_schedule_changed"] };
+  }
+
+  const epochs = await readCodexRebaseEpochJournal(params.stateDir, params.sessionId);
+  if (epochs.readError || epochs.malformedLineCount > 0) {
+    return { valid: false, reasonCodes: ["cleaner_runtime_epoch_journal_unavailable"] };
+  }
+  if (epochs.epochs.some((epoch) => (
+    epoch.status === "committed"
+    && epoch.planId === params.prepared.execution.mutationPlan.planId
+  ))) {
+    return { valid: false, reasonCodes: ["cleaner_runtime_already_committed"] };
+  }
+
+  let current;
+  try {
+    current = await executionContext(params);
+  } catch {
+    return {
+      valid: false,
+      reasonCodes: ["cleaner_runtime_execution_context_unavailable"],
+    };
+  }
+  const bridge = executionBridge({
+    ...params,
+    backendRequest: current.backendRequest,
+    snapshot: current.snapshot,
+  });
+  const prepared = await bridge.prepareScheduledClean({
+    cleanPlanId: schedule.record.cleanPlanId,
+    sessionId: schedule.record.sessionId,
+    baseRevision: schedule.record.baseRevision,
+    selectedTaskIds: schedule.record.selectedTaskIds,
+  });
+  if (prepared.outcome !== "ready") {
+    return { valid: false, reasonCodes: prepared.reasons };
+  }
+  if (!sameCanonicalValue(params.prepared.execution.mutationPlan, prepared.execution.mutationPlan)
+    || !sameCanonicalValue(params.prepared.snapshot, current.snapshot)) {
+    return { valid: false, reasonCodes: ["cleaner_runtime_snapshot_changed"] };
+  }
+  const validation = await codexSharedContextRewriteBackend.validate({
+    snapshot: current.snapshot,
+    plan: prepared.execution.mutationPlan,
+  });
+  const operationIds = prepared.execution.mutationPlan.operations.map((operation) => operation.id);
+  const valid = validation.valid
+    && validation.deferredOperationIds.length === 0
+    && validation.applicableOperationIds.length === operationIds.length
+    && operationIds.every((operationId) => validation.applicableOperationIds.includes(operationId));
+  return valid
+    ? { valid: true, reasonCodes: [] }
+    : { valid: false, reasonCodes: ["cleaner_runtime_plan_invalid", ...validation.reasons] };
+}

--- a/components/adapters/codex/src/context-cleaner/scheduler.ts
+++ b/components/adapters/codex/src/context-cleaner/scheduler.ts
@@ -1,0 +1,468 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { appendJsonl } from "@lightrsi/host-adapter";
+
+import {
+  acquireCodexRebaseSessionLock,
+  codexRebaseEpochJournalPath,
+} from "../context-rewrite/rebase-epoch.js";
+
+export const CODEX_CLEANER_SCHEDULE_SCHEMA = "lightrsi.codex.cleaner-schedule/v1" as const;
+
+type CodexCleanerScheduleIdentity = {
+  schema: typeof CODEX_CLEANER_SCHEDULE_SCHEMA;
+  hostId: "codex";
+  sessionId: string;
+  cleanPlanId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+  scheduledAt: string;
+  updatedAt: string;
+};
+
+export type CodexCleanerScheduledRecord = CodexCleanerScheduleIdentity & {
+  status: "scheduled";
+};
+
+/** Adapter-local commit marker. This is not a shared Cleaner applied receipt. */
+export type CodexCleanerCommittedRecord = CodexCleanerScheduleIdentity & {
+  status: "committed";
+  mutationPlanId: string;
+  epochId: string;
+};
+
+export type CodexCleanerTerminalRecord = CodexCleanerScheduleIdentity & {
+  status: "terminal";
+  receiptStatus: "stale" | "cancelled" | "failed";
+  reasons: string[];
+};
+
+export type CodexCleanerScheduleRecord =
+  | CodexCleanerScheduledRecord
+  | CodexCleanerCommittedRecord
+  | CodexCleanerTerminalRecord;
+
+export type CodexCleanerScheduleReadResult =
+  | { outcome: "missing"; reasons: [] }
+  | { outcome: "ready"; record: CodexCleanerScheduledRecord; reasons: [] }
+  | { outcome: "committed"; record: CodexCleanerCommittedRecord; reasons: [] }
+  | { outcome: "terminal"; record: CodexCleanerTerminalRecord; reasons: [] }
+  | { outcome: "bypassed"; reasons: string[] };
+
+export type CodexCleanerScheduleWriteResult = {
+  outcome: "stored" | "transitioned" | "unchanged" | "missing" | "conflict" | "bypassed";
+  record?: CodexCleanerScheduleRecord;
+  reasons: string[];
+};
+
+type CodexCleanerScheduleJournal = {
+  entries: CodexCleanerScheduleRecord[];
+  records: CodexCleanerScheduleRecord[];
+  malformedLineCount: number;
+  readError?: string;
+};
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error
+    && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function nonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function uniqueNonBlankStrings(value: unknown): value is string[] {
+  return Array.isArray(value)
+    && value.length > 0
+    && value.every(nonBlankString)
+    && new Set(value).size === value.length;
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && left.every((value, index) => value === right[index]);
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
+}
+
+function sameIdentity(
+  left: CodexCleanerScheduleIdentity,
+  right: CodexCleanerScheduleIdentity,
+): boolean {
+  return left.hostId === right.hostId
+    && left.sessionId === right.sessionId
+    && left.cleanPlanId === right.cleanPlanId
+    && left.baseRevision === right.baseRevision
+    && left.scheduledAt === right.scheduledAt
+    && sameStringSet(left.selectedTaskIds, right.selectedTaskIds);
+}
+
+function canonicalRecord(value: unknown): CodexCleanerScheduleRecord | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (record.schema !== CODEX_CLEANER_SCHEDULE_SCHEMA
+    || record.hostId !== "codex"
+    || !nonBlankString(record.sessionId)
+    || !nonBlankString(record.cleanPlanId)
+    || !nonBlankString(record.baseRevision)
+    || !uniqueNonBlankStrings(record.selectedTaskIds)
+    || !canonicalTimestamp(record.scheduledAt)
+    || !canonicalTimestamp(record.updatedAt)) {
+    return undefined;
+  }
+  const identity: CodexCleanerScheduleIdentity = {
+    schema: CODEX_CLEANER_SCHEDULE_SCHEMA,
+    hostId: "codex",
+    sessionId: record.sessionId,
+    cleanPlanId: record.cleanPlanId,
+    baseRevision: record.baseRevision,
+    selectedTaskIds: [...record.selectedTaskIds],
+    scheduledAt: record.scheduledAt,
+    updatedAt: record.updatedAt,
+  };
+  if (record.status === "scheduled") {
+    return { ...identity, status: "scheduled" };
+  }
+  if (record.status === "committed"
+    && nonBlankString(record.mutationPlanId)
+    && nonBlankString(record.epochId)) {
+    return {
+      ...identity,
+      status: "committed",
+      mutationPlanId: record.mutationPlanId,
+      epochId: record.epochId,
+    };
+  }
+  if (record.status === "terminal"
+    && (record.receiptStatus === "stale"
+      || record.receiptStatus === "cancelled"
+      || record.receiptStatus === "failed")
+    && uniqueNonBlankStrings(record.reasons)) {
+    return {
+      ...identity,
+      status: "terminal",
+      receiptStatus: record.receiptStatus,
+      reasons: [...record.reasons],
+    };
+  }
+  return undefined;
+}
+
+function validTransition(
+  previous: CodexCleanerScheduleRecord | undefined,
+  next: CodexCleanerScheduleRecord,
+): boolean {
+  if (!previous) return next.status === "scheduled";
+  if (!sameIdentity(previous, next)) return false;
+  if (previous.status === "scheduled") return true;
+  return JSON.stringify(previous) === JSON.stringify(next);
+}
+
+function collapseLatest(
+  entries: readonly CodexCleanerScheduleRecord[],
+): CodexCleanerScheduleRecord[] {
+  const latest = new Map<string, CodexCleanerScheduleRecord>();
+  for (const entry of entries) {
+    latest.delete(entry.cleanPlanId);
+    latest.set(entry.cleanPlanId, entry);
+  }
+  return [...latest.values()];
+}
+
+export function codexCleanerScheduleJournalPath(
+  stateDir: string,
+  sessionId: string,
+): string {
+  return join(
+    dirname(codexRebaseEpochJournalPath(stateDir, sessionId)),
+    "cleaner-schedule.jsonl",
+  );
+}
+
+async function readScheduleJournal(
+  stateDir: string,
+  sessionId: string,
+): Promise<CodexCleanerScheduleJournal> {
+  let raw: string;
+  try {
+    raw = await readFile(codexCleanerScheduleJournalPath(stateDir, sessionId), "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return { entries: [], records: [], malformedLineCount: 0 };
+    }
+    return {
+      entries: [],
+      records: [],
+      malformedLineCount: 0,
+      readError: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const entries: CodexCleanerScheduleRecord[] = [];
+  const latestByPlanId = new Map<string, CodexCleanerScheduleRecord>();
+  let malformedLineCount = 0;
+  for (const line of raw.split(/\r?\n/u).filter(Boolean)) {
+    try {
+      const entry = canonicalRecord(JSON.parse(line) as unknown);
+      const previous = entry ? latestByPlanId.get(entry.cleanPlanId) : undefined;
+      if (!entry
+        || entry.sessionId !== sessionId
+        || !validTransition(previous, entry)) {
+        malformedLineCount += 1;
+        continue;
+      }
+      entries.push(entry);
+      latestByPlanId.set(entry.cleanPlanId, entry);
+    } catch {
+      malformedLineCount += 1;
+    }
+  }
+  return {
+    entries,
+    records: collapseLatest(entries),
+    malformedLineCount,
+  };
+}
+
+function journalFailureReasons(
+  journal: CodexCleanerScheduleJournal,
+): string[] | undefined {
+  if (journal.readError) {
+    return ["cleaner_schedule_journal_unavailable"];
+  }
+  if (journal.malformedLineCount > 0) {
+    return ["cleaner_schedule_journal_malformed"];
+  }
+  return undefined;
+}
+
+export async function readCodexCleanerSchedule(params: {
+  stateDir: string;
+  sessionId: string;
+}): Promise<CodexCleanerScheduleReadResult> {
+  if (!params.stateDir.trim() || !params.sessionId.trim()) {
+    return { outcome: "bypassed", reasons: ["cleaner_schedule_request_invalid"] };
+  }
+  const journal = await readScheduleJournal(params.stateDir, params.sessionId);
+  const failureReasons = journalFailureReasons(journal);
+  if (failureReasons) return { outcome: "bypassed", reasons: failureReasons };
+  const scheduled = journal.records.filter(
+    (record): record is CodexCleanerScheduledRecord => record.status === "scheduled",
+  );
+  if (scheduled.length > 1) {
+    return { outcome: "bypassed", reasons: ["cleaner_schedule_pending_conflict"] };
+  }
+  if (scheduled[0]) return { outcome: "ready", record: scheduled[0], reasons: [] };
+  const latest = journal.records.at(-1);
+  if (!latest) return { outcome: "missing", reasons: [] };
+  if (latest.status === "committed") {
+    return { outcome: "committed", record: latest, reasons: [] };
+  }
+  if (latest.status === "terminal") {
+    return { outcome: "terminal", record: latest, reasons: [] };
+  }
+  return { outcome: "bypassed", reasons: ["cleaner_schedule_pending_conflict"] };
+}
+
+function validScheduleParams(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+  scheduledAt: string;
+}): boolean {
+  return nonBlankString(params.stateDir)
+    && nonBlankString(params.sessionId)
+    && nonBlankString(params.cleanPlanId)
+    && nonBlankString(params.baseRevision)
+    && uniqueNonBlankStrings(params.selectedTaskIds)
+    && canonicalTimestamp(params.scheduledAt);
+}
+
+export async function scheduleCodexCleanerPlan(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+  scheduledAt?: string;
+}): Promise<CodexCleanerScheduleWriteResult> {
+  const scheduledAt = params.scheduledAt ?? new Date().toISOString();
+  const normalized = { ...params, scheduledAt };
+  if (!validScheduleParams(normalized)) {
+    return { outcome: "bypassed", reasons: ["cleaner_schedule_request_invalid"] };
+  }
+  const record: CodexCleanerScheduledRecord = {
+    schema: CODEX_CLEANER_SCHEDULE_SCHEMA,
+    hostId: "codex",
+    sessionId: params.sessionId,
+    cleanPlanId: params.cleanPlanId,
+    baseRevision: params.baseRevision,
+    selectedTaskIds: [...params.selectedTaskIds],
+    status: "scheduled",
+    scheduledAt,
+    updatedAt: scheduledAt,
+  };
+
+  const lock = await acquireCodexRebaseSessionLock({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+  });
+  if (!lock) {
+    return { outcome: "bypassed", reasons: ["cleaner_schedule_lock_busy"] };
+  }
+  try {
+    const journal = await readScheduleJournal(params.stateDir, params.sessionId);
+    const failureReasons = journalFailureReasons(journal);
+    if (failureReasons) return { outcome: "bypassed", reasons: failureReasons };
+    const existing = journal.records.find(
+      (entry) => entry.cleanPlanId === params.cleanPlanId,
+    );
+    if (existing) {
+      if (existing.status === "scheduled" && sameIdentity(existing, record)) {
+        return { outcome: "unchanged", record: existing, reasons: [] };
+      }
+      return {
+        outcome: "conflict",
+        record: existing,
+        reasons: ["cleaner_schedule_identity_conflict"],
+      };
+    }
+    if (journal.records.some((entry) => entry.status === "scheduled")) {
+      return { outcome: "conflict", reasons: ["cleaner_schedule_pending_conflict"] };
+    }
+    await appendJsonl(codexCleanerScheduleJournalPath(params.stateDir, params.sessionId), record);
+    return { outcome: "stored", record, reasons: [] };
+  } finally {
+    await lock.release();
+  }
+}
+
+async function transitionSchedule(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  updatedAt: string;
+  build(previous: CodexCleanerScheduledRecord): CodexCleanerScheduleRecord;
+  matchesExisting(existing: CodexCleanerScheduleRecord): boolean;
+}): Promise<CodexCleanerScheduleWriteResult> {
+  if (!nonBlankString(params.stateDir)
+    || !nonBlankString(params.sessionId)
+    || !nonBlankString(params.cleanPlanId)
+    || !canonicalTimestamp(params.updatedAt)) {
+    return { outcome: "bypassed", reasons: ["cleaner_schedule_request_invalid"] };
+  }
+  const lock = await acquireCodexRebaseSessionLock({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+  });
+  if (!lock) return { outcome: "bypassed", reasons: ["cleaner_schedule_lock_busy"] };
+  try {
+    const journal = await readScheduleJournal(params.stateDir, params.sessionId);
+    const failureReasons = journalFailureReasons(journal);
+    if (failureReasons) return { outcome: "bypassed", reasons: failureReasons };
+    const existing = journal.records.find(
+      (record) => record.cleanPlanId === params.cleanPlanId,
+    );
+    if (!existing) return { outcome: "missing", reasons: ["cleaner_schedule_missing"] };
+    if (existing.status !== "scheduled") {
+      return params.matchesExisting(existing)
+        ? { outcome: "unchanged", record: existing, reasons: [] }
+        : {
+            outcome: "conflict",
+            record: existing,
+            reasons: ["cleaner_schedule_terminal_conflict"],
+          };
+    }
+    const next = params.build(existing);
+    const canonical = canonicalRecord(next);
+    if (!canonical || !validTransition(existing, canonical)) {
+      return { outcome: "bypassed", reasons: ["cleaner_schedule_transition_invalid"] };
+    }
+    await appendJsonl(
+      codexCleanerScheduleJournalPath(params.stateDir, params.sessionId),
+      canonical,
+    );
+    return { outcome: "transitioned", record: canonical, reasons: [] };
+  } finally {
+    await lock.release();
+  }
+}
+
+export async function appendCodexCleanerCommitted(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  mutationPlanId: string;
+  epochId: string;
+  updatedAt?: string;
+}): Promise<CodexCleanerScheduleWriteResult> {
+  if (!nonBlankString(params.mutationPlanId) || !nonBlankString(params.epochId)) {
+    return { outcome: "bypassed", reasons: ["cleaner_schedule_request_invalid"] };
+  }
+  const updatedAt = params.updatedAt ?? new Date().toISOString();
+  return transitionSchedule({
+    ...params,
+    updatedAt,
+    build(previous) {
+      return {
+        ...previous,
+        status: "committed",
+        mutationPlanId: params.mutationPlanId,
+        epochId: params.epochId,
+        updatedAt,
+      };
+    },
+    matchesExisting(existing) {
+      return existing.status === "committed"
+        && existing.mutationPlanId === params.mutationPlanId
+        && existing.epochId === params.epochId;
+    },
+  });
+}
+
+export async function appendCodexCleanerTerminal(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  receiptStatus: "stale" | "cancelled" | "failed";
+  reasons: string[];
+  updatedAt?: string;
+}): Promise<CodexCleanerScheduleWriteResult> {
+  if (!uniqueNonBlankStrings(params.reasons)) {
+    return { outcome: "bypassed", reasons: ["cleaner_schedule_request_invalid"] };
+  }
+  const updatedAt = params.updatedAt ?? new Date().toISOString();
+  return transitionSchedule({
+    ...params,
+    updatedAt,
+    build(previous) {
+      return {
+        ...previous,
+        status: "terminal",
+        receiptStatus: params.receiptStatus,
+        reasons: [...params.reasons],
+        updatedAt,
+      };
+    },
+    matchesExisting(existing) {
+      return existing.status === "terminal"
+        && existing.receiptStatus === params.receiptStatus
+        && sameStrings(existing.reasons, params.reasons);
+    },
+  });
+}

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -97,6 +97,17 @@ import type {
   CodexMutationPlan,
   CodexRebaseRequestResult,
 } from "./context-rewrite/types.js";
+import {
+  finalizeCodexCleanerHandoffFailure,
+  isCodexCleanerStaleReasonCode,
+  prepareCodexCleanerRebase,
+  revalidateCodexCleanerPreparedRebase,
+  type CodexCleanerPreparedRebase,
+} from "./context-cleaner/runtime.js";
+import {
+  appendCodexCleanerCommitted,
+  readCodexCleanerSchedule,
+} from "./context-cleaner/scheduler.js";
 
 export type CodexProxyRuntime = {
   baseUrl: string;
@@ -563,9 +574,18 @@ export async function startCodexResponsesProxy(params: {
       let rebaseRequest: CodexRebaseRequestResult | undefined;
       let rebasePlanId: string | undefined;
       let lifecyclePreparedPlan: CodexLifecyclePreparedPlan | undefined;
+      let cleanerPreparedRebase: CodexCleanerPreparedRebase | undefined;
       let continuationReplayRequest: CodexRebaseRequestResult | undefined;
       let rebaseAccounting = rebaseRequest?.accounting;
-      const mutationPlan = lifecyclePlanningConfigured ? undefined : activeMutationPlan(config);
+      const cleanerSchedule = await readCodexCleanerSchedule({
+        stateDir: config.stateDir,
+        sessionId,
+      });
+      const manualCleanerReserved = cleanerSchedule.outcome === "ready"
+        || cleanerSchedule.outcome === "bypassed";
+      const mutationPlan = manualCleanerReserved || lifecyclePlanningConfigured
+        ? undefined
+        : activeMutationPlan(config);
       let effectiveHistoryViewPromise: ReturnType<typeof buildCodexEffectiveHistoryView> | undefined;
       const buildEffectiveHistoryViewForHead = (): ReturnType<typeof buildCodexEffectiveHistoryView> => {
         if (!requestJournalEntry || typeof originalPayload.previous_response_id !== "string") {
@@ -612,7 +632,94 @@ export async function startCodexResponsesProxy(params: {
         await effectiveHistoryViewForHead()
       ).history;
 
-      if (lifecyclePlanningConfigured) {
+      if (manualCleanerReserved) {
+        if (!config.contextRewrite.enabled) {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["feature_disabled"],
+            fallbackUsed: true,
+          });
+        } else if (!requestJournalEntry) {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["request_journal_unavailable"],
+            fallbackUsed: true,
+          });
+        } else if (typeof originalPayload.previous_response_id !== "string"
+          || !originalPayload.previous_response_id) {
+          await emitContextRewriteStage("context_rewrite_deferred", {
+            reasonCodes: ["response_chain_head_missing"],
+          });
+        } else if (!config.contextRewrite.retryOriginalRequest
+          || config.contextRewrite.mode !== "response_chain_rebase"
+          || config.contextRewrite.failureMode !== "bypass") {
+          await emitContextRewriteStage("context_rewrite_bypassed", {
+            reasonCodes: ["rewrite_configuration_unsupported"],
+            fallbackUsed: true,
+          });
+        } else {
+          try {
+            const effectiveHistoryView = await effectiveHistoryViewForHead();
+            const cleanerResult = await prepareCodexCleanerRebase({
+              stateDir: config.stateDir,
+              sessionId,
+              view: effectiveHistoryView,
+              backendRequest: {
+                sessionId,
+                payload: originalPayload,
+                effectiveHistory: effectiveHistoryView.history,
+                currentInput: originalPayload.input,
+              },
+            });
+            await appendTrace(config.stateDir, {
+              stage: "context_cleaner_runtime_prepared",
+              sessionId,
+              model,
+              outcome: cleanerResult.outcome,
+              reasonCodes: cleanerResult.reasonCodes,
+            });
+            if (cleanerResult.outcome === "ready") {
+              cleanerPreparedRebase = cleanerResult.prepared;
+              activeLifecyclePlan = codexSharedLifecyclePlan(
+                cleanerResult.prepared.execution.mutationPlan,
+              );
+              rebaseRequest = cleanerResult.prepared.rebaseRequest;
+              rebasePlanId = cleanerResult.prepared.execution.mutationPlan.planId;
+              rebaseAccounting = cleanerResult.prepared.rebaseRequest.accounting;
+              activeLifecyclePlan = {
+                ...activeLifecyclePlan,
+                previousRevision: rebaseRequest.oldRevision,
+                nextRevision: rebaseRequest.rebaseRevision,
+                estimatedSavedChars: rebaseRequest.accounting.plannedSavedChars,
+                savedChars: rebaseRequest.accounting.actuallyRemovedChars,
+              };
+              await emitContextRewriteStage("context_rewrite_planned");
+            } else {
+              await emitContextRewriteStage(
+                cleanerResult.outcome === "stale" || cleanerResult.outcome === "reserved"
+                  ? "context_rewrite_deferred"
+                  : "context_rewrite_bypassed",
+                {
+                  reasonCodes: cleanerResult.reasonCodes.length > 0
+                    ? cleanerResult.reasonCodes
+                    : [`cleaner_runtime_${cleanerResult.outcome}`],
+                  fallbackUsed: cleanerResult.outcome !== "stale",
+                },
+              );
+            }
+          } catch (err) {
+            cleanerPreparedRebase = undefined;
+            await appendTrace(config.stateDir, {
+              stage: "context_cleaner_runtime_failed",
+              sessionId,
+              model,
+              reason: err instanceof Error ? err.message : String(err),
+            });
+            await emitContextRewriteStage("context_rewrite_bypassed", {
+              reasonCodes: ["cleaner_runtime_failed"],
+              fallbackUsed: true,
+            });
+          }
+        }
+      } else if (lifecyclePlanningConfigured) {
         if (!config.contextRewrite.enabled) {
           await emitContextRewriteStage("context_rewrite_bypassed", {
             reasonCodes: ["feature_disabled"],
@@ -826,6 +933,7 @@ export async function startCodexResponsesProxy(params: {
       }
 
       const canPrepareContinuationReplay = !rebaseRequest
+        && !manualCleanerReserved
         && requestJournalEntry
         && typeof originalPayload.previous_response_id === "string"
         && config.contextRewrite.providerCompatibilityProbe !== "disabled";
@@ -1284,7 +1392,35 @@ export async function startCodexResponsesProxy(params: {
                 cooldownMs: config.contextRewrite.cooldownMs,
               },
               capabilityStore,
-              executionGuard: lifecyclePreparedPlan
+              executionGuard: cleanerPreparedRebase
+                ? async () => {
+                    let currentView;
+                    try {
+                      currentView = await buildEffectiveHistoryViewForHead();
+                    } catch {
+                      return {
+                        allowed: false,
+                        reason: "cleaner_runtime_snapshot_changed",
+                      };
+                    }
+                    const handoff = await revalidateCodexCleanerPreparedRebase({
+                      stateDir: config.stateDir,
+                      sessionId,
+                      prepared: cleanerPreparedRebase,
+                      view: currentView,
+                      backendRequest: {
+                        sessionId,
+                        payload: originalPayload,
+                        effectiveHistory: currentView.history,
+                        currentInput: originalPayload.input,
+                      },
+                    });
+                    return {
+                      allowed: handoff.valid,
+                      reason: handoff.reasonCodes[0],
+                    };
+                  }
+                : lifecyclePreparedPlan
                 ? async () => {
                     let currentView;
                     try {
@@ -1314,6 +1450,44 @@ export async function startCodexResponsesProxy(params: {
                   }
                 : undefined,
             });
+            if (result.outcome === "committed"
+              && cleanerPreparedRebase
+              && result.epoch?.status === "committed") {
+              const localCommit = await appendCodexCleanerCommitted({
+                stateDir: config.stateDir,
+                sessionId,
+                cleanPlanId: cleanerPreparedRebase.execution.cleanPlanId,
+                mutationPlanId: cleanerPreparedRebase.execution.mutationPlan.planId,
+                epochId: result.epoch.epochId,
+                updatedAt: result.epoch.updatedAt,
+              });
+              if (localCommit.outcome !== "transitioned"
+                && localCommit.outcome !== "unchanged") {
+                await appendTrace(config.stateDir, {
+                  stage: "context_cleaner_local_commit_failed",
+                  sessionId,
+                  model,
+                  reasonCodes: localCommit.reasons,
+                });
+              }
+            }
+            if (result.outcome === "bypassed"
+              && cleanerPreparedRebase
+              && isCodexCleanerStaleReasonCode(result.reason)) {
+              const finalized = await finalizeCodexCleanerHandoffFailure({
+                stateDir: config.stateDir,
+                sessionId,
+                prepared: cleanerPreparedRebase,
+                reasonCodes: [result.reason!],
+              });
+              await appendTrace(config.stateDir, {
+                stage: "context_cleaner_handoff_finalized",
+                sessionId,
+                model,
+                outcome: finalized.outcome,
+                reasonCodes: finalized.reasonCodes,
+              });
+            }
             contextRewriteOutcome = result.outcome;
             contextRewriteValidationPassed = Boolean(result.rebaseResponse)
               || result.outcome === "committed";

--- a/components/adapters/codex/tests/context-cleaner-bridge.test.ts
+++ b/components/adapters/codex/tests/context-cleaner-bridge.test.ts
@@ -24,7 +24,19 @@ import {
   appendCodexResponseJournalEntry,
 } from "../src/context-history/index.js";
 import { createCodexContextCleanerBridge } from "../src/context-cleaner/index.js";
+import { readCodexCleanerSchedule } from "../src/context-cleaner/scheduler.js";
 import { upsertCodexSessionSnapshot } from "../src/session-state.js";
+
+async function withTempState(
+  run: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-bridge-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
 
 function pendingReceipt(
   status: ContextCleanPendingReceipt["status"],
@@ -80,11 +92,12 @@ function fakeControlPlane(): ContextCleanerControlPlane {
 }
 
 test("Codex cleaner bridge preserves approved targets and control-plane receipts", async () => {
+  await withTempState(async (stateDir) => {
   let captured: ExecuteApprovedContextCleanParams | undefined;
   const applied = appliedReceipt();
   const cancelled = terminalReceipt("cancelled");
   const bridge = createCodexContextCleanerBridge({
-    stateDir: "unused-state-dir",
+    stateDir,
     controlPlane: {
       async executeApprovedClean(request) {
         captured = request;
@@ -127,6 +140,14 @@ test("Codex cleaner bridge preserves approved targets and control-plane receipts
     itemIds: ["item-1"],
   });
   assert.strictEqual(await bridge.cancelCleanPlan(request.cleanPlanId), cancelled);
+  const stored = await readCodexCleanerSchedule({ stateDir, sessionId: request.sessionId });
+  assert.equal(stored.outcome, "ready");
+  if (stored.outcome === "ready") {
+    assert.equal(stored.record.cleanPlanId, request.cleanPlanId);
+    assert.equal(stored.record.baseRevision, request.baseRevision);
+    assert.deepEqual(stored.record.selectedTaskIds, ["task-1"]);
+  }
+  });
 });
 
 test("Codex cleaner bridge rejects cross-host approvals before control-plane execution", async () => {
@@ -241,6 +262,38 @@ test("Codex cleaner bridge rejects malformed applied receipts loaded at runtime"
     bridge.readCleanReceipt("clean-plan-1"),
     /codex_clean_receipt_mismatch/,
   );
+});
+
+test("Codex cleaner bridge does not schedule a non-scheduled control-plane receipt", async () => {
+  await withTempState(async (stateDir) => {
+    const bridge = createCodexContextCleanerBridge({
+      stateDir,
+      controlPlane: {
+        ...fakeControlPlane(),
+        async executeApprovedClean() {
+          return pendingReceipt("approved");
+        },
+      },
+    });
+    const receipt = await bridge.executeApprovedClean({
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      cleanPlanId: "clean-plan-1",
+      hostId: "codex",
+      sessionId: "codex-cleaner-session",
+      baseRevision: "revision-before",
+      approvedAt: "2026-08-21T00:00:00.000Z",
+      selectedTasks: [{
+        taskId: "task-1",
+        itemIds: ["item-1"],
+        itemDigests: { "item-1": "digest-1" },
+      }],
+    });
+    assert.equal(receipt.status, "approved");
+    assert.equal((await readCodexCleanerSchedule({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+    })).outcome, "missing");
+  });
 });
 
 test("Codex cleaner bridge lists persisted sessions and reads canonical effective history", async () => {

--- a/components/adapters/codex/tests/context-cleaner-runtime.test.ts
+++ b/components/adapters/codex/tests/context-cleaner-runtime.test.ts
@@ -1,0 +1,776 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  readContextCleanReceipt,
+  saveContextCleanPlan,
+  transitionContextCleanState,
+  type ContextCleanPendingReceipt,
+  type ContextCleanPlan,
+} from "@lightrsi/cleaner";
+import {
+  createEmptySessionTaskRegistry,
+  persistSessionTaskRegistry,
+} from "@lightrsi/history";
+import { reserveUnusedPort } from "@lightrsi/host-adapter";
+
+import { normalizeTokenPilotCodexConfig } from "../src/config.js";
+import type {
+  CodexEffectiveHistoryItem,
+  CodexEffectiveHistoryView,
+  JsonObject,
+} from "../src/context-history/index.js";
+import { buildCodexEffectiveHistoryView } from "../src/context-history/index.js";
+import {
+  appendPendingCodexRebaseEpoch,
+  buildCodexLifecycleBackendRequest,
+  codexSharedContextRewriteBackend,
+  commitCodexRebaseEpoch,
+  type CodexLifecycleBackendRequestBase,
+} from "../src/context-rewrite/index.js";
+import {
+  finalizeCodexCleanerHandoffFailure,
+  prepareCodexCleanerRebase,
+  revalidateCodexCleanerPreparedRebase,
+} from "../src/context-cleaner/runtime.js";
+import {
+  readCodexCleanerSchedule,
+  scheduleCodexCleanerPlan,
+} from "../src/context-cleaner/scheduler.js";
+import { createConsoleLogger } from "../src/logger.js";
+import { startCodexResponsesProxy } from "../src/proxy-runtime.js";
+
+const SESSION_ID = "codex-cleaner-runtime-session";
+const CLEAN_PLAN_ID = "clean-plan-runtime";
+const REVISION = "codex-cleaner-runtime-revision";
+const CREATED_AT = "2026-08-22T00:00:00.000Z";
+
+async function withTempState(
+  run: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-runtime-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+async function readBody(
+  request: Parameters<Parameters<typeof createServer>[0]>[0],
+): Promise<JsonObject> {
+  const text = await new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk) => chunks.push(
+      Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)),
+    ));
+    request.on("error", reject);
+    request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+  });
+  return JSON.parse(text) as JsonObject;
+}
+
+async function listen(server: ReturnType<typeof createServer>): Promise<number> {
+  const port = await reserveUnusedPort();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return port;
+}
+
+async function closeServer(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function startRuntimeUpstream(): Promise<{
+  baseUrl: string;
+  requests: JsonObject[];
+  close(): Promise<void>;
+}> {
+  const requests: JsonObject[] = [];
+  const server = createServer(async (request, response) => {
+    if (request.method !== "POST" || request.url !== "/v1/responses") {
+      response.statusCode = 404;
+      response.end("not found");
+      return;
+    }
+    const payload = await readBody(request);
+    requests.push(payload);
+    const requestNumber = requests.length;
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({
+      id: `response-cleaner-${requestNumber}`,
+      object: "response",
+      status: "completed",
+      output: [{
+        type: "message",
+        role: "assistant",
+        content: [{
+          type: "output_text",
+          text: `KEEP_RESPONSE_cleaner_${requestNumber}`,
+        }],
+      }],
+    }));
+  });
+  const port = await listen(server);
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    close: () => closeServer(server),
+  };
+}
+
+async function startCountingEstimator(): Promise<{
+  baseUrl: string;
+  calls(): number;
+  close(): Promise<void>;
+}> {
+  let calls = 0;
+  const server = createServer(async (request, response) => {
+    await readBody(request);
+    calls += 1;
+    response.statusCode = 200;
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify({
+      id: `estimator-cleaner-${calls}`,
+      status: "completed",
+      output: [{
+        type: "message",
+        role: "assistant",
+        content: [{
+          type: "output_text",
+          text: JSON.stringify({ baseVersion: 0, taskUpdates: [] }),
+        }],
+      }],
+    }));
+  });
+  const port = await listen(server);
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    calls: () => calls,
+    close: () => closeServer(server),
+  };
+}
+
+function effective(stableItemId: string, item: JsonObject): CodexEffectiveHistoryItem {
+  return { stableItemId, item };
+}
+
+function sourceView(
+  revision = REVISION,
+  targetRole: "user" | "system" = "user",
+): CodexEffectiveHistoryView {
+  return {
+    history: {
+      revision,
+      replayableItems: [
+        effective("old-item", {
+          type: "message",
+          role: targetRole,
+          content: "EVICT_ME_cleaner_runtime",
+        }),
+        effective("keep-item", {
+          type: "message",
+          role: "assistant",
+          content: "KEEP_ME_cleaner_runtime",
+        }),
+      ],
+      observationOnlyItems: [],
+      deferredItems: [],
+      unresolvedCallIds: [],
+      source: "proxy_journal",
+      incomplete: false,
+    },
+    turns: [
+      {
+        turnSeq: 1,
+        turnAbsId: `${SESSION_ID}:t1`,
+        inputItemIds: ["old-item"],
+        outputItemIds: [],
+      },
+      {
+        turnSeq: 2,
+        turnAbsId: `${SESSION_ID}:t2`,
+        inputItemIds: [],
+        outputItemIds: ["keep-item"],
+      },
+    ],
+    semanticComplete: true,
+    reasonCodes: [],
+  };
+}
+
+function backendRequest(view: CodexEffectiveHistoryView): CodexLifecycleBackendRequestBase {
+  return {
+    sessionId: SESSION_ID,
+    payload: {
+      model: "gpt-5.4-mini",
+      previous_response_id: "response-parent",
+      input: [{
+        type: "message",
+        role: "user",
+        content: "CURRENT_INPUT_cleaner_runtime",
+      }],
+    },
+    effectiveHistory: view.history,
+    currentInput: [{
+      type: "message",
+      role: "user",
+      content: "CURRENT_INPUT_cleaner_runtime",
+    }],
+  };
+}
+
+function pendingReceipt(
+  status: ContextCleanPendingReceipt["status"],
+): ContextCleanPendingReceipt {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: CLEAN_PLAN_ID,
+    hostId: "codex",
+    sessionId: SESSION_ID,
+    status,
+    selectedTaskIds: status === "analyzed" ? [] : ["task-old"],
+    estimatedSavedTokens: null,
+    estimatedSavedChars: 70,
+    tokenCountMode: "chars_only",
+    deferredTaskIds: [],
+    fallbackUsed: false,
+    reasons: [],
+    updatedAt: status === "analyzed"
+      ? "2026-08-22T00:00:00.000Z"
+      : status === "approved"
+        ? "2026-08-22T00:00:01.000Z"
+        : "2026-08-22T00:00:02.000Z",
+  };
+}
+
+async function seedScheduledClean(
+  stateDir: string,
+  targetRole: "user" | "system" = "user",
+): Promise<{
+  view: CodexEffectiveHistoryView;
+  request: CodexLifecycleBackendRequestBase;
+}> {
+  const view = sourceView(REVISION, targetRole);
+  const registry = createEmptySessionTaskRegistry(SESSION_ID);
+  registry.version = 1;
+  registry.lastProcessedTurnSeq = 2;
+  registry.activeTaskIds = ["task-current"];
+  registry.evictableTaskIds = ["task-old"];
+  registry.turnToTaskIds[`${SESSION_ID}:t1`] = ["task-old"];
+  registry.turnToTaskIds[`${SESSION_ID}:t2`] = ["task-current"];
+  registry.tasks["task-old"] = {
+    taskId: "task-old",
+    title: "old task",
+    objective: "remove completed context",
+    lifecycle: "evictable",
+    completionEvidence: ["completed"],
+    unresolvedQuestions: [],
+    span: { startTurnSeq: 1, endTurnSeq: 1 },
+    coveredTurnAbsIds: [`${SESSION_ID}:t1`],
+    updatedAt: CREATED_AT,
+  };
+  registry.tasks["task-current"] = {
+    taskId: "task-current",
+    title: "current task",
+    objective: "retain active context",
+    lifecycle: "active",
+    completionEvidence: [],
+    unresolvedQuestions: [],
+    span: { startTurnSeq: 2, endTurnSeq: 2 },
+    coveredTurnAbsIds: [`${SESSION_ID}:t2`],
+    updatedAt: CREATED_AT,
+  };
+  await persistSessionTaskRegistry(stateDir, registry);
+
+  const request = backendRequest(view);
+  const attributedRequest = buildCodexLifecycleBackendRequest({ view, registry, request });
+  const snapshot = await codexSharedContextRewriteBackend.readSnapshot({
+    sessionId: SESSION_ID,
+    request: attributedRequest,
+  });
+  const oldItem = snapshot.items.find((item) => item.stableId === "old-item")!;
+  const keepItem = snapshot.items.find((item) => item.stableId === "keep-item")!;
+  const plan: ContextCleanPlan = {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: CLEAN_PLAN_ID,
+    hostId: "codex",
+    sessionId: SESSION_ID,
+    baseRevision: REVISION,
+    model: "gpt-5.4-mini",
+    usedTokens: null,
+    usedChars: oldItem.chars + keepItem.chars,
+    protectedTokens: null,
+    protectedChars: 0,
+    unassignedTokens: null,
+    unassignedChars: 0,
+    tokenCountMode: "chars_only",
+    tokenCountMethod: "utf16_chars",
+    tasks: [
+      {
+        taskId: "task-old",
+        label: "old task",
+        description: "completed old task",
+        summary: "completed",
+        lifecycleState: "completed",
+        itemIds: ["old-item"],
+        itemDigests: { "old-item": oldItem.fingerprint },
+        tokenCount: null,
+        charCount: oldItem.chars,
+        tokenPercent: null,
+        recommendation: "clean",
+        reasonCodes: ["completed"],
+        selectable: true,
+      },
+      {
+        taskId: "task-current",
+        label: "current task",
+        description: "active task",
+        summary: "active",
+        lifecycleState: "active",
+        itemIds: ["keep-item"],
+        itemDigests: { "keep-item": keepItem.fingerprint },
+        tokenCount: null,
+        charCount: keepItem.chars,
+        tokenPercent: null,
+        recommendation: "protected",
+        reasonCodes: ["active_task"],
+        selectable: false,
+      },
+    ],
+    createdAt: CREATED_AT,
+  };
+  assert.equal((await saveContextCleanPlan({ stateDir, plan })).bypassed, false);
+  for (const status of ["analyzed", "approved", "scheduled"] as const) {
+    assert.equal((await transitionContextCleanState({
+      stateDir,
+      receipt: pendingReceipt(status),
+    })).bypassed, false);
+  }
+  assert.equal((await scheduleCodexCleanerPlan({
+    stateDir,
+    sessionId: SESSION_ID,
+    cleanPlanId: CLEAN_PLAN_ID,
+    baseRevision: REVISION,
+    selectedTaskIds: ["task-old"],
+    scheduledAt: pendingReceipt("scheduled").updatedAt,
+  })).outcome, "stored");
+  return { view, request };
+}
+
+test("Codex cleaner runtime prepares only the scheduled manual plan with the existing backend", async () => {
+  await withTempState(async (stateDir) => {
+    const seeded = await seedScheduledClean(stateDir);
+    const result = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view: seeded.view,
+      backendRequest: seeded.request,
+      now: "2026-08-22T00:00:03.000Z",
+    });
+
+    assert.equal(result.outcome, "ready");
+    if (result.outcome !== "ready") return;
+    assert.equal(result.prepared.execution.mutationPlan.sourceModuleId, "cleaner_manual");
+    assert.equal(result.prepared.execution.cleanPlanId, CLEAN_PLAN_ID);
+    assert.doesNotMatch(
+      JSON.stringify(result.prepared.rebaseRequest.payload),
+      /EVICT_ME_cleaner_runtime/,
+    );
+    assert.match(
+      JSON.stringify(result.prepared.rebaseRequest.payload),
+      /KEEP_ME_cleaner_runtime/,
+    );
+    assert.match(
+      JSON.stringify(result.prepared.rebaseRequest.payload),
+      /CURRENT_INPUT_cleaner_runtime/,
+    );
+  });
+});
+
+test("Codex cleaner runtime marks revision drift stale and preserves the original request", async () => {
+  await withTempState(async (stateDir) => {
+    const seeded = await seedScheduledClean(stateDir);
+    const changedView = sourceView("changed-revision");
+    const result = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view: changedView,
+      backendRequest: backendRequest(changedView),
+      now: "2026-08-22T00:00:04.000Z",
+    });
+
+    assert.equal(result.outcome, "stale");
+    assert.deepEqual(result.reasonCodes, ["clean_execution_revision_stale"]);
+    const receipt = await readContextCleanReceipt({ stateDir, planId: CLEAN_PLAN_ID });
+    assert.equal(receipt.value?.status, "stale");
+    assert.equal(receipt.value?.fallbackUsed, false);
+    assert.equal("appliedSavedChars" in (receipt.value ?? {}), false);
+    assert.equal(
+      (await readCodexCleanerSchedule({ stateDir, sessionId: SESSION_ID })).outcome,
+      "terminal",
+    );
+  });
+});
+
+test("Codex cleaner runtime terminates a scheduled plan that targets protected system content", async () => {
+  await withTempState(async (stateDir) => {
+    const seeded = await seedScheduledClean(stateDir, "system");
+    const result = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view: seeded.view,
+      backendRequest: seeded.request,
+      now: "2026-08-22T00:00:04.000Z",
+    });
+
+    assert.equal(result.outcome, "stale");
+    assert.deepEqual(result.reasonCodes, ["clean_execution_protected_item_targeted"]);
+    assert.equal(
+      (await readContextCleanReceipt({ stateDir, planId: CLEAN_PLAN_ID })).value?.status,
+      "stale",
+    );
+    assert.equal(
+      (await readCodexCleanerSchedule({ stateDir, sessionId: SESSION_ID })).outcome,
+      "terminal",
+    );
+  });
+});
+
+test("Codex cleaner runtime never mutates from an adapter-local schedule without shared approval state", async () => {
+  await withTempState(async (stateDir) => {
+    const view = sourceView();
+    assert.equal((await scheduleCodexCleanerPlan({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: CLEAN_PLAN_ID,
+      baseRevision: REVISION,
+      selectedTaskIds: ["task-old"],
+      scheduledAt: "2026-08-22T00:00:02.000Z",
+    })).outcome, "stored");
+
+    const result = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view,
+      backendRequest: backendRequest(view),
+    });
+    assert.equal(result.outcome, "reserved");
+    assert.ok(result.reasonCodes.includes("clean_execution_missing"));
+    assert.equal("prepared" in result, false);
+  });
+});
+
+test("Codex cleaner runtime repairs the crash window after a committed rebase epoch", async () => {
+  await withTempState(async (stateDir) => {
+    const seeded = await seedScheduledClean(stateDir);
+    const first = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view: seeded.view,
+      backendRequest: seeded.request,
+    });
+    assert.equal(first.outcome, "ready");
+    if (first.outcome !== "ready") return;
+
+    await appendPendingCodexRebaseEpoch({
+      stateDir,
+      sessionId: SESSION_ID,
+      planId: first.prepared.execution.mutationPlan.planId,
+      epochId: "epoch-crash-window",
+      oldPreviousResponseId: "response-parent",
+      oldRevision: first.prepared.rebaseRequest.oldRevision,
+    });
+    await commitCodexRebaseEpoch({
+      stateDir,
+      sessionId: SESSION_ID,
+      epochId: "epoch-crash-window",
+      newResponseId: "response-after-clean",
+      newRevision: first.prepared.rebaseRequest.rebaseRevision,
+      updatedAt: "2026-08-22T00:00:05.000Z",
+    });
+
+    const recovered = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view: seeded.view,
+      backendRequest: seeded.request,
+      now: "2026-08-22T00:00:06.000Z",
+    });
+    assert.equal(recovered.outcome, "committed");
+    const local = await readCodexCleanerSchedule({ stateDir, sessionId: SESSION_ID });
+    assert.equal(local.outcome, "committed");
+    if (local.outcome === "committed") {
+      assert.equal(local.record.epochId, "epoch-crash-window");
+      assert.equal(
+        local.record.mutationPlanId,
+        first.prepared.execution.mutationPlan.planId,
+      );
+    }
+  });
+});
+
+test("Codex cleaner runtime handoff rejects fingerprint drift before provider execution", async () => {
+  await withTempState(async (stateDir) => {
+    const seeded = await seedScheduledClean(stateDir);
+    const prepared = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view: seeded.view,
+      backendRequest: seeded.request,
+      now: "2026-08-22T00:00:03.000Z",
+    });
+    assert.equal(prepared.outcome, "ready");
+    if (prepared.outcome !== "ready") return;
+
+    const changedView = structuredClone(seeded.view);
+    changedView.history.replayableItems[0]!.item.content = "history changed after prepare";
+    const handoff = await revalidateCodexCleanerPreparedRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      prepared: prepared.prepared,
+      view: changedView,
+      backendRequest: backendRequest(changedView),
+    });
+    assert.equal(handoff.valid, false);
+    assert.ok(handoff.reasonCodes.includes("clean_execution_item_stale"));
+
+    const finalized = await finalizeCodexCleanerHandoffFailure({
+      stateDir,
+      sessionId: SESSION_ID,
+      prepared: prepared.prepared,
+      reasonCodes: handoff.reasonCodes,
+      now: "2026-08-22T00:00:04.000Z",
+    });
+    assert.equal(finalized.outcome, "stale");
+    assert.equal(
+      (await readContextCleanReceipt({ stateDir, planId: CLEAN_PLAN_ID })).value?.status,
+      "stale",
+    );
+  });
+});
+
+test("Codex proxy gives the scheduled manual cleaner exclusive ownership of the next request", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-cleaner-proxy-session";
+    const cleanPlanId = "clean-plan-proxy";
+    const upstream = await startRuntimeUpstream();
+    const estimator = await startCountingEstimator();
+    let runtime: Awaited<ReturnType<typeof startCodexResponsesProxy>> | undefined;
+    try {
+      const config = normalizeTokenPilotCodexConfig({
+        stateDir,
+        proxyPort: await reserveUnusedPort(),
+        upstreamProvider: "OpenAI",
+        upstream: {
+          baseUrl: upstream.baseUrl,
+          wireApi: "responses",
+          requiresOpenAIAuth: false,
+        },
+        modules: { stabilizer: false, reduction: false },
+        taskStateEstimator: {
+          enabled: true,
+          baseUrl: estimator.baseUrl,
+          apiKey: "synthetic-estimator-key",
+          model: "synthetic-estimator",
+          batchTurns: 1,
+        },
+        contextRewrite: {
+          enabled: true,
+          providerCompatibilityProbe: "mock_fixture",
+        },
+      } as any);
+      runtime = await startCodexResponsesProxy({
+        config,
+        logger: createConsoleLogger(false),
+        allowMockFixtureEvidence: true,
+      });
+
+      const send = async (payload: JsonObject) => fetch(`${runtime!.baseUrl}/responses`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      assert.equal((await send({
+        model: "gpt-5.4-mini",
+        stream: false,
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "KEEP_INITIAL_cleaner_proxy" }],
+      })).status, 200);
+      assert.equal((await send({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "response-cleaner-1",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "EVICT_ME_cleaner_proxy" }],
+      })).status, 200);
+
+      const view = await buildCodexEffectiveHistoryView({
+        stateDir,
+        sessionId,
+        headResponseId: "response-cleaner-2",
+      });
+      const selectedItem = view.history.replayableItems.find((item) => (
+        JSON.stringify(item.item).includes("EVICT_ME_cleaner_proxy")
+      ));
+      assert.ok(selectedItem);
+      const registry = createEmptySessionTaskRegistry(sessionId);
+      registry.version = 1;
+      registry.lastProcessedTurnSeq = Math.max(...view.turns.map((turn) => turn.turnSeq));
+      registry.evictableTaskIds = ["task-proxy-old"];
+      registry.blockToTaskIds[selectedItem.stableItemId] = ["task-proxy-old"];
+      registry.tasks["task-proxy-old"] = {
+        taskId: "task-proxy-old",
+        title: "old proxy task",
+        objective: "remove the approved old request",
+        lifecycle: "evictable",
+        completionEvidence: ["completed"],
+        unresolvedQuestions: [],
+        span: { startTurnSeq: 2, endTurnSeq: 2 },
+        coveredTurnAbsIds: [],
+        updatedAt: CREATED_AT,
+      };
+      await persistSessionTaskRegistry(stateDir, registry);
+
+      const baseRequest: CodexLifecycleBackendRequestBase = {
+        sessionId,
+        payload: {
+          model: "gpt-5.4-mini",
+          previous_response_id: "response-cleaner-2",
+          input: [],
+        },
+        effectiveHistory: view.history,
+        currentInput: [],
+      };
+      const attributed = buildCodexLifecycleBackendRequest({
+        view,
+        registry,
+        request: baseRequest,
+      });
+      const snapshot = await codexSharedContextRewriteBackend.readSnapshot({
+        sessionId,
+        request: attributed,
+      });
+      const selectedSnapshotItem = snapshot.items.find(
+        (item) => item.stableId === selectedItem.stableItemId,
+      )!;
+      const totalChars = snapshot.items.reduce((sum, item) => sum + item.chars, 0);
+      const plan: ContextCleanPlan = {
+        schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+        planId: cleanPlanId,
+        hostId: "codex",
+        sessionId,
+        baseRevision: snapshot.revision,
+        model: "gpt-5.4-mini",
+        usedTokens: null,
+        usedChars: totalChars,
+        protectedTokens: null,
+        protectedChars: 0,
+        unassignedTokens: null,
+        unassignedChars: totalChars - selectedSnapshotItem.chars,
+        tokenCountMode: "chars_only",
+        tokenCountMethod: "utf16_chars",
+        tasks: [{
+          taskId: "task-proxy-old",
+          label: "old proxy task",
+          description: "approved old request",
+          summary: "completed",
+          lifecycleState: "completed",
+          itemIds: [selectedItem.stableItemId],
+          itemDigests: { [selectedItem.stableItemId]: selectedSnapshotItem.fingerprint },
+          tokenCount: null,
+          charCount: selectedSnapshotItem.chars,
+          tokenPercent: null,
+          recommendation: "clean",
+          reasonCodes: ["completed"],
+          selectable: true,
+        }],
+        createdAt: CREATED_AT,
+      };
+      assert.equal((await saveContextCleanPlan({ stateDir, plan })).bypassed, false);
+      const receiptFor = (status: ContextCleanPendingReceipt["status"]): ContextCleanPendingReceipt => ({
+        schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+        planId: cleanPlanId,
+        hostId: "codex",
+        sessionId,
+        status,
+        selectedTaskIds: status === "analyzed" ? [] : ["task-proxy-old"],
+        estimatedSavedTokens: null,
+        estimatedSavedChars: selectedSnapshotItem.chars,
+        tokenCountMode: "chars_only",
+        deferredTaskIds: [],
+        fallbackUsed: false,
+        reasons: [],
+        updatedAt: status === "analyzed"
+          ? "2026-08-22T00:01:00.000Z"
+          : status === "approved"
+            ? "2026-08-22T00:01:01.000Z"
+            : "2026-08-22T00:01:02.000Z",
+      });
+      for (const status of ["analyzed", "approved", "scheduled"] as const) {
+        assert.equal((await transitionContextCleanState({
+          stateDir,
+          receipt: receiptFor(status),
+        })).bypassed, false);
+      }
+      assert.equal((await scheduleCodexCleanerPlan({
+        stateDir,
+        sessionId,
+        cleanPlanId,
+        baseRevision: snapshot.revision,
+        selectedTaskIds: ["task-proxy-old"],
+        scheduledAt: receiptFor("scheduled").updatedAt,
+      })).outcome, "stored");
+      const estimatorCallsBeforeManualRequest = estimator.calls();
+
+      assert.equal((await send({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "response-cleaner-2",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "CURRENT_KEEP_cleaner_proxy" }],
+      })).status, 200);
+
+      assert.equal(estimator.calls(), estimatorCallsBeforeManualRequest);
+      assert.equal(upstream.requests.length, 3);
+      assert.equal(upstream.requests[2]?.previous_response_id, undefined);
+      const outgoing = JSON.stringify(upstream.requests[2]);
+      assert.doesNotMatch(outgoing, /EVICT_ME_cleaner_proxy/);
+      assert.match(outgoing, /KEEP_RESPONSE_cleaner_1/);
+      assert.match(outgoing, /CURRENT_KEEP_cleaner_proxy/);
+      assert.equal(
+        (await readCodexCleanerSchedule({ stateDir, sessionId })).outcome,
+        "committed",
+      );
+      assert.equal(
+        (await readContextCleanReceipt({ stateDir, planId: cleanPlanId })).value?.status,
+        "scheduled",
+      );
+
+      const estimatorCallsAfterManualCommit = estimator.calls();
+      assert.equal((await send({
+        model: "gpt-5.4-mini",
+        stream: false,
+        previous_response_id: "response-cleaner-3",
+        metadata: { tokenpilotSessionId: sessionId },
+        input: [{ role: "user", content: "AUTOMATIC_RESUMES_cleaner_proxy" }],
+      })).status, 200);
+      assert.ok(estimator.calls() > estimatorCallsAfterManualCommit);
+    } finally {
+      await runtime?.close();
+      await estimator.close();
+      await upstream.close();
+    }
+  });
+});

--- a/components/adapters/codex/tests/context-cleaner-scheduler.test.ts
+++ b/components/adapters/codex/tests/context-cleaner-scheduler.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { appendFile, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  acquireCodexRebaseSessionLock,
+} from "../src/context-rewrite/index.js";
+import {
+  appendCodexCleanerCommitted,
+  appendCodexCleanerTerminal,
+  codexCleanerScheduleJournalPath,
+  readCodexCleanerSchedule,
+  scheduleCodexCleanerPlan,
+} from "../src/context-cleaner/scheduler.js";
+
+async function withTempState(
+  run: (stateDir: string) => Promise<void>,
+): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-scheduler-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+const scheduledAt = "2026-08-22T00:00:00.000Z";
+
+function scheduleParams(stateDir: string) {
+  return {
+    stateDir,
+    sessionId: "codex-cleaner-session",
+    cleanPlanId: "clean-plan-1",
+    baseRevision: "revision-1",
+    selectedTaskIds: ["task-1", "task-2"],
+    scheduledAt,
+  };
+}
+
+test("Codex cleaner scheduler persists only the approved plan reference and is idempotent", async () => {
+  await withTempState(async (stateDir) => {
+    const first = await scheduleCodexCleanerPlan(scheduleParams(stateDir));
+    const duplicate = await scheduleCodexCleanerPlan(scheduleParams(stateDir));
+    const reorderedDuplicate = await scheduleCodexCleanerPlan({
+      ...scheduleParams(stateDir),
+      selectedTaskIds: ["task-2", "task-1"],
+    });
+
+    assert.equal(first.outcome, "stored");
+    assert.equal(duplicate.outcome, "unchanged");
+    assert.deepEqual(duplicate.record, first.record);
+    assert.equal(reorderedDuplicate.outcome, "unchanged");
+    assert.deepEqual(reorderedDuplicate.record, first.record);
+
+    const read = await readCodexCleanerSchedule({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+    });
+    assert.equal(read.outcome, "ready");
+    if (read.outcome !== "ready") return;
+    assert.deepEqual(read.record.selectedTaskIds, ["task-1", "task-2"]);
+    assert.equal(read.record.baseRevision, "revision-1");
+
+    const raw = await readFile(
+      codexCleanerScheduleJournalPath(stateDir, "codex-cleaner-session"),
+      "utf8",
+    );
+    assert.equal(raw.includes("itemIds"), false);
+    assert.equal(raw.includes("itemDigests"), false);
+    assert.equal(raw.trim().split(/\r?\n/u).length, 1);
+  });
+});
+
+test("Codex cleaner scheduler rejects conflicting pending plans and selections", async () => {
+  await withTempState(async (stateDir) => {
+    assert.equal(
+      (await scheduleCodexCleanerPlan(scheduleParams(stateDir))).outcome,
+      "stored",
+    );
+
+    const changedSelection = await scheduleCodexCleanerPlan({
+      ...scheduleParams(stateDir),
+      selectedTaskIds: ["task-1"],
+    });
+    assert.equal(changedSelection.outcome, "conflict");
+    assert.deepEqual(changedSelection.reasons, ["cleaner_schedule_identity_conflict"]);
+
+    const secondPlan = await scheduleCodexCleanerPlan({
+      ...scheduleParams(stateDir),
+      cleanPlanId: "clean-plan-2",
+    });
+    assert.equal(secondPlan.outcome, "conflict");
+    assert.deepEqual(secondPlan.reasons, ["cleaner_schedule_pending_conflict"]);
+  });
+});
+
+test("Codex cleaner scheduler uses the existing rebase session lock", async () => {
+  await withTempState(async (stateDir) => {
+    const lock = await acquireCodexRebaseSessionLock({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+    });
+    assert.ok(lock);
+    try {
+      const blocked = await scheduleCodexCleanerPlan(scheduleParams(stateDir));
+      assert.equal(blocked.outcome, "bypassed");
+      assert.deepEqual(blocked.reasons, ["cleaner_schedule_lock_busy"]);
+    } finally {
+      await lock.release();
+    }
+  });
+});
+
+test("Codex cleaner scheduler survives restart and terminal records are not active", async () => {
+  await withTempState(async (stateDir) => {
+    await scheduleCodexCleanerPlan(scheduleParams(stateDir));
+    assert.equal(
+      (await readCodexCleanerSchedule({
+        stateDir,
+        sessionId: "codex-cleaner-session",
+      })).outcome,
+      "ready",
+    );
+
+    const terminal = await appendCodexCleanerTerminal({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+      cleanPlanId: "clean-plan-1",
+      receiptStatus: "stale",
+      reasons: ["clean_execution_revision_stale"],
+      updatedAt: "2026-08-22T00:00:01.000Z",
+    });
+    assert.equal(terminal.outcome, "transitioned");
+
+    const restored = await readCodexCleanerSchedule({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+    });
+    assert.equal(restored.outcome, "terminal");
+    if (restored.outcome !== "terminal") return;
+    assert.equal(restored.record.receiptStatus, "stale");
+  });
+});
+
+test("Codex cleaner scheduler preserves a local committed marker without creating an applied receipt", async () => {
+  await withTempState(async (stateDir) => {
+    await scheduleCodexCleanerPlan(scheduleParams(stateDir));
+    const committed = await appendCodexCleanerCommitted({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+      cleanPlanId: "clean-plan-1",
+      mutationPlanId: "ctxcleanplan-v1-digest",
+      epochId: "epoch-clean-1",
+      updatedAt: "2026-08-22T00:00:02.000Z",
+    });
+    assert.equal(committed.outcome, "transitioned");
+
+    const restored = await readCodexCleanerSchedule({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+    });
+    assert.equal(restored.outcome, "committed");
+    if (restored.outcome !== "committed") return;
+    assert.equal(restored.record.mutationPlanId, "ctxcleanplan-v1-digest");
+    assert.equal(restored.record.epochId, "epoch-clean-1");
+    assert.equal("appliedSavedChars" in restored.record, false);
+    assert.equal("evidence" in restored.record, false);
+
+    const conflict = await appendCodexCleanerCommitted({
+      stateDir,
+      sessionId: "codex-cleaner-session",
+      cleanPlanId: "clean-plan-1",
+      mutationPlanId: "ctxcleanplan-v1-different",
+      epochId: "epoch-clean-different",
+      updatedAt: "2026-08-22T00:00:03.000Z",
+    });
+    assert.equal(conflict.outcome, "conflict");
+    assert.deepEqual(conflict.reasons, ["cleaner_schedule_terminal_conflict"]);
+  });
+});
+
+test("Codex cleaner scheduler fails closed on malformed or cross-session journal rows", async () => {
+  await withTempState(async (stateDir) => {
+    const sessionId = "codex-cleaner-session";
+    await scheduleCodexCleanerPlan(scheduleParams(stateDir));
+    await appendFile(
+      codexCleanerScheduleJournalPath(stateDir, sessionId),
+      [
+        "not-json",
+        JSON.stringify({
+          schema: "lightrsi.codex.cleaner-schedule/v1",
+          hostId: "codex",
+          sessionId: "different-session",
+          cleanPlanId: "clean-plan-other",
+          baseRevision: "revision-other",
+          selectedTaskIds: ["task-other"],
+          status: "scheduled",
+          scheduledAt,
+          updatedAt: scheduledAt,
+        }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const read = await readCodexCleanerSchedule({ stateDir, sessionId });
+    assert.equal(read.outcome, "bypassed");
+    assert.deepEqual(read.reasons, ["cleaner_schedule_journal_malformed"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Persist validated `scheduled` Cleaner receipts as adapter-local, per-session schedule references without copying approved item IDs, item digests, or raw Host payloads.
- Apply approved clean plans at the next safe Codex Responses request boundary through the shared Host execution bridge and existing response-chain rebase backend.
- Revalidate shared plan/receipt state, revision, item fingerprints, task attribution, lifecycle state, and protocol closure before provider execution.
- Give the scheduled manual Cleaner exclusive mutation ownership for the request and preserve the original request on stale or fallback paths.
- Recover committed rebase epochs after restart while keeping the local committed marker separate from the shared `applied` receipt.

## Safety boundaries

- Adapter-local schedule records are not Cleaner approval authority and cannot select or replace approved items.
- System/developer content and protocol-unsafe targets terminate as stale instead of remaining pending.
- Reordered retries containing the same selected task set are idempotent.
- Lifecycle cleaning resumes only after the scheduled manual operation becomes terminal or committed.
- This PR does not create shared applied receipts or report actual clean savings; that remains the next PR.
- This PR contains only Codex adapter implementation and tests.

## Validation

- `pnpm --dir components/adapters/codex test` — 404/404 passed
- `pnpm --dir components/adapters/codex typecheck` — passed
- `pnpm check:boundaries` — passed, 18 packages / 66 internal edges
- `pnpm typecheck` — passed
- `pnpm build` — passed
- `git diff --check` — passed