### PR TITLE
feat(cleaner): add recommendation analyzer

### DIFF
--- a/components/packages/features/cleaner/package.json
+++ b/components/packages/features/cleaner/package.json
@@ -12,6 +12,7 @@
     "test": "node --import tsx --test tests/*.test.ts"
   },
   "dependencies": {
+    "@lightrsi/eviction": "workspace:*",
     "@lightrsi/history": "workspace:*",
     "@lightrsi/host-adapter": "workspace:*"
   }

--- a/components/packages/features/cleaner/src/index.ts
+++ b/components/packages/features/cleaner/src/index.ts
@@ -41,3 +41,4 @@ export {
   createContextCleanerHostExecutionBridge,
   type CreateContextCleanerHostExecutionBridgeParams,
 } from "./host-execution-bridge.js";
+export * from "./recommendation.js";

--- a/components/packages/features/cleaner/src/recommendation.ts
+++ b/components/packages/features/cleaner/src/recommendation.ts
@@ -1,0 +1,285 @@
+import { createHash } from "node:crypto";
+
+import {
+  createApiJsonModelClient,
+  type JsonModelClient,
+  type JsonModelUsage,
+  type TaskStateEstimatorApiConfig,
+} from "@lightrsi/eviction";
+import type {
+  ContextCleanRecommendation,
+  ContextCleanTaskBreakdown,
+} from "./contracts.js";
+
+const MAX_LABEL_CHARS = 80;
+const MAX_DESCRIPTION_CHARS = 200;
+const MAX_SUMMARY_CHARS = 600;
+const MAX_EVIDENCE_CHARS = 240;
+const MAX_EVIDENCE_ITEMS = 8;
+
+export type ContextCleanTaskEvidence = {
+  completionEvidence?: string[];
+  unresolvedIssues?: string[];
+  recallCount?: number;
+  turnsSinceLastRecall?: number;
+  supersededByTaskIds?: string[];
+  futureReuseSignals?: string[];
+};
+
+export type ContextCleanRecommendationProviderTask = {
+  taskId: string;
+  digest: string;
+  label: string;
+  description: string;
+  summary: string;
+  lifecycleState: ContextCleanTaskBreakdown["lifecycleState"];
+  tokenCount: number | null;
+  charCount: number;
+  tokenPercent: number | null;
+  selectable: boolean;
+  evidence: ContextCleanTaskEvidence;
+};
+
+export type ContextCleanRecommendationProviderInput = {
+  tasks: ContextCleanRecommendationProviderTask[];
+};
+
+export type ContextCleanRecommendationProviderResponse = {
+  output: unknown;
+  usage?: JsonModelUsage;
+};
+
+export type ContextCleanRecommendationProvider = {
+  recommend(
+    input: ContextCleanRecommendationProviderInput,
+  ): Promise<ContextCleanRecommendationProviderResponse>;
+};
+
+export type ContextCleanRecommendationResult = {
+  tasks: ContextCleanTaskBreakdown[];
+  confidenceByTaskId: Record<string, number>;
+  fallbackUsed: boolean;
+  reasons: string[];
+  usage?: JsonModelUsage;
+};
+
+type ModelRecommendation = {
+  taskId: string;
+  label: string;
+  description: string;
+  summary: string;
+  recommendation: ContextCleanRecommendation;
+  reasonCodes: string[];
+  confidence: number;
+};
+
+function redactSecrets(value: string): string {
+  return value
+    .replace(/\bBearer\s+[A-Za-z0-9._~+\/-]+=*/gi, "[REDACTED]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[REDACTED]");
+}
+
+function sanitizeText(value: string, maxChars: number): string {
+  const normalized = redactSecrets(value).replace(/\s+/g, " ").trim();
+  return normalized.length <= maxChars ? normalized : normalized.slice(0, maxChars);
+}
+
+function sanitizeList(values: string[] | undefined): string[] {
+  return (values ?? [])
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .slice(0, MAX_EVIDENCE_ITEMS)
+    .map((value) => sanitizeText(value, MAX_EVIDENCE_CHARS));
+}
+
+function sanitizeEvidence(value: ContextCleanTaskEvidence | undefined): ContextCleanTaskEvidence {
+  const count = (candidate: unknown): number | undefined =>
+    typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate >= 0
+      ? candidate : undefined;
+  return {
+    completionEvidence: sanitizeList(value?.completionEvidence),
+    unresolvedIssues: sanitizeList(value?.unresolvedIssues),
+    ...(count(value?.recallCount) !== undefined ? { recallCount: count(value?.recallCount) } : {}),
+    ...(count(value?.turnsSinceLastRecall) !== undefined
+      ? { turnsSinceLastRecall: count(value?.turnsSinceLastRecall) } : {}),
+    supersededByTaskIds: sanitizeList(value?.supersededByTaskIds),
+    futureReuseSignals: sanitizeList(value?.futureReuseSignals),
+  };
+}
+
+function taskDigest(task: ContextCleanTaskBreakdown): string {
+  const canonical = Object.entries(task.itemDigests)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, digest]) => digest)
+    .join("\n");
+  return createHash("sha256").update(canonical).digest("hex");
+}
+
+export function buildContextCleanRecommendationProviderInput(params: {
+  tasks: ContextCleanTaskBreakdown[];
+  evidenceByTaskId?: Record<string, ContextCleanTaskEvidence>;
+}): ContextCleanRecommendationProviderInput {
+  return {
+    tasks: params.tasks.map((task) => ({
+      taskId: task.taskId,
+      digest: taskDigest(task),
+      label: sanitizeText(task.label, MAX_LABEL_CHARS),
+      description: sanitizeText(task.description, MAX_DESCRIPTION_CHARS),
+      summary: sanitizeText(task.summary, MAX_SUMMARY_CHARS),
+      lifecycleState: task.lifecycleState,
+      tokenCount: task.tokenCount,
+      charCount: task.charCount,
+      tokenPercent: task.tokenPercent,
+      selectable: task.selectable,
+      evidence: sanitizeEvidence(params.evidenceByTaskId?.[task.taskId]),
+    })),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length
+    && actual.every((key, index) => key === expected[index]);
+}
+
+function parseModelOutput(value: unknown, expectedTaskIds: string[]): ModelRecommendation[] | undefined {
+  let parsed = value;
+  if (typeof parsed === "string") {
+    try { parsed = JSON.parse(parsed) as unknown; } catch { return undefined; }
+  }
+  if (!isRecord(parsed) || !hasExactKeys(parsed, ["tasks"]) || !Array.isArray(parsed.tasks)) {
+    return undefined;
+  }
+  const results: ModelRecommendation[] = [];
+  for (const candidate of parsed.tasks) {
+    if (!isRecord(candidate)
+      || !hasExactKeys(candidate, [
+        "taskId", "label", "description", "summary", "recommendation", "reasonCodes", "confidence",
+      ])
+      || typeof candidate.taskId !== "string" || !candidate.taskId.trim()
+      || typeof candidate.label !== "string" || !candidate.label.trim()
+      || candidate.label.length > MAX_LABEL_CHARS
+      || typeof candidate.description !== "string" || !candidate.description.trim()
+      || /[\r\n]/.test(candidate.description) || candidate.description.length > MAX_DESCRIPTION_CHARS
+      || typeof candidate.summary !== "string" || !candidate.summary.trim()
+      || candidate.summary.length > MAX_SUMMARY_CHARS
+      || !["clean", "keep", "protected"].includes(String(candidate.recommendation))
+      || !Array.isArray(candidate.reasonCodes)
+      || candidate.reasonCodes.some((reason) =>
+        typeof reason !== "string" || !/^[a-z0-9_:-]{1,64}$/.test(reason))
+      || new Set(candidate.reasonCodes).size !== candidate.reasonCodes.length
+      || typeof candidate.confidence !== "number" || !Number.isFinite(candidate.confidence)
+      || candidate.confidence < 0 || candidate.confidence > 1) return undefined;
+    results.push({
+      taskId: candidate.taskId.trim(),
+      label: sanitizeText(candidate.label, MAX_LABEL_CHARS),
+      description: sanitizeText(candidate.description, MAX_DESCRIPTION_CHARS),
+      summary: sanitizeText(candidate.summary, MAX_SUMMARY_CHARS),
+      recommendation: candidate.recommendation as ContextCleanRecommendation,
+      reasonCodes: [...candidate.reasonCodes] as string[],
+      confidence: candidate.confidence,
+    });
+  }
+  const actualIds = results.map((result) => result.taskId);
+  if (new Set(actualIds).size !== actualIds.length
+    || actualIds.length !== expectedTaskIds.length
+    || actualIds.some((taskId) => !expectedTaskIds.includes(taskId))) return undefined;
+  return results;
+}
+
+function protectedByDeterministicPolicy(task: ContextCleanTaskBreakdown): boolean {
+  return !task.selectable
+    || task.lifecycleState === "active"
+    || task.lifecycleState === "unresolved";
+}
+
+function fallbackTasks(tasks: ContextCleanTaskBreakdown[]): ContextCleanTaskBreakdown[] {
+  return tasks.map((task) => {
+    const protectedTask = protectedByDeterministicPolicy(task);
+    return {
+      ...task,
+      recommendation: protectedTask ? "protected" : "keep",
+      reasonCodes: [protectedTask ? "recommendation_fallback_protected" : "recommendation_fallback_keep"],
+    };
+  });
+}
+
+function fallbackReason(error: unknown): string {
+  const message = error instanceof Error ? `${error.name}:${error.message}` : String(error);
+  if (/requires baseUrl, apiKey, and model/i.test(message)) {
+    return "recommendation_provider_unavailable";
+  }
+  if (/AbortError|aborted|timeout/i.test(message)) return "recommendation_provider_timeout";
+  if (/:429(?:\D|$)/.test(message)) return "recommendation_provider_rate_limited";
+  if (/:(?:5\d\d)(?:\D|$)/.test(message)) return "recommendation_provider_server_error";
+  return "recommendation_provider_failed";
+}
+
+export async function analyzeContextCleanRecommendations(params: {
+  tasks: ContextCleanTaskBreakdown[];
+  evidenceByTaskId?: Record<string, ContextCleanTaskEvidence>;
+  provider?: ContextCleanRecommendationProvider;
+}): Promise<ContextCleanRecommendationResult> {
+  if (!params.provider) {
+    return { tasks: fallbackTasks(params.tasks), confidenceByTaskId: {}, fallbackUsed: true,
+      reasons: ["recommendation_provider_unavailable"] };
+  }
+  let response: ContextCleanRecommendationProviderResponse;
+  try {
+    response = await params.provider.recommend(buildContextCleanRecommendationProviderInput(params));
+  } catch (error) {
+    return { tasks: fallbackTasks(params.tasks), confidenceByTaskId: {}, fallbackUsed: true,
+      reasons: [fallbackReason(error)] };
+  }
+  const recommendations = parseModelOutput(response.output, params.tasks.map((task) => task.taskId));
+  if (!recommendations) {
+    return { tasks: fallbackTasks(params.tasks), confidenceByTaskId: {}, fallbackUsed: true,
+      reasons: ["recommendation_output_invalid"], ...(response.usage ? { usage: response.usage } : {}) };
+  }
+  const byTaskId = new Map(recommendations.map((recommendation) => [recommendation.taskId, recommendation]));
+  const confidenceByTaskId: Record<string, number> = {};
+  const tasks = params.tasks.map((task) => {
+    const recommendation = byTaskId.get(task.taskId)!;
+    confidenceByTaskId[task.taskId] = recommendation.confidence;
+    if (protectedByDeterministicPolicy(task)) {
+      return { ...task, label: recommendation.label, description: recommendation.description,
+        summary: recommendation.summary, recommendation: "protected" as const,
+        reasonCodes: [...recommendation.reasonCodes, "deterministic_protection"] };
+    }
+    return { ...task, label: recommendation.label, description: recommendation.description,
+      summary: recommendation.summary, recommendation: recommendation.recommendation,
+      reasonCodes: recommendation.reasonCodes };
+  });
+  return { tasks, confidenceByTaskId, fallbackUsed: false, reasons: [],
+    ...(response.usage ? { usage: response.usage } : {}) };
+}
+
+const RECOMMENDATION_SYSTEM_PROMPT = [
+  "You recommend whether completed task context should be cleaned from an agent session.",
+  "Return only JSON: {\"tasks\":[{\"taskId\":string,\"label\":string,\"description\":string,\"summary\":string,\"recommendation\":\"clean\"|\"keep\"|\"protected\",\"reasonCodes\":string[],\"confidence\":number}]}",
+  "Return exactly one result for every input task and never invent task IDs.",
+  "description must be one short line. confidence must be between 0 and 1.",
+  "Consider completion evidence, unresolved issues, recall count, recency, supersession, and future reuse signals.",
+  "Never infer token counts. Never choose item IDs or raw text ranges.",
+].join(" ");
+
+export function createApiContextCleanRecommendationProvider(
+  config: TaskStateEstimatorApiConfig,
+  createClient: (config: TaskStateEstimatorApiConfig) => JsonModelClient = createApiJsonModelClient,
+): ContextCleanRecommendationProvider {
+  let client: JsonModelClient | undefined;
+  return {
+    async recommend(input) {
+      client ??= createClient(config);
+      const response = await client.request({
+        systemPrompt: RECOMMENDATION_SYSTEM_PROMPT,
+        userPayload: JSON.stringify(input),
+      });
+      return { output: response.text, usage: response.usage };
+    },
+  };
+}

--- a/components/packages/features/cleaner/tests/recommendation.test.ts
+++ b/components/packages/features/cleaner/tests/recommendation.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  analyzeContextCleanRecommendations,
+  buildContextCleanRecommendationProviderInput,
+  createApiContextCleanRecommendationProvider,
+  type ContextCleanRecommendationProvider,
+  type ContextCleanTaskBreakdown,
+} from "../src/index.js";
+
+function task(overrides: Partial<ContextCleanTaskBreakdown> = {}): ContextCleanTaskBreakdown {
+  return {
+    taskId: "task-a", label: "Task A", description: "Inspect task A", summary: "Task A summary",
+    lifecycleState: "completed", itemIds: ["item-a"], itemDigests: { "item-a": "digest-a" },
+    tokenCount: 50, charCount: 200, tokenPercent: 25, recommendation: "keep",
+    reasonCodes: [], selectable: true, ...overrides,
+  };
+}
+
+function outputFor(tasks: ContextCleanTaskBreakdown[], overrides: Record<string, unknown> = {}): unknown {
+  return { tasks: tasks.map((item) => ({ taskId: item.taskId, label: `Label ${item.taskId}`,
+    description: `Description ${item.taskId}`, summary: `Summary ${item.taskId}`,
+    recommendation: "clean", reasonCodes: ["completed_and_cold"], confidence: 0.9,
+    ...overrides })) };
+}
+
+function provider(output: unknown): ContextCleanRecommendationProvider {
+  return { async recommend() { return { output }; } };
+}
+
+test("applies strict model recommendations without changing accounting or target identity", async () => {
+  const original = task();
+  const result = await analyzeContextCleanRecommendations({ tasks: [original], provider: provider(outputFor([original])) });
+  assert.equal(result.fallbackUsed, false);
+  assert.equal(result.tasks[0]?.recommendation, "clean");
+  assert.equal(result.confidenceByTaskId[original.taskId], 0.9);
+  assert.deepEqual(result.tasks[0]?.itemIds, original.itemIds);
+  assert.deepEqual(result.tasks[0]?.itemDigests, original.itemDigests);
+  assert.equal(result.tasks[0]?.tokenCount, original.tokenCount);
+});
+
+test("deterministic protection overrides model clean recommendations", async () => {
+  const tasks = [
+    task({ taskId: "active", lifecycleState: "active", selectable: false }),
+    task({ taskId: "unresolved", lifecycleState: "unresolved", selectable: false }),
+    task({ taskId: "not-selectable", selectable: false }),
+  ];
+  const result = await analyzeContextCleanRecommendations({ tasks, provider: provider(outputFor(tasks)) });
+  assert.deepEqual(result.tasks.map((item) => item.recommendation), ["protected", "protected", "protected"]);
+  assert.ok(result.tasks.every((item) => item.reasonCodes.includes("deterministic_protection")));
+});
+
+test("a previous model-only protected recommendation does not become a deterministic lock", async () => {
+  const original = task({ recommendation: "protected", selectable: true, lifecycleState: "completed" });
+  const result = await analyzeContextCleanRecommendations({ tasks: [original], provider: provider(outputFor([original])) });
+  assert.equal(result.tasks[0]?.recommendation, "clean");
+});
+
+test("provider input contains bounded task evidence and no raw target data or secrets", () => {
+  const input = buildContextCleanRecommendationProviderInput({
+    tasks: [task({ description: "Bearer secret-token", summary: "sk-abcdefghijklmnop" })],
+    evidenceByTaskId: { "task-a": { completionEvidence: ["Delivered sk-1234567890"], recallCount: 2 } },
+  });
+  const serialized = JSON.stringify(input);
+  assert.equal(serialized.includes("itemIds"), false);
+  assert.equal(serialized.includes("itemDigests"), false);
+  assert.equal(serialized.includes("secret-token"), false);
+  assert.equal(serialized.includes("sk-1234567890"), false);
+  assert.match(input.tasks[0]?.digest ?? "", /^[a-f0-9]{64}$/);
+});
+
+test("provider input limits evidence count and length", () => {
+  const input = buildContextCleanRecommendationProviderInput({
+    tasks: [task()],
+    evidenceByTaskId: {
+      "task-a": {
+        completionEvidence: Array.from({ length: 10 }, (_, index) => `${index}-${"x".repeat(300)}`),
+      },
+    },
+  });
+  const evidence = input.tasks[0]?.evidence.completionEvidence ?? [];
+  assert.equal(evidence.length, 8);
+  assert.ok(evidence.every((item) => item.length <= 240));
+});
+
+test("missing provider preserves breakdown and safely falls back", async () => {
+  const tasks = [task(), task({ taskId: "active", lifecycleState: "active", selectable: false })];
+  const result = await analyzeContextCleanRecommendations({ tasks });
+  assert.equal(result.fallbackUsed, true);
+  assert.deepEqual(result.reasons, ["recommendation_provider_unavailable"]);
+  assert.deepEqual(result.tasks.map((item) => item.recommendation), ["keep", "protected"]);
+  assert.deepEqual(result.tasks.map((item) => item.tokenCount), tasks.map((item) => item.tokenCount));
+});
+
+test("malformed, missing, duplicate, unknown, multiline, and invalid-confidence outputs fail closed", async () => {
+  const tasks = [task(), task({ taskId: "task-b" })];
+  const invalidOutputs = [
+    "not-json",
+    { tasks: [] },
+    { tasks: [outputFor([tasks[0]!]) as never] },
+    outputFor(tasks, { taskId: "unknown" }),
+    outputFor(tasks, { description: "two\nlines" }),
+    outputFor(tasks, { confidence: 2 }),
+    { ...(outputFor(tasks) as Record<string, unknown>), futureField: true },
+    outputFor(tasks, { futureField: true }),
+  ];
+  for (const output of invalidOutputs) {
+    const result = await analyzeContextCleanRecommendations({ tasks, provider: provider(output) });
+    assert.equal(result.fallbackUsed, true);
+    assert.deepEqual(result.reasons, ["recommendation_output_invalid"]);
+    assert.deepEqual(result.tasks.map((item) => item.recommendation), ["keep", "keep"]);
+  }
+});
+
+test("an unknown task ID fails closed even when output IDs are unique", async () => {
+  const tasks = [task(), task({ taskId: "task-b" })];
+  const output = outputFor(tasks) as { tasks: Array<Record<string, unknown>> };
+  output.tasks[0] = { ...output.tasks[0], taskId: "unknown" };
+  const result = await analyzeContextCleanRecommendations({ tasks, provider: provider(output) });
+  assert.equal(result.fallbackUsed, true);
+  assert.deepEqual(result.reasons, ["recommendation_output_invalid"]);
+  assert.deepEqual(result.tasks.map((item) => item.recommendation), ["keep", "keep"]);
+});
+
+test("malformed output fallback preserves provider usage", async () => {
+  const usage = { inputTokens: 12, outputTokens: 3, totalTokens: 15, costUsd: 0.001 };
+  const malformed: ContextCleanRecommendationProvider = {
+    async recommend() { return { output: "not-json", usage }; },
+  };
+  const result = await analyzeContextCleanRecommendations({ tasks: [task()], provider: malformed });
+  assert.equal(result.fallbackUsed, true);
+  assert.deepEqual(result.usage, usage);
+});
+
+test("classifies timeout, 429, 5xx, and network provider failures", async () => {
+  for (const [error, reason] of [
+    [new Error("AbortError: request aborted"), "recommendation_provider_timeout"],
+    [new Error("chat_completions_failed:429:busy"), "recommendation_provider_rate_limited"],
+    [new Error("responses_api_failed:503:down"), "recommendation_provider_server_error"],
+    [new TypeError("fetch failed"), "recommendation_provider_failed"],
+  ] as const) {
+    const failing: ContextCleanRecommendationProvider = { async recommend() { throw error; } };
+    const result = await analyzeContextCleanRecommendations({ tasks: [task()], provider: failing });
+    assert.deepEqual(result.reasons, [reason]);
+  }
+});
+
+test("incomplete estimator config is lazy and falls back as provider unavailable", async () => {
+  let apiProvider: ContextCleanRecommendationProvider | undefined;
+  assert.doesNotThrow(() => {
+    apiProvider = createApiContextCleanRecommendationProvider({
+      baseUrl: "", apiKey: "", model: "",
+    });
+  });
+  const result = await analyzeContextCleanRecommendations({ tasks: [task()], provider: apiProvider });
+  assert.equal(result.fallbackUsed, true);
+  assert.deepEqual(result.reasons, ["recommendation_provider_unavailable"]);
+  assert.equal(result.tasks[0]?.recommendation, "keep");
+});
+
+test("API provider reuses estimator config and JSON client without exposing credentials", async () => {
+  let capturedConfig: unknown;
+  let capturedPayload = "";
+  const apiProvider = createApiContextCleanRecommendationProvider(
+    { baseUrl: "https://example.test/v1", apiKey: "sk-secret-value", model: "model-a" },
+    (config) => {
+      capturedConfig = config;
+      return { async request(request) {
+        capturedPayload = request.userPayload;
+        return { text: JSON.stringify(outputFor([task()])) };
+      } };
+    },
+  );
+  await apiProvider.recommend(buildContextCleanRecommendationProviderInput({ tasks: [task()] }));
+  assert.deepEqual(capturedConfig, {
+    baseUrl: "https://example.test/v1", apiKey: "sk-secret-value", model: "model-a",
+  });
+  assert.equal(capturedPayload.includes("sk-secret-value"), false);
+});

--- a/components/packages/features/eviction/src/index.ts
+++ b/components/packages/features/eviction/src/index.ts
@@ -3,6 +3,7 @@ export * from "./contracts.js";
 export * from "./context-mutation-plan.js";
 export * from "./planning/index.js";
 export * from "./task-state-estimator.js";
+export * from "./json-model-client.js";
 export * from "./task-update-mapper.js";
 export * from "./history-apply.js";
 export * from "./lifecycle-policy-context.js";

--- a/components/packages/features/eviction/src/json-model-client.ts
+++ b/components/packages/features/eviction/src/json-model-client.ts
@@ -1,0 +1,122 @@
+import type { TaskStateEstimatorApiConfig, TaskStateEstimatorOutput } from "./types.js";
+
+export type JsonModelUsage = NonNullable<TaskStateEstimatorOutput["usage"]>;
+export type JsonModelRequest = { systemPrompt: string; userPayload: string };
+export type JsonModelResponse = { text: string; usage?: JsonModelUsage };
+export type JsonModelClient = {
+  request(input: JsonModelRequest): Promise<JsonModelResponse>;
+};
+
+function extractResponsesText(payload: any): string {
+  const texts: string[] = [];
+  for (const item of Array.isArray(payload?.output) ? payload.output : []) {
+    for (const part of Array.isArray(item?.content) ? item.content : []) {
+      if (typeof part?.text === "string" && part.text.trim()) texts.push(part.text.trim());
+    }
+  }
+  if (texts.length > 0) return texts.join("\n");
+  return typeof payload?.output_text === "string" ? payload.output_text.trim() : "";
+}
+
+function extractChatText(payload: any): string {
+  const content = Array.isArray(payload?.choices) ? payload.choices[0]?.message?.content : undefined;
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part: any) => typeof part?.text === "string" ? part.text.trim() : "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  if (value == null || value === "") return undefined;
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : undefined;
+}
+
+function extractUsage(payload: any): JsonModelUsage | undefined {
+  const usage = payload?.usage;
+  if (!usage || typeof usage !== "object") return undefined;
+  const inputTokens = finiteNumber(
+    usage.input_tokens ?? usage.prompt_tokens ?? usage.inputTokens ?? usage.promptTokens,
+  ) ?? 0;
+  const outputTokens = finiteNumber(
+    usage.output_tokens ?? usage.completion_tokens ?? usage.outputTokens ?? usage.completionTokens,
+  ) ?? 0;
+  const totalTokens = finiteNumber(usage.total_tokens ?? usage.totalTokens)
+    ?? inputTokens + outputTokens;
+  const costUsd = finiteNumber(
+    usage.cost_usd ?? usage.costUsd ?? usage.total_cost ?? usage.totalCost ?? payload?.cost_usd,
+  );
+  return {
+    inputTokens: Math.max(0, inputTokens),
+    outputTokens: Math.max(0, outputTokens),
+    totalTokens: Math.max(0, totalTokens),
+    ...(costUsd !== undefined ? { costUsd: Math.max(0, costUsd) } : {}),
+  };
+}
+
+/** OpenAI-compatible JSON client shared by estimator-backed feature analyzers. */
+export function createApiJsonModelClient(
+  config: Pick<TaskStateEstimatorApiConfig, "baseUrl" | "apiKey" | "model" | "requestTimeoutMs">,
+): JsonModelClient {
+  if (!config.baseUrl || !config.apiKey || !config.model) {
+    throw new Error("json model client requires baseUrl, apiKey, and model");
+  }
+  const baseUrl = config.baseUrl.replace(/\/+$/, "");
+  const requestTimeoutMs = Math.max(1_000, config.requestTimeoutMs ?? 60_000);
+
+  return {
+    async request(input): Promise<JsonModelResponse> {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+      try {
+        try {
+          const response = await fetch(`${baseUrl}/responses`, {
+            method: "POST",
+            headers: { "content-type": "application/json", authorization: `Bearer ${config.apiKey}` },
+            signal: controller.signal,
+            body: JSON.stringify({
+              model: config.model,
+              input: [
+                { role: "system", content: [{ type: "input_text", text: input.systemPrompt }] },
+                { role: "user", content: [{ type: "input_text", text: input.userPayload }] },
+              ],
+              text: { format: { type: "json_object" } },
+            }),
+          });
+          if (!response.ok) {
+            throw new Error(`responses_api_failed:${response.status}:${await response.text()}`);
+          }
+          const payload = await response.json();
+          return { text: extractResponsesText(payload), usage: extractUsage(payload) };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!message.includes("responses_api_failed:")) throw error;
+        }
+
+        const response = await fetch(`${baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: `Bearer ${config.apiKey}` },
+          signal: controller.signal,
+          body: JSON.stringify({
+            model: config.model,
+            messages: [
+              { role: "system", content: input.systemPrompt },
+              { role: "user", content: input.userPayload },
+            ],
+            response_format: { type: "json_object" },
+            temperature: 0,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(`chat_completions_failed:${response.status}:${await response.text()}`);
+        }
+        const payload = await response.json();
+        return { text: extractChatText(payload), usage: extractUsage(payload) };
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+  };
+}

--- a/components/packages/features/eviction/src/task-state-estimator.ts
+++ b/components/packages/features/eviction/src/task-state-estimator.ts
@@ -5,6 +5,7 @@ import type {
   TaskStateEstimatorInput,
   TaskStateEstimatorOutput,
 } from "./types.js";
+import { createApiJsonModelClient } from "./json-model-client.js";
 
 function truncateText(value: string, maxChars = 600): string {
   const text = value.trim();
@@ -14,10 +15,6 @@ function truncateText(value: string, maxChars = 600): string {
 
 function uniqueStrings(values: Iterable<string>): string[] {
   return [...new Set([...values].filter((value) => value.trim().length > 0))];
-}
-
-function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
 }
 
 function buildSystemPrompt(
@@ -224,40 +221,6 @@ function buildUserPayload(
   });
 }
 
-function extractTextFromResponsePayload(payload: any): string {
-  const output = Array.isArray(payload?.output) ? payload.output : [];
-  const texts: string[] = [];
-  for (const item of output) {
-    const content = Array.isArray(item?.content) ? item.content : [];
-    for (const part of content) {
-      if (typeof part?.text === "string" && part.text.trim()) {
-        texts.push(part.text.trim());
-      }
-    }
-  }
-  if (texts.length > 0) return texts.join("\n");
-  if (typeof payload?.output_text === "string" && payload.output_text.trim()) {
-    return payload.output_text.trim();
-  }
-  return "";
-}
-
-function extractTextFromChatCompletionPayload(payload: any): string {
-  const choices = Array.isArray(payload?.choices) ? payload.choices : [];
-  const first = choices[0];
-  const content = first?.message?.content;
-  if (typeof content === "string" && content.trim()) {
-    return content.trim();
-  }
-  if (Array.isArray(content)) {
-    const texts = content
-      .map((part: any) => (typeof part?.text === "string" ? part.text.trim() : ""))
-      .filter((text: string) => text.length > 0);
-    if (texts.length > 0) return texts.join("\n");
-  }
-  return "";
-}
-
 function normalizeTaskUpdate(update: SemanticTaskUpdate): SemanticTaskUpdate {
   return {
     taskId: String(update.taskId ?? "").trim(),
@@ -327,143 +290,23 @@ function parseEstimatorOutput(
   return normalizeEstimatorOutput(parsed, input);
 }
 
-function numberFrom(value: unknown): number | undefined {
-  if (value == null || value === "") return undefined;
-  const numeric = Number(value);
-  return Number.isFinite(numeric) ? numeric : undefined;
-}
-
-function extractUsage(payload: any): TaskStateEstimatorOutput["usage"] {
-  const usage = payload?.usage;
-  if (!usage || typeof usage !== "object") return undefined;
-  const inputTokens = numberFrom(
-    usage.input_tokens ?? usage.prompt_tokens ?? usage.inputTokens ?? usage.promptTokens,
-  ) ?? 0;
-  const outputTokens = numberFrom(
-    usage.output_tokens ?? usage.completion_tokens ?? usage.outputTokens ?? usage.completionTokens,
-  ) ?? 0;
-  const totalTokens = numberFrom(usage.total_tokens ?? usage.totalTokens)
-    ?? inputTokens + outputTokens;
-  const costUsd = numberFrom(
-    usage.cost_usd ?? usage.costUsd ?? usage.total_cost ?? usage.totalCost ?? payload?.cost_usd,
-  );
-  return {
-    inputTokens: Math.max(0, inputTokens),
-    outputTokens: Math.max(0, outputTokens),
-    totalTokens: Math.max(0, totalTokens),
-    ...(costUsd !== undefined ? { costUsd: Math.max(0, costUsd) } : {}),
-  };
-}
-
 export function createApiTaskStateEstimator(
   cfg: TaskStateEstimatorApiConfig,
 ): TaskStateEstimator {
   if (!cfg.baseUrl || !cfg.apiKey || !cfg.model) {
     throw new Error("task-state estimator requires baseUrl, apiKey, and model");
   }
-  const baseUrl = normalizeBaseUrl(cfg.baseUrl);
-  const requestTimeoutMs = Math.max(1000, cfg.requestTimeoutMs ?? 60_000);
   const evictionLookaheadTurns = Math.max(1, cfg.evictionLookaheadTurns ?? 3);
   const lifecycleMode = cfg.lifecycleMode === "decoupled" ? "decoupled" : "coupled";
   const evidenceMode = cfg.evidenceMode === "two_state" ? "two_state" : "three_state";
-  async function requestViaResponses(
-    controller: AbortController,
-    input: TaskStateEstimatorInput,
-  ): Promise<TaskStateEstimatorOutput> {
-    const response = await fetch(`${baseUrl}/responses`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${cfg.apiKey}`,
-      },
-      signal: controller.signal,
-      body: JSON.stringify({
-        model: cfg.model,
-        input: [
-          {
-            role: "system",
-            content: [{ type: "input_text", text: buildSystemPrompt({ evictionLookaheadTurns, lifecycleMode, evidenceMode }) }],
-          },
-          {
-            role: "user",
-            content: [{ type: "input_text", text: buildUserPayload(input, evidenceMode) }],
-          },
-        ],
-        text: {
-          format: {
-            type: "json_object",
-          },
-        },
-      }),
-    });
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`responses_api_failed:${response.status}:${errorText}`);
-    }
-    const payload = await response.json();
-    const rawText = extractTextFromResponsePayload(payload);
-    return {
-      ...parseEstimatorOutput(rawText, input),
-      usage: extractUsage(payload),
-    };
-  }
-
-  async function requestViaChatCompletions(
-    controller: AbortController,
-    input: TaskStateEstimatorInput,
-  ): Promise<TaskStateEstimatorOutput> {
-    const response = await fetch(`${baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${cfg.apiKey}`,
-      },
-      signal: controller.signal,
-      body: JSON.stringify({
-        model: cfg.model,
-        messages: [
-          {
-            role: "system",
-            content: buildSystemPrompt({ evictionLookaheadTurns, lifecycleMode, evidenceMode }),
-          },
-          {
-            role: "user",
-            content: buildUserPayload(input, evidenceMode),
-          },
-        ],
-        response_format: {
-          type: "json_object",
-        },
-        temperature: 0,
-      }),
-    });
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`chat_completions_failed:${response.status}:${errorText}`);
-    }
-    const payload = await response.json();
-    const rawText = extractTextFromChatCompletionPayload(payload);
-    return {
-      ...parseEstimatorOutput(rawText, input),
-      usage: extractUsage(payload),
-    };
-  }
-
+  const client = createApiJsonModelClient(cfg);
   return {
     async estimate(input: TaskStateEstimatorInput): Promise<TaskStateEstimatorOutput> {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
-      try {
-        try {
-          return await requestViaResponses(controller, input);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          if (!message.includes("responses_api_failed:")) throw error;
-        }
-        return await requestViaChatCompletions(controller, input);
-      } finally {
-        clearTimeout(timeout);
-      }
+      const response = await client.request({
+        systemPrompt: buildSystemPrompt({ evictionLookaheadTurns, lifecycleMode, evidenceMode }),
+        userPayload: buildUserPayload(input, evidenceMode),
+      });
+      return { ...parseEstimatorOutput(response.text, input), usage: response.usage };
     },
   };
 }

--- a/components/packages/features/eviction/tests/json-model-client.test.ts
+++ b/components/packages/features/eviction/tests/json-model-client.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createApiJsonModelClient } from "../src/json-model-client.js";
+
+test("sends a Responses JSON request and preserves text and usage", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestedUrl = "";
+  let requestedInit: RequestInit | undefined;
+  globalThis.fetch = async (input, init) => {
+    requestedUrl = String(input);
+    requestedInit = init;
+    return {
+      ok: true,
+      async json() {
+        return {
+          output: [{ content: [{ text: "{\"ok\":true}" }] }],
+          usage: { input_tokens: 12, output_tokens: 3, total_tokens: 15, cost_usd: 0.001 },
+        };
+      },
+    } as Response;
+  };
+  try {
+    const client = createApiJsonModelClient({
+      baseUrl: "https://example.test/v1/", apiKey: "secret", model: "model-a",
+    });
+    const response = await client.request({ systemPrompt: "system", userPayload: "{\"input\":true}" });
+    assert.equal(requestedUrl, "https://example.test/v1/responses");
+    assert.equal(new Headers(requestedInit?.headers).get("authorization"), "Bearer secret");
+    assert.deepEqual(JSON.parse(String(requestedInit?.body)), {
+      model: "model-a",
+      input: [
+        { role: "system", content: [{ type: "input_text", text: "system" }] },
+        { role: "user", content: [{ type: "input_text", text: "{\"input\":true}" }] },
+      ],
+      text: { format: { type: "json_object" } },
+    });
+    assert.deepEqual(response, {
+      text: "{\"ok\":true}",
+      usage: { inputTokens: 12, outputTokens: 3, totalTokens: 15, costUsd: 0.001 },
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("falls back to Chat Completions and preserves array content usage", async () => {
+  const originalFetch = globalThis.fetch;
+  const requestedUrls: string[] = [];
+  let chatBody: Record<string, unknown> | undefined;
+  globalThis.fetch = async (input, init) => {
+    requestedUrls.push(String(input));
+    if (requestedUrls.length === 1) {
+      return { ok: false, status: 404, async text() { return "missing"; } } as Response;
+    }
+    chatBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    return {
+      ok: true,
+      async json() {
+        return {
+          choices: [{ message: { content: [{ text: "{\"fallback\":true}" }] } }],
+          usage: { prompt_tokens: 8, completion_tokens: 2 },
+        };
+      },
+    } as Response;
+  };
+  try {
+    const client = createApiJsonModelClient({
+      baseUrl: "https://example.test/v1", apiKey: "secret", model: "model-a",
+    });
+    const response = await client.request({ systemPrompt: "system", userPayload: "payload" });
+    assert.deepEqual(requestedUrls, [
+      "https://example.test/v1/responses",
+      "https://example.test/v1/chat/completions",
+    ]);
+    assert.deepEqual(chatBody, {
+      model: "model-a",
+      messages: [
+        { role: "system", content: "system" },
+        { role: "user", content: "payload" },
+      ],
+      response_format: { type: "json_object" },
+      temperature: 0,
+    });
+    assert.deepEqual(response, {
+      text: "{\"fallback\":true}",
+      usage: { inputTokens: 8, outputTokens: 2, totalTokens: 10 },
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("does not hide network failures behind Chat Completions fallback", async () => {
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    throw new TypeError("fetch failed");
+  };
+  try {
+    const client = createApiJsonModelClient({
+      baseUrl: "https://example.test/v1", apiKey: "secret", model: "model-a",
+    });
+    await assert.rejects(
+      client.request({ systemPrompt: "system", userPayload: "payload" }),
+      /fetch failed/,
+    );
+    assert.equal(calls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("aborts requests at the configured timeout", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) => new Promise<Response>((_resolve, reject) => {
+    init?.signal?.addEventListener("abort", () => {
+      reject(new DOMException("request aborted", "AbortError"));
+    }, { once: true });
+  });
+  try {
+    const client = createApiJsonModelClient({
+      baseUrl: "https://example.test/v1", apiKey: "secret", model: "model-a", requestTimeoutMs: 1,
+    });
+    await assert.rejects(
+      client.request({ systemPrompt: "system", userPayload: "payload" }),
+      (error: unknown) => error instanceof Error && error.name === "AbortError",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("rejects incomplete estimator API configuration", () => {
+  assert.throws(
+    () => createApiJsonModelClient({ baseUrl: "", apiKey: "", model: "" }),
+    /requires baseUrl, apiKey, and model/,
+  );
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
 
   components/packages/features/cleaner:
     dependencies:
+      '@lightrsi/eviction':
+        specifier: workspace:*
+        version: link:../eviction
       '@lightrsi/history':
         specifier: workspace:*
         version: link:../../foundation/history


### PR DESCRIPTION
 ## Summary

  Implements the Context Cleaner Recommendation Analyzer described in task 7.3.

  The analyzer generates task-level labels, descriptions, summaries, recommendations, reason codes, and confidence values
  while preserving deterministic accounting, task identity, and safety decisions.

  ## Changes

  - Add the shared Context Cleaner recommendation analyzer and provider interface.
  - Reuse `TaskStateEstimatorApiConfig`; no Cleaner-specific credential configuration is introduced.
  - Extract the existing estimator HTTP transport into a shared `createApiJsonModelClient`.
  - Update the task-state estimator to use the extracted client without changing its prompt, schema, or lifecycle
  behavior.
  - Add strict model output validation with exact-field checking.
  - Add deterministic protection for active, unresolved, and non-selectable tasks.
  - Add fail-closed fallback behavior for unavailable providers, invalid configuration, timeout, 429, 5xx, network
  failures, and malformed output.
  - Preserve provider usage when a malformed output triggers fallback.

  ## Privacy And Safety

  The provider input contains only bounded task-level data:

  - SHA-256 task digest
  - sanitized label, description, and summary
  - bounded task evidence
  - lifecycle and accounting values

  It does not send:

  - raw Host context
  - raw request or response payloads
  - item IDs
  - item digests
  - API credentials

  Evidence is limited to 8 entries per category and 240 characters per entry. Known bearer tokens and API-key-like values
  are redacted.

  Model recommendations cannot change task identity, item targets, token accounting, or selectability. Deterministic
  protection always overrides a model recommendation to clean.

  ## Shared Client Refactor

  The OpenAI-compatible request logic previously lived inside `task-state-estimator.ts` and was not reusable.

  This PR extracts that logic into `json-model-client.ts` so the estimator and Cleaner analyzer use the same:

  - provider configuration
  - Responses API request format
  - Chat Completions fallback
  - timeout behavior
  - response text parsing
  - usage parsing

  The estimator prompt, input construction, output parsing, and lifecycle semantics are unchanged.

  ## Fallback Behavior

  - Missing provider or incomplete configuration: `recommendation_provider_unavailable`
  - Timeout or abort: `recommendation_provider_timeout`
  - HTTP 429: `recommendation_provider_rate_limited`
  - HTTP 5xx: `recommendation_provider_server_error`
  - Other network/provider failures: `recommendation_provider_failed`
  - Malformed model output: `recommendation_output_invalid`

  Fallback preserves the deterministic token breakdown and changes candidates only to `keep` or `protected`.

  ## Validation

  - `@lightrsi/cleaner`: 73/73 tests passed
  - `@lightrsi/eviction`: 45/45 tests passed
  - Cleaner typecheck passed
  - Eviction typecheck passed
  - Codex adapter typecheck passed
  - Claude Code adapter typecheck passed
  - Package boundaries passed: 18 packages / 68 internal edges
  - `git diff --cached --check` passed

  ## Scope

  Included:

  - Task-level recommendation analysis
  - Strict schema validation
  - Deterministic safety fallback
  - Shared estimator API-client extraction
  - Focused regression tests

  Not included:

  - CLI/TUI integration
  - Cleaner selection or approval flow
  - Host adapter runtime changes
  - OpenClaw apply integration
  - Applied receipt work
  - Changes to Cleaner contracts or state machines