### PR TITLE
feat(gateway): preserve transparent provider forwarding

### DIFF
--- a/components/adapters/claude-code/src/upstream.ts
+++ b/components/adapters/claude-code/src/upstream.ts
@@ -7,6 +7,7 @@ import type {
 } from "@lightrsi/host-adapter";
 import {
   buildGatewayForwardHeaders,
+  forwardGatewayRawRequest,
   readJsonFile,
   resolveGatewayRequestUrl,
   writeJsonFileAtomic,
@@ -204,5 +205,6 @@ export function createClaudeCodeGatewayForwarder(config: TokenPilotClaudeCodeCon
   return {
     request,
     requestStream,
+    requestRaw: forwardGatewayRawRequest,
   };
 }

--- a/components/adapters/claude-code/tests/context-rewrite-acceptance.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-acceptance.test.ts
@@ -25,6 +25,9 @@ const TEST_UUID = "123e4567-e89b-42d3-a456-426614174000";
 
 function createClaudeForwarder(upstreamUrl: string): HostGatewayForwarder {
   return {
+    async requestRaw() {
+      throw new Error("requestRaw not used in test");
+    },
     async request({ payload }) {
       const response = await fetch(`${upstreamUrl}/v1/messages`, {
         method: "POST",

--- a/components/adapters/claude-code/tests/context-rewrite-session-binding.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-session-binding.test.ts
@@ -32,6 +32,9 @@ async function reserveUnusedPort(): Promise<number> {
 
 function okForwarder(): HostGatewayForwarder {
   return {
+    async requestRaw() {
+      throw new Error("requestRaw not used in test");
+    },
     async request() {
       return {
         status: 200,

--- a/components/adapters/claude-code/tests/context-rewrite-streaming-overlay.test.ts
+++ b/components/adapters/claude-code/tests/context-rewrite-streaming-overlay.test.ts
@@ -38,6 +38,9 @@ test("gateway overlay applies on the streaming path", async () => {
   const proxyPort = await reserveUnusedPort();
   const seenStreamPayloads: Array<Record<string, unknown>> = [];
   const forwarder: HostGatewayForwarder = {
+    async requestRaw() {
+      throw new Error("requestRaw not used in test");
+    },
     async request() {
       throw new Error("non-stream path should not be used in this test");
     },

--- a/components/adapters/claude-code/tests/e2e.test.ts
+++ b/components/adapters/claude-code/tests/e2e.test.ts
@@ -42,6 +42,9 @@ test("Claude Code host e2e wires install, gateway reduction, report/visual, and 
     const seenPayloads: Array<Record<string, unknown>> = [];
     const longToolPayload = createLongToolPayload();
     const forwarder: HostGatewayForwarder = {
+      async requestRaw() {
+        throw new Error("requestRaw not used in test");
+      },
       async request(params) {
         seenPayloads.push(params.payload as Record<string, unknown>);
         return {

--- a/components/adapters/claude-code/tests/gateway-runtime.test.ts
+++ b/components/adapters/claude-code/tests/gateway-runtime.test.ts
@@ -87,6 +87,9 @@ test("gateway runtime serves health and forwards Claude Messages requests", asyn
   const proxyPort = await reserveUnusedPort();
   const seenPayloads: unknown[] = [];
   const forwarder: HostGatewayForwarder = {
+    async requestRaw() {
+      throw new Error("requestRaw not used in test");
+    },
     async request(params) {
       seenPayloads.push(params.payload);
       return {
@@ -183,6 +186,7 @@ test("gateway snapshot persistence is fail-open and logs only reported failures"
       error() {},
     },
     forwarder: {
+      requestRaw: async () => { throw new Error("requestRaw not used in test"); },
       async request() {
         return {
           status: 200,
@@ -260,6 +264,7 @@ test("gateway persists an unassigned snapshot when task registry recovery fails"
       error() {},
     },
     forwarder: {
+      requestRaw: async () => { throw new Error("requestRaw not used in test"); },
       async request() {
         return {
           status: 200,
@@ -342,6 +347,7 @@ test("gateway publishes only block-proven task attribution from the persisted re
     }),
     logger: createConsoleLogger(false),
     forwarder: {
+      requestRaw: async () => { throw new Error("requestRaw not used in test"); },
       async request() {
         return {
           status: 200,
@@ -653,6 +659,7 @@ test("gateway runtime records session-state and ux-effects after a reduced reque
   const proxyPort = await reserveUnusedPort();
   const longToolPayload = `payload\n${"line\n".repeat(800)}`;
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request() {
       return {
         status: 200,
@@ -763,6 +770,7 @@ test("gateway runtime reuses the latest real Claude hook session when request ma
   const stateDir = join(dir, "state");
   const longToolPayload = `payload\n${"line\n".repeat(800)}`;
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request() {
       return {
         status: 200,
@@ -854,6 +862,7 @@ export function saveConfig(file: string, text: string) {
 `.repeat(30);
   const seenPayloads: Array<Record<string, unknown>> = [];
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -959,6 +968,7 @@ test("gateway runtime does not record ux-effects when reduced request fails upst
   const proxyPort = await reserveUnusedPort();
   const longToolPayload = `payload\n${"line\n".repeat(800)}`;
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request() {
       throw new Error("upstream failed");
     },
@@ -1027,6 +1037,7 @@ test("gateway runtime applies stable-prefix rewrite before forwarding", async ()
   const proxyPort = await reserveUnusedPort();
   const seenPayloads: Record<string, unknown>[] = [];
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -1103,6 +1114,7 @@ test("gateway runtime supports developer-targeted stable-prefix injection", asyn
   const proxyPort = await reserveUnusedPort();
   const seenPayloads: Record<string, unknown>[] = [];
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -1181,6 +1193,7 @@ test("gateway runtime reuses the same Claude prompt_cache_key for the same stabl
   const proxyPort = await reserveUnusedPort();
   const seenPayloads: Record<string, unknown>[] = [];
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -1252,6 +1265,7 @@ test("gateway runtime preserves inbound Claude prompt_cache_key while converging
   const proxyPort = await reserveUnusedPort();
   const seenPayloads: Record<string, unknown>[] = [];
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -1422,6 +1436,7 @@ test("gateway eviction preserves tool closure and the active user turn", async (
   const proxyPort = await reserveUnusedPort();
   const seenPayloads: Array<Record<string, unknown>> = [];
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -1536,6 +1551,7 @@ test("gateway relocates a persisted plan onto shifted history across turns", asy
   const proxyPort = await reserveUnusedPort();
   const seenPayloads: Array<Record<string, unknown>> = [];
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -1652,6 +1668,7 @@ test("gateway runs the semantic pipeline when an estimator is injected, and stay
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-claude-gateway-semantic-"));
   const proxyPort = await reserveUnusedPort();
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request() {
       return {
         status: 200,
@@ -1709,6 +1726,7 @@ test("gateway persists a task registry when the injected estimator returns updat
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-claude-gateway-semantic-ok-"));
   const proxyPort = await reserveUnusedPort();
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request() {
       return {
         status: 200,
@@ -1787,6 +1805,7 @@ test("lifecycle estimator rewrites the real Claude upstream payload", async () =
   const seenPayloads: Array<Record<string, unknown>> = [];
   const bigToolResult = "EVICT_ME_" + "x".repeat(5000);
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {
@@ -1909,6 +1928,7 @@ test("lifecycle registry persistence failure bypasses the plan and heuristic fal
   const seenPayloads: Array<Record<string, unknown>> = [];
   const bigToolResult = "EVICT_ME_" + "x".repeat(5000);
   const forwarder: HostGatewayForwarder = {
+    requestRaw: async () => { throw new Error("requestRaw not used in test"); },
     async request(params) {
       seenPayloads.push(params.payload as Record<string, unknown>);
       return {

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createServer } from "node:http";
 import { mkdir } from "node:fs/promises";
+import { performance } from "node:perf_hooks";
+import { Readable, Transform } from "node:stream";
 import {
   findFirstMessageText,
   prepareObservedBeforeCall,
@@ -15,6 +17,7 @@ import {
   type HostRequestEnvelope,
   prepareBeforeCallWithReductionSummary,
   recordUxEffect,
+  forwardGatewayRawRequest,
   sendJsonResponse,
   startHostGatewayRuntimeServer,
   setForwardResponseHeaders,
@@ -389,6 +392,155 @@ function canAttemptCodexRebase(params: {
   );
 }
 
+function upstreamRequestPath(baseUrl: string, inboundPath: string): string {
+  const base = baseUrl.replace(/\/+$/, "");
+  if (base.endsWith("/v1")) {
+    return inboundPath.startsWith("/v1") ? inboundPath.slice(3) || "/" : inboundPath;
+  }
+  return inboundPath.startsWith("/v1") ? inboundPath : `/v1${inboundPath}`;
+}
+
+async function forwardPureProviderWire(params: {
+  upstream: Awaited<ReturnType<typeof resolveUpstreamProvider>>;
+  req: import("node:http").IncomingMessage;
+  res: import("node:http").ServerResponse;
+  pathname: string;
+  body: string;
+  controller: AbortController;
+  stateDir: string;
+  requestStartedAt: number;
+  bodyReceivedAt: number;
+}): Promise<void> {
+  const requestId = randomUUID();
+  const dispatchAt = performance.now();
+  const requestBytes = Buffer.byteLength(params.body, "utf8");
+  let responseStatus: number | null = null;
+  let headersAt: number | null = null;
+  let firstResponseBodyChunkAt: number | null = null;
+  let lastResponseBodyChunkAt: number | null = null;
+  let downstreamFinishAt: number | null = null;
+  let abortSource: string | null = null;
+  const traceTiming = () => ({
+    pre_upstream_ms: dispatchAt - params.requestStartedAt,
+    body_received_ms: params.bodyReceivedAt - params.requestStartedAt,
+    upstream_headers_ms: headersAt === null ? null : headersAt - dispatchAt,
+    upstream_first_chunk_ms: firstResponseBodyChunkAt === null || headersAt === null
+      ? null
+      : firstResponseBodyChunkAt - headersAt,
+    upstream_stream_ms: firstResponseBodyChunkAt === null || lastResponseBodyChunkAt === null
+      ? null
+      : lastResponseBodyChunkAt - firstResponseBodyChunkAt,
+    downstream_drain_ms: downstreamFinishAt === null
+      ? null
+      : downstreamFinishAt - (lastResponseBodyChunkAt ?? headersAt ?? dispatchAt),
+    total_ms: downstreamFinishAt === null ? null : downstreamFinishAt - params.requestStartedAt,
+  });
+  const appendTimingTrace = (stage: string, extra: Record<string, unknown> = {}) => {
+    void appendTrace(params.stateDir, {
+      stage,
+      requestId,
+      method: params.req.method ?? "POST",
+      pathname: params.pathname,
+      requestBytes,
+      responseStatus,
+      hasResponseBody: firstResponseBodyChunkAt !== null,
+      ...traceTiming(),
+      ...extra,
+    }).catch(() => {});
+  };
+  params.req.once("aborted", () => {
+    abortSource = "request_aborted";
+    params.controller.abort();
+  });
+  params.res.once("close", () => {
+    abortSource = params.res.writableFinished ? "response_close_after_finish" : "response_close_before_finish";
+    params.controller.abort();
+  });
+  try {
+    const authorization = params.req.headers.authorization;
+    const inboundAuthorization = Array.isArray(authorization)
+      ? authorization.join(", ")
+      : authorization;
+    const response = await forwardGatewayRawRequest({
+      upstream: {
+        baseUrl: params.upstream.baseUrl,
+        apiKey: params.upstream.apiKey,
+        name: params.upstream.name,
+        protocol: "custom",
+      },
+      method: params.req.method ?? "POST",
+      requestPath: upstreamRequestPath(params.upstream.baseUrl, params.pathname),
+      body: params.body,
+      inboundAuthorization,
+      inboundHeaders: params.req.headers,
+      includeJsonContentType: false,
+      signal: params.controller.signal,
+    });
+    responseStatus = response.status;
+    headersAt = performance.now();
+    params.res.statusCode = response.status;
+    setForwardResponseHeaders(
+      params.res,
+      Object.fromEntries(response.headers.entries()),
+      "application/octet-stream",
+    );
+    if (!response.body) {
+      await new Promise<void>((resolve, reject) => {
+        params.res.once("finish", resolve);
+        params.res.once("error", reject);
+        params.res.end();
+      });
+      downstreamFinishAt = performance.now();
+      appendTimingTrace("pure_forward_timing", { hasResponseBody: false });
+      return;
+    }
+    const observer = new Transform({
+      transform(chunk, _encoding, callback) {
+        const now = performance.now();
+        if (firstResponseBodyChunkAt === null) firstResponseBodyChunkAt = now;
+        lastResponseBodyChunkAt = now;
+        callback(null, chunk);
+      },
+    });
+    const upstreamStream = Readable.fromWeb(response.body as any);
+    await new Promise<void>((resolve, reject) => {
+      params.res.once("finish", () => {
+        downstreamFinishAt = performance.now();
+        resolve();
+      });
+      params.res.once("error", reject);
+      upstreamStream.once("error", reject);
+      observer.once("error", reject);
+      upstreamStream.pipe(observer).pipe(params.res);
+    });
+    appendTimingTrace("pure_forward_timing");
+  } catch (error) {
+    if (params.controller.signal.aborted || params.res.destroyed) {
+      appendTimingTrace("pure_forward_cancelled", {
+        abortSource,
+        responseDestroyed: params.res.destroyed,
+        responseWritableEnded: params.res.writableEnded,
+        responseWritableFinished: params.res.writableFinished,
+      });
+      return;
+    }
+    if (!params.res.headersSent) {
+      sendJsonResponse(params.res, 502, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } else {
+      params.res.destroy(error instanceof Error ? error : new Error(String(error)));
+    }
+    appendTimingTrace("pure_forward_failed", {
+      errorClass: error instanceof Error ? error.name : "unknown",
+      abortSource,
+      responseDestroyed: params.res.destroyed,
+      responseWritableEnded: params.res.writableEnded,
+      responseWritableFinished: params.res.writableFinished,
+    });
+  }
+}
+
 export async function startCodexResponsesProxy(params: {
   config: TokenPilotCodexConfig;
   logger: TokenPilotCodexLogger;
@@ -473,6 +625,42 @@ export async function startCodexResponsesProxy(params: {
       adapter: "tokenpilot-codex",
       upstream: upstreamProviderName,
       stateDir: config.stateDir,
+    },
+    async handleRoute({ req, res, pathname, readBody }) {
+      if (!config.proxyMode.pureForward
+        || req.method !== "POST"
+        || !["/v1/responses", "/v1/chat/completions"].includes(pathname)) {
+        return false;
+      }
+      const requestStartedAt = performance.now();
+      const controller = new AbortController();
+      const onRequestAborted = () => controller.abort();
+      const onResponseClose = () => {
+        if (!res.writableFinished) controller.abort();
+      };
+      req.once("aborted", onRequestAborted);
+      res.once("close", onResponseClose);
+      try {
+        const body = await readBody(controller.signal);
+        const bodyReceivedAt = performance.now();
+        await forwardPureProviderWire({
+          upstream,
+          req,
+          res,
+          pathname,
+          body,
+          controller,
+          stateDir: config.stateDir,
+          requestStartedAt,
+          bodyReceivedAt,
+        });
+      } catch (error) {
+        if (!controller.signal.aborted && !res.destroyed) throw error;
+      } finally {
+        req.off("aborted", onRequestAborted);
+        res.off("close", onResponseClose);
+      }
+      return true;
     },
     async handleRequest({ req, res, body }) {
       const inboundPayload = JSON.parse(body) as JsonObject;

--- a/components/adapters/codex/tests/stable-prefix.test.ts
+++ b/components/adapters/codex/tests/stable-prefix.test.ts
@@ -241,6 +241,44 @@ test("cache contract splits cache-relevant options and tool schemas", () => {
   );
 });
 
+test("Tura-shaped command_run schema stays in one cache family across turns", () => {
+  const config = normalizeTokenPilotCodexConfig({});
+  const commandRun = {
+    type: "function",
+    function: {
+      name: "command_run",
+      description: "Run one batch of commands.",
+      parameters: {
+        type: "object",
+        required: ["commands"],
+        properties: {
+          commands: { type: "array", items: { type: "object" } },
+        },
+      },
+    },
+  };
+  const startup = prepareCodexStablePrefix({
+    ...makeCacheFamilyEnvelope("gpt-5.6-sol"),
+    tools: [commandRun],
+    metadata: { promptCacheKey: "tura-startup-session-key" },
+  }, config);
+  const active = prepareCodexStablePrefix({
+    ...makeCacheFamilyEnvelope("gpt-5.6-sol"),
+    tools: [commandRun],
+    metadata: { promptCacheKey: "tura-active-session-key" },
+  }, config);
+  const final = prepareCodexStablePrefix({
+    ...makeCacheFamilyEnvelope("gpt-5.6-sol"),
+    tools: [commandRun],
+    metadata: { promptCacheKey: "tura-final-session-key" },
+  }, config);
+
+  assert.equal(startup.metadata?.lightrsiCacheContractDigest, active.metadata?.lightrsiCacheContractDigest);
+  assert.equal(active.metadata?.lightrsiCacheContractDigest, final.metadata?.lightrsiCacheContractDigest);
+  assert.equal(startup.metadata?.promptCacheKey, active.metadata?.promptCacheKey);
+  assert.equal(active.metadata?.promptCacheKey, final.metadata?.promptCacheKey);
+});
+
 test("cache contract ignores volatile Codex client metadata but preserves semantic options", () => {
   const config = normalizeTokenPilotCodexConfig({});
   const base = makeCacheFamilyEnvelope("gpt-5.6-sol");

--- a/components/adapters/codex/tests/transparent-provider-wire.test.ts
+++ b/components/adapters/codex/tests/transparent-provider-wire.test.ts
@@ -1,0 +1,319 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { reserveUnusedPort } from "@lightrsi/host-adapter";
+import { normalizeTokenPilotCodexConfig } from "../src/config.js";
+import { createConsoleLogger } from "../src/logger.js";
+import { startCodexResponsesProxy } from "../src/proxy-runtime.js";
+
+async function startWireUpstream(params: {
+  path: string;
+  body: string;
+  contentType: string;
+  responseChunks?: string[];
+  responseStatus?: number;
+  chunkDelayMs?: number;
+}) {
+  const port = await reserveUnusedPort();
+  const requests: string[] = [];
+  const requestPaths: string[] = [];
+  const requestMethods: string[] = [];
+  let upstreamAbortCount = 0;
+  const server = createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    requests.push(Buffer.concat(chunks).toString("utf8"));
+    requestPaths.push(req.url ?? "");
+    requestMethods.push(req.method ?? "");
+    if (req.method !== "POST" || req.url !== params.path) {
+      res.statusCode = 404;
+      res.end("not found");
+      return;
+    }
+    res.on("close", () => {
+      if (!res.writableEnded) upstreamAbortCount += 1;
+    });
+    res.statusCode = params.responseStatus ?? 200;
+    res.setHeader("content-type", params.contentType);
+    const responseChunks = params.responseChunks ?? [params.body];
+    for (const chunk of responseChunks) {
+      if (res.destroyed) return;
+      res.write(chunk);
+      if (params.chunkDelayMs) await new Promise((resolve) => setTimeout(resolve, params.chunkDelayMs));
+    }
+    if (!res.destroyed) res.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  return {
+    baseUrl: `http://127.0.0.1:${port}/v1`,
+    requests,
+    requestPaths,
+    requestMethods,
+    get upstreamAbortCount() {
+      return upstreamAbortCount;
+    },
+    close: () => new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections();
+    }),
+  };
+}
+
+async function startPureForwardProxy(upstreamBaseUrl: string) {
+  const proxyPort = await reserveUnusedPort();
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-pure-forward-"));
+  const config = normalizeTokenPilotCodexConfig({
+    proxyPort,
+    stateDir,
+    upstream: {
+      name: "capture",
+      baseUrl: upstreamBaseUrl,
+      wireApi: "responses",
+    },
+    proxyMode: { pureForward: true },
+    modules: { stabilizer: true, reduction: true },
+  });
+  const runtime = await startCodexResponsesProxy({
+    config,
+    logger: createConsoleLogger(false),
+  });
+  return {
+    runtime,
+    stateDir,
+    cleanup: () => rm(stateDir, { recursive: true, force: true }),
+  };
+}
+
+async function readPureForwardTrace(stateDir: string, stage = "pure_forward_timing") {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const rows = (await readFile(`${stateDir}/event-trace.jsonl`, "utf8").catch(() => ""))
+      .split(/\r?\n/u)
+      .flatMap((line) => {
+        try {
+          return [JSON.parse(line) as Record<string, unknown>];
+        } catch {
+          return [];
+        }
+      });
+    const row = rows.find((entry) => entry.stage === stage);
+    if (row) return row;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return undefined;
+}
+
+test("pure forward preserves unknown JSON fields on chat completions", async () => {
+  const upstream = await startWireUpstream({
+    path: "/v1/chat/completions",
+    contentType: "application/json",
+    body: '{"id":"chat_capture","unknown_response_field":{"keep":true}}',
+  });
+  const proxy = await startPureForwardProxy(upstream.baseUrl);
+  try {
+    const requestBody = JSON.stringify({
+      model: "capture-model",
+      stream: false,
+      unknown_request_field: { keep: true },
+      messages: [{ role: "user", content: "hello" }],
+    });
+    const response = await fetch(`${proxy.runtime.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: requestBody,
+    });
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), '{"id":"chat_capture","unknown_response_field":{"keep":true}}');
+    assert.deepEqual(upstream.requests, [requestBody]);
+  } finally {
+    await proxy.runtime.close();
+    await proxy.cleanup();
+    await upstream.close();
+  }
+});
+
+test("pure forward preserves SSE bytes and content type", async () => {
+  const streamBody = "event: response.created\ndata: {\"id\":\"resp_capture\"}\n\nevent: response.completed\ndata: {}\n\n";
+  const upstream = await startWireUpstream({
+    path: "/v1/responses",
+    contentType: "text/event-stream",
+    body: streamBody,
+    responseChunks: ["event: response.created\ndata: {\"id\":\"resp_capture\"}\n\n", "event: response.completed\ndata: {}\n\n"],
+    chunkDelayMs: 20,
+  });
+  const proxy = await startPureForwardProxy(upstream.baseUrl);
+  try {
+    const requestBody = JSON.stringify({
+      model: "capture-model",
+      stream: true,
+      input: [{ role: "user", content: "hello" }],
+      unknown_request_field: [1, 2, 3],
+    });
+    const response = await fetch(`${proxy.runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: requestBody,
+    });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "text/event-stream");
+    assert.equal(await response.text(), streamBody);
+    assert.deepEqual(upstream.requests, [requestBody]);
+    const trace = await readPureForwardTrace(proxy.stateDir);
+    assert.equal(trace?.stage, "pure_forward_timing");
+    assert.equal(trace?.responseStatus, 200);
+    assert.equal(typeof trace?.requestId, "string");
+    assert.equal(trace?.requestBytes, Buffer.byteLength(requestBody));
+    assert.equal(trace?.responseStatus, 200);
+    assert.equal(trace?.hasResponseBody, true);
+    assert.equal(typeof trace?.pre_upstream_ms, "number");
+    assert.equal(typeof trace?.upstream_headers_ms, "number");
+    assert.equal(typeof trace?.upstream_first_chunk_ms, "number");
+    assert.equal(typeof trace?.upstream_stream_ms, "number");
+    assert.equal(typeof trace?.downstream_drain_ms, "number");
+    assert.equal(typeof trace?.total_ms, "number");
+    assert.equal(Number(trace?.upstream_first_chunk_ms) >= 0, true);
+    assert.equal(Number(trace?.upstream_stream_ms) >= 0, true);
+    assert.equal(Number(trace?.downstream_drain_ms) >= 0, true);
+  } finally {
+    await proxy.runtime.close();
+    await proxy.cleanup();
+    await upstream.close();
+  }
+});
+
+test("pure forward preserves provider payload and endpoint with normal defaults", async () => {
+  const streamBody = "event: response.completed\n\n";
+  const upstream = await startWireUpstream({
+    path: "/v1/responses",
+    contentType: "text/event-stream",
+    body: streamBody,
+    responseChunks: [streamBody],
+  });
+  const proxy = await startPureForwardProxy(upstream.baseUrl);
+  try {
+    const requestBody = JSON.stringify({
+      model: "capture-model",
+      stream: true,
+      prompt_cache_key: "session-cache-key",
+      input: [{ role: "user", content: "hello" }],
+    });
+    const response = await fetch(`${proxy.runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: requestBody,
+    });
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), streamBody);
+    assert.deepEqual(upstream.requestMethods, ["POST"]);
+    assert.deepEqual(upstream.requestPaths, ["/v1/responses"]);
+    assert.equal(upstream.requests.length, 1);
+    assert.equal(upstream.requests[0], requestBody);
+    assert.equal(
+      createHash("sha256").update(upstream.requests[0]).digest("hex"),
+      createHash("sha256").update(requestBody).digest("hex"),
+    );
+    assert.equal(upstream.requestPaths.some((path) => path.endsWith("/models")), false);
+  } finally {
+    await proxy.runtime.close();
+    await proxy.cleanup();
+    await upstream.close();
+  }
+});
+
+test("pure forward preserves upstream error status and body", async () => {
+  const errorBody = JSON.stringify({ error: { type: "rate_limit_error" } });
+  const upstream = await startWireUpstream({
+    path: "/v1/responses",
+    contentType: "application/json",
+    body: errorBody,
+    responseStatus: 429,
+  });
+  const proxy = await startPureForwardProxy(upstream.baseUrl);
+  try {
+    const response = await fetch(`${proxy.runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "capture-model", input: [] }),
+    });
+    assert.equal(response.status, 429);
+    assert.equal(await response.text(), errorBody);
+    assert.deepEqual(upstream.requestMethods, ["POST"]);
+    assert.deepEqual(upstream.requestPaths, ["/v1/responses"]);
+  } finally {
+    await proxy.runtime.close();
+    await proxy.cleanup();
+    await upstream.close();
+  }
+});
+test("pure forward records empty-body timing without inventing chunks", async () => {
+  const upstream = await startWireUpstream({
+    path: "/v1/responses",
+    contentType: "application/json",
+    body: "",
+  });
+  const proxy = await startPureForwardProxy(upstream.baseUrl);
+  try {
+    const response = await fetch(`${proxy.runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "capture-model", input: [] }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "");
+    const trace = await readPureForwardTrace(proxy.stateDir);
+    assert.equal(trace?.hasResponseBody, false);
+    assert.equal(trace?.upstream_first_chunk_ms, null);
+    assert.equal(trace?.upstream_stream_ms, null);
+    assert.equal(typeof trace?.downstream_drain_ms, "number");
+  } finally {
+    await proxy.runtime.close();
+    await proxy.cleanup();
+    await upstream.close();
+  }
+});
+
+test("pure forward abort cancels upstream response without unhandled rejection", async () => {
+  const upstream = await startWireUpstream({
+    path: "/v1/responses",
+    contentType: "text/event-stream",
+    body: "",
+    responseChunks: ["event: response.created\\n\\n", "event: response.completed\\n\\n"],
+    chunkDelayMs: 500,
+  });
+  const proxy = await startPureForwardProxy(upstream.baseUrl);
+  try {
+    const response = await fetch(`${proxy.runtime.baseUrl}/responses`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: "capture-model", stream: true, input: [] }),
+    });
+    const reader = response.body?.getReader();
+    assert.ok(reader);
+    try {
+      await reader.read();
+    } catch (error) {
+      assert.equal((error as Error).name, "AbortError");
+    }
+    await reader.cancel().catch(() => {});
+    for (let attempt = 0; attempt < 40 && upstream.upstreamAbortCount === 0; attempt += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(upstream.upstreamAbortCount > 0, true);
+    const trace = await readPureForwardTrace(proxy.stateDir, "pure_forward_cancelled");
+    assert.equal(trace?.stage, "pure_forward_cancelled");
+    assert.equal(["request_aborted", "response_close_before_finish"].includes(String(trace?.abortSource)), true);
+  } finally {
+    await proxy.runtime.close();
+    await proxy.cleanup();
+    await upstream.close();
+  }
+});

--- a/components/packages/foundation/host-adapter/src/contracts/gateway-runtime.ts
+++ b/components/packages/foundation/host-adapter/src/contracts/gateway-runtime.ts
@@ -18,6 +18,16 @@ export type HostGatewayHttpResponse = {
   text: string;
 };
 
+export type HostGatewayRawRequest = {
+  upstream: HostGatewayUpstreamConfig;
+  method?: string;
+  requestPath?: string;
+  body?: string | Uint8Array;
+  inboundAuthorization?: string;
+  inboundHeaders?: Record<string, string | string[] | undefined>;
+  signal?: AbortSignal;
+};
+
 export type HostGatewayStreamResponse = {
   status: number;
   headers: Record<string, string>;
@@ -48,6 +58,7 @@ export type HostGatewayForwarder = {
       inboundHeaders?: Record<string, string | string[] | undefined>;
     },
   ): Promise<HostGatewayStreamResponse>;
+  requestRaw(params: HostGatewayRawRequest): Promise<Response>;
 };
 
 export type HostGatewayStreamObserver = {

--- a/components/packages/foundation/host-adapter/src/gateway/http-forwarder.ts
+++ b/components/packages/foundation/host-adapter/src/gateway/http-forwarder.ts
@@ -3,6 +3,7 @@ import { Readable } from "node:stream";
 import type {
   HostGatewayForwarder,
   HostGatewayHttpResponse,
+  HostGatewayRawRequest,
   HostGatewayStreamResponse,
   HostGatewayUpstreamConfig,
 } from "../contracts/gateway-runtime.js";
@@ -39,12 +40,20 @@ function normalizeHeaderValue(value: string | string[] | undefined): string | un
 }
 
 function shouldSkipForwardHeader(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (lower.startsWith("x-lightrsi-")
+    || lower.startsWith("x-tokenpilot-")) {
+    return true;
+  }
   switch (name.toLowerCase()) {
     case "host":
     case "connection":
     case "content-length":
     case "content-encoding":
     case "transfer-encoding":
+    case "accept-language":
+    case "sec-fetch-mode":
+    case "user-agent":
       return true;
     default:
       return false;
@@ -120,16 +129,35 @@ export async function forwardGatewayRequest(params: {
 }): Promise<Response> {
   const method = params.method ?? "POST";
   const hasPayload = params.payload !== undefined;
-  const headers = buildGatewayForwardHeaders({
+  return forwardGatewayRawRequest({
     upstream: params.upstream,
+    method,
+    requestPath: params.requestPath,
+    payload: hasPayload ? JSON.stringify(params.payload) : undefined,
     inboundAuthorization: params.inboundAuthorization,
     inboundHeaders: params.inboundHeaders,
     includeJsonContentType: hasPayload,
   });
+}
+
+export async function forwardGatewayRawRequest(
+  params: HostGatewayRawRequest & {
+    payload?: string | Uint8Array;
+    includeJsonContentType?: boolean;
+  },
+): Promise<Response> {
+  const body = params.payload ?? params.body;
+  const headers = buildGatewayForwardHeaders({
+    upstream: params.upstream,
+    inboundAuthorization: params.inboundAuthorization,
+    inboundHeaders: params.inboundHeaders,
+    includeJsonContentType: params.includeJsonContentType ?? body !== undefined,
+  });
   return fetch(resolveGatewayRequestUrl(params.upstream, params.requestPath), {
-    method,
+    method: params.method ?? "POST",
     headers,
-    body: hasPayload ? JSON.stringify(params.payload) : undefined,
+    body: body as BodyInit | undefined,
+    signal: params.signal,
   });
 }
 
@@ -165,5 +193,6 @@ export function createDefaultGatewayForwarder(): HostGatewayForwarder {
   return {
     request: forwardGatewayJsonRequest,
     requestStream: forwardGatewayJsonStreamRequest,
+    requestRaw: forwardGatewayRawRequest,
   };
 }

--- a/components/packages/foundation/host-adapter/src/gateway/http-server.ts
+++ b/components/packages/foundation/host-adapter/src/gateway/http-server.ts
@@ -1,11 +1,30 @@
 import { type IncomingMessage, type Server, type ServerResponse } from "node:http";
 
-export async function readHttpRequestBody(req: IncomingMessage): Promise<string> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of req) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+export async function readHttpRequestBody(req: IncomingMessage, signal?: AbortSignal): Promise<string> {
+  if (signal?.aborted) {
+    throw new DOMException("The operation was aborted", "AbortError");
   }
-  return Buffer.concat(chunks).toString("utf8");
+  const chunks: Buffer[] = [];
+  const read = (async () => {
+    for await (const chunk of req) {
+      if (signal?.aborted) {
+        throw new DOMException("The operation was aborted", "AbortError");
+      }
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+    }
+    return Buffer.concat(chunks).toString("utf8");
+  })();
+  if (!signal) return read;
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () => reject(new DOMException("The operation was aborted", "AbortError"));
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([read, aborted]);
+  } finally {
+    if (onAbort) signal.removeEventListener("abort", onAbort);
+  }
 }
 
 export function sendJsonResponse(res: ServerResponse, statusCode: number, payload: unknown): void {

--- a/components/packages/foundation/host-adapter/src/gateway/runtime-server.ts
+++ b/components/packages/foundation/host-adapter/src/gateway/runtime-server.ts
@@ -20,7 +20,7 @@ export async function startHostGatewayRuntimeServer(params: {
     req: IncomingMessage;
     res: ServerResponse;
     pathname: string;
-    readBody(): Promise<string>;
+    readBody(signal?: AbortSignal): Promise<string>;
   }): Promise<boolean | void>;
   handleRequest(args: {
     req: IncomingMessage;
@@ -39,8 +39,8 @@ export async function startHostGatewayRuntimeServer(params: {
     try {
       let bodyPromise: Promise<string> | null = null;
       const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
-      const readBody = () => {
-        bodyPromise ??= readHttpRequestBody(req);
+      const readBody = (signal?: AbortSignal) => {
+        bodyPromise ??= readHttpRequestBody(req, signal);
         return bodyPromise;
       };
       if (req.method === "GET" && pathname === "/health") {

--- a/components/packages/foundation/host-adapter/tests/http-forwarder.test.ts
+++ b/components/packages/foundation/host-adapter/tests/http-forwarder.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildGatewayForwardHeaders } from "../src/gateway/http-forwarder.js";
+
+test("forward headers omit transport metadata that can split provider cache identity", () => {
+  const headers = buildGatewayForwardHeaders({
+    upstream: { baseUrl: "http://provider.test/v1", apiKey: "key", name: "provider", protocol: "custom" },
+    inboundHeaders: {
+      accept: "text/event-stream",
+      "accept-language": "en-US",
+      authorization: "Bearer inbound",
+      "content-type": "application/json",
+      "sec-fetch-mode": "cors",
+      "user-agent": "browser",
+      "x-request-id": "request",
+    },
+  });
+
+  assert.deepEqual(headers, {
+    accept: "text/event-stream",
+    authorization: "Bearer inbound",
+    "content-type": "application/json",
+    "x-request-id": "request",
+  });
+});


### PR DESCRIPTION
## Summary
- preserve raw provider request and response bytes in Codex pure-forward mode
- forward provider endpoint, status, headers, SSE bytes, and unknown JSON fields without decoding
- propagate client cancellation to request-body reads and upstream fetches
- close test HTTP connections so CI exits cleanly on Ubuntu

## Validation
- `pnpm typecheck`
- `pnpm --dir components/adapters/codex test` — 411/411 passed
- host-adapter HTTP forwarder test — 1/1 passed