### PR TITLE
fix(stabilizer): preserve user payload bytes

### DIFF
--- a/components/packages/features/stabilizer/src/stable-prefix.ts
+++ b/components/packages/features/stabilizer/src/stable-prefix.ts
@@ -1,7 +1,6 @@
 import type { StabilizerRequestEnvelope } from "./contracts.js";
 import {
   extractContentText,
-  normalizeUserMessageText,
   prependTextToContent,
   replaceContentText,
   rewriteTextForStablePrefix,
@@ -176,26 +175,6 @@ function rewriteSystemMessage(messages: StabilizerRequestEnvelope["messages"]): 
   };
 }
 
-function normalizeUserMessages(messages: StabilizerRequestEnvelope["messages"]): {
-  changed: boolean;
-  messages: StabilizerRequestEnvelope["messages"];
-} {
-  let changed = false;
-  const nextMessages = messages.map((message) => {
-    if (message?.role !== "user") return message;
-    const sourceText = extractContentText(message.content);
-    if (!sourceText.trim()) return message;
-    const normalizedText = normalizeUserMessageText(sourceText);
-    if (normalizedText === sourceText) return message;
-    changed = true;
-    return {
-      ...message,
-      content: replaceContentText(message.content, normalizedText),
-    };
-  });
-  return { changed, messages: changed ? nextMessages : messages };
-}
-
 function injectDynamicContext(
   messages: StabilizerRequestEnvelope["messages"],
   dynamicContextText: string,
@@ -227,14 +206,12 @@ export function defaultPrepareStablePrefix<TEnvelope extends StabilizerRequestEn
   const systemRewrite = instructionRewrite.changed
     ? { changed: false, messages: sourceMessages, dynamicContextText: instructionRewrite.dynamicContextText }
     : rewriteSystemMessage(sourceMessages);
-  const normalizedUsers = normalizeUserMessages(systemRewrite.messages);
   const dynamicContextText = instructionRewrite.dynamicContextText || systemRewrite.dynamicContextText;
-  const dynamicInjection = injectDynamicContext(normalizedUsers.messages, dynamicContextText);
+  const dynamicInjection = injectDynamicContext(systemRewrite.messages, dynamicContextText);
 
   const anyChanged =
     instructionRewrite.changed ||
     systemRewrite.changed ||
-    normalizedUsers.changed ||
     dynamicInjection.changed;
 
   if (!anyChanged) return envelope;

--- a/components/packages/features/stabilizer/tests/fixtures/before-call-default-expected.json
+++ b/components/packages/features/stabilizer/tests/fixtures/before-call-default-expected.json
@@ -13,7 +13,7 @@
   "messages": [
     {
       "role": "user",
-      "content": "- WORKDIR: /tmp/demo/project\n- AGENT_ID: main\n\nPlease analyze the repository."
+      "content": "- WORKDIR: /tmp/demo/project\n- AGENT_ID: main\n\nSender (untrusted metadata): ```json\n{\"agent\":\"main\"}\n```\n\nPlease analyze the repository."
     }
   ],
   "rawPayload": {

--- a/components/packages/features/stabilizer/tests/stabilizer.test.ts
+++ b/components/packages/features/stabilizer/tests/stabilizer.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { RuntimeContentBlock } from "@lightrsi/kernel";
 
 import {
   applyStablePrefixToInstructions,
   buildStabilityVisualSnapshotFromTexts,
   canonicalizeTools,
+  defaultPrepareStablePrefix,
   fingerprintStablePrefixEnvelope,
   rewriteTextForStablePrefix,
   type StabilizerRequestEnvelope,
@@ -46,6 +48,43 @@ test("stable prefix preparation preserves host-specific envelope fields", () => 
   assert.equal(prepared.transport, "responses");
   assert.equal(prepared.instructions, "Runtime: agent=agent-123");
   assert.match(String(prepared.messages[0].content), /Current date: 2026-07-21/);
+});
+
+test("default stable prefix preparation preserves user payload bytes", () => {
+  const userText = " [request-123] \r\n- CURRENT_DATE: 2026-08-26\r\nSender (untrusted metadata): ```json\n{\"x\":1}\n```\r\nKeep exact.";
+  const input = envelope(userText);
+  input.instructions = "Stable instructions";
+
+  const prepared = defaultPrepareStablePrefix(input);
+
+  assert.equal(prepared, input);
+  assert.equal(prepared.messages[0]?.content, userText);
+});
+
+test("default stable prefix preparation injects context without rewriting structured user content", () => {
+  const content: RuntimeContentBlock[] = [
+    { type: "text", text: "[IMPORTANT] keep exact\r\n---\nvalue: user-owned" },
+    { type: "image", imageUrl: "https://example.com/user-owned.png" },
+  ];
+  const input: StabilizerRequestEnvelope = {
+    session: { host: { hostId: "test-host" } },
+    model: "test-model",
+    instructions: "Your working directory is: C:\\repo\\project\nRuntime: agent=agent-123 | session_id=session-456",
+    messages: [{ role: "user", content }],
+    tools: [],
+  };
+
+  const prepared = defaultPrepareStablePrefix(input);
+
+  assert.notEqual(prepared, input);
+  assert.deepEqual(input.messages[0]?.content, content);
+  assert.deepEqual(prepared.messages[0]?.content, [
+    {
+      type: "text",
+      text: "- WORKDIR: C:\\repo\\project\n- AGENT_ID: agent-123\nsession_id=session-456\n\n[IMPORTANT] keep exact\r\n---\nvalue: user-owned",
+    },
+    { type: "image", imageUrl: "https://example.com/user-owned.png" },
+  ]);
 });
 
 test("stable prefix fingerprint excludes volatile user tail", () => {


### PR DESCRIPTION
## Summary
- stop rewriting user-owned message text during stable-prefix preparation
- preserve string and structured content bytes while retaining additive dynamic context injection
- update regression fixtures and tests

## Validation
- `pnpm typecheck`
- stabilizer tests — 48/48 passed