### PR TITLE
feat(codex): record applied clean receipts

### DIFF
--- a/components/adapters/codex/src/context-cleaner/applied-receipt.ts
+++ b/components/adapters/codex/src/context-cleaner/applied-receipt.ts
@@ -1,0 +1,150 @@
+import type {
+  ContextCleanAppliedReceipt,
+  ContextCleanPreparedExecution,
+} from "@lightrsi/cleaner";
+import type { ContextRewriteResult } from "@lightrsi/host-adapter";
+
+import type { CodexSharedBackendDetails } from "../context-rewrite/backend.js";
+import type {
+  CodexRebaseEpoch,
+  CodexRebaseRequestResult,
+} from "../context-rewrite/types.js";
+
+export type CodexCleanerAppliedReceiptInput = {
+  execution: ContextCleanPreparedExecution;
+  epoch: CodexRebaseEpoch;
+};
+
+export type CodexCleanerAppliedReceiptBuildResult =
+  | { receipt: ContextCleanAppliedReceipt; reasons: [] }
+  | { receipt?: undefined; reasons: string[] };
+
+function uniqueNonBlankStrings(values: readonly string[]): boolean {
+  return values.length > 0
+    && values.every((value) => value.trim().length > 0)
+    && new Set(values).size === values.length;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && left.every((value) => right.includes(value));
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function validTimestamp(value: string): boolean {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function appliedTokenSavings(
+  execution: ContextCleanPreparedExecution,
+): number | null | undefined {
+  if (execution.scheduledReceipt.tokenCountMode === "chars_only") return null;
+  const savedTokens = execution.scheduledReceipt.estimatedSavedTokens;
+  return savedTokens !== null && nonNegativeInteger(savedTokens)
+    ? savedTokens
+    : undefined;
+}
+
+/**
+ * Builds an applied receipt only from the frozen Cleaner execution and the
+ * durable successful rebase epoch. This is also safe to use after a crash,
+ * because the plan id commits the exact operation and item scope.
+ */
+export function buildCodexCleanerAppliedReceipt(
+  params: CodexCleanerAppliedReceiptInput,
+): CodexCleanerAppliedReceiptBuildResult {
+  const { execution, epoch } = params;
+  const operationIds = execution.mutationPlan.operations.map((operation) => operation.id);
+  const itemIds = execution.mutationPlan.operations.flatMap(
+    (operation) => operation.targetItemIds,
+  );
+  if (execution.scheduledReceipt.status !== "scheduled"
+    || execution.mutationPlan.sourceModuleId !== "cleaner_manual"
+    || execution.cleanPlanId !== execution.scheduledReceipt.planId
+    || execution.hostId !== "codex"
+    || execution.sessionId !== execution.scheduledReceipt.sessionId
+    || execution.baseRevision !== execution.mutationPlan.baseRevision
+    || !uniqueNonBlankStrings(operationIds)
+    || !uniqueNonBlankStrings(itemIds)) {
+    return { reasons: ["cleaner_receipt_execution_invalid"] };
+  }
+  if (epoch.status !== "committed"
+    || epoch.sessionId !== execution.sessionId
+    || epoch.planId !== execution.mutationPlan.planId
+    || epoch.oldRevision !== execution.baseRevision
+    || !epoch.newResponseId?.trim()
+    || !epoch.newRevision?.trim()
+    || !epoch.accounting
+    || !validTimestamp(epoch.updatedAt)
+    || !nonNegativeInteger(epoch.accounting.actuallyRemovedChars)
+    || !nonNegativeInteger(epoch.accounting.actuallyRemovedTokens)
+    || epoch.accounting.fallbackExtraRequestCount !== 0) {
+    return { reasons: ["cleaner_receipt_epoch_invalid"] };
+  }
+  const appliedSavedTokens = appliedTokenSavings(execution);
+  if (appliedSavedTokens === undefined) {
+    return { reasons: ["cleaner_receipt_token_accounting_invalid"] };
+  }
+  return {
+    receipt: {
+      ...execution.scheduledReceipt,
+      status: "applied",
+      deferredTaskIds: [],
+      fallbackUsed: false,
+      reasons: [],
+      updatedAt: epoch.updatedAt,
+      appliedSavedTokens,
+      appliedSavedChars: epoch.accounting.actuallyRemovedChars,
+      evidence: {
+        previousRevision: epoch.oldRevision,
+        nextRevision: epoch.newRevision,
+        operationIds,
+        itemIds,
+        eventIds: [`codex-rebase-epoch:${epoch.epochId}`],
+        providerResponseId: epoch.newResponseId,
+      },
+    },
+    reasons: [],
+  };
+}
+
+/** Validates that a just-prepared rewrite fully matches the committed epoch. */
+export function buildCodexCleanerAppliedReceiptFromRewrite(params: {
+  execution: ContextCleanPreparedExecution;
+  rewriteResult: ContextRewriteResult<CodexSharedBackendDetails>;
+  rebaseRequest: CodexRebaseRequestResult;
+  epoch: CodexRebaseEpoch;
+}): CodexCleanerAppliedReceiptBuildResult {
+  const base = buildCodexCleanerAppliedReceipt(params);
+  if (!base.receipt) return base;
+
+  const operationIds = params.execution.mutationPlan.operations.map((operation) => operation.id);
+  const itemIds = params.execution.mutationPlan.operations.flatMap(
+    (operation) => operation.targetItemIds,
+  );
+  const { rewriteResult, rebaseRequest, epoch } = params;
+  const accountingMatches = JSON.stringify(rebaseRequest.accounting)
+    === JSON.stringify(epoch.accounting);
+  if (!rewriteResult.applied
+    || !rewriteResult.changed
+    || rewriteResult.fallbackUsed
+    || rewriteResult.details?.rebasePrepared !== true
+    || rewriteResult.planId !== params.execution.mutationPlan.planId
+    || rewriteResult.previousRevision !== rebaseRequest.oldRevision
+    || rewriteResult.nextRevision !== rebaseRequest.rebaseRevision
+    || rewriteResult.previousRevision !== epoch.oldRevision
+    || rewriteResult.nextRevision !== epoch.newRevision
+    || rewriteResult.deferredOperationIds.length !== 0
+    || !sameStringSet(rewriteResult.appliedOperationIds, operationIds)
+    || !sameStringSet(rewriteResult.removedItemIds, itemIds)
+    || rewriteResult.savedChars !== epoch.accounting?.actuallyRemovedChars
+    || JSON.stringify(rewriteResult.details.accounting) !== JSON.stringify(rebaseRequest.accounting)
+    || !accountingMatches) {
+    return { reasons: ["cleaner_receipt_rewrite_evidence_invalid"] };
+  }
+  return base;
+}

--- a/components/adapters/codex/src/context-cleaner/index.ts
+++ b/components/adapters/codex/src/context-cleaner/index.ts
@@ -1,2 +1,3 @@
 export * from "./bridge.js";
+export * from "./applied-receipt.js";
 export * from "./session-catalog.js";

--- a/components/adapters/codex/src/context-cleaner/runtime.ts
+++ b/components/adapters/codex/src/context-cleaner/runtime.ts
@@ -1,5 +1,9 @@
 import {
   createContextCleanerHostExecutionBridge,
+  deriveContextCleanStoredExecution,
+  readContextCleanPlan,
+  readContextCleanReceipt,
+  recoverContextCleanState,
   type ContextCleanPreparedExecution,
   type ContextCleanReceipt,
   type ContextCleanScheduledReceipt,
@@ -26,11 +30,19 @@ import {
   acquireCodexRebaseSessionLock,
   readCodexRebaseEpochJournal,
 } from "../context-rewrite/rebase-epoch.js";
-import type { CodexRebaseRequestResult } from "../context-rewrite/types.js";
+import type {
+  CodexRebaseEpoch,
+  CodexRebaseRequestResult,
+} from "../context-rewrite/types.js";
+import {
+  buildCodexCleanerAppliedReceipt,
+  buildCodexCleanerAppliedReceiptFromRewrite,
+} from "./applied-receipt.js";
 import {
   appendCodexCleanerCommitted,
   appendCodexCleanerTerminal,
   readCodexCleanerSchedule,
+  type CodexCleanerCommittedRecord,
   type CodexCleanerScheduledRecord,
 } from "./scheduler.js";
 
@@ -68,6 +80,10 @@ export type CodexCleanerHandoffValidation = {
   reasonCodes: string[];
 };
 
+export type CodexCleanerAppliedReceiptFinalization =
+  | { outcome: "applied"; reasonCodes: [] }
+  | { outcome: "reserved"; reasonCodes: string[] };
+
 function uniqueStrings(values: Iterable<string>): string[] {
   const result: string[] = [];
   const seen = new Set<string>();
@@ -82,6 +98,10 @@ function uniqueStrings(values: Iterable<string>): string[] {
 
 function sameCanonicalValue(left: unknown, right: unknown): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value) => right.includes(value));
 }
 
 function fullyApplied(
@@ -146,6 +166,16 @@ function executionBridge(params: {
   });
 }
 
+function receiptBridge(stateDir: string) {
+  return createContextCleanerHostExecutionBridge({
+    stateDir,
+    hostId: "codex",
+    async readExecutionSnapshot() {
+      throw new Error("cleaner_runtime_receipt_write_does_not_read_host_state");
+    },
+  });
+}
+
 function staleReasonCodes(reasonCodes: readonly string[]): string[] | undefined {
   const stale = uniqueStrings(reasonCodes.filter((reason) => STALE_REASONS.has(reason)));
   return stale.length > 0 ? stale : undefined;
@@ -190,14 +220,7 @@ async function persistStale(params: {
     reasons: [...params.reasonCodes],
     updatedAt: params.updatedAt,
   };
-  const bridge = createContextCleanerHostExecutionBridge({
-    stateDir: params.stateDir,
-    hostId: "codex",
-    async readExecutionSnapshot() {
-      throw new Error("cleaner_runtime_stale_does_not_read_host_state");
-    },
-  });
-  const stored = await bridge.recordCleanReceipt(receipt);
+  const stored = await receiptBridge(params.stateDir).recordCleanReceipt(receipt);
   if (stored.bypassed) {
     return {
       outcome: "reserved",
@@ -248,6 +271,197 @@ export async function finalizeCodexCleanerHandoffFailure(params: {
   });
 }
 
+export async function finalizeCodexCleanerAppliedReceipt(params: {
+  stateDir: string;
+  sessionId: string;
+  prepared: CodexCleanerPreparedRebase;
+  epoch: CodexRebaseEpoch;
+}): Promise<CodexCleanerAppliedReceiptFinalization> {
+  const built = buildCodexCleanerAppliedReceiptFromRewrite({
+    execution: params.prepared.execution,
+    rewriteResult: params.prepared.rewriteResult,
+    rebaseRequest: params.prepared.rebaseRequest,
+    epoch: params.epoch,
+  });
+  if (!built.receipt) {
+    return { outcome: "reserved", reasonCodes: built.reasons };
+  }
+  const stored = await receiptBridge(params.stateDir).recordCleanReceipt(built.receipt);
+  if (stored.bypassed || stored.value?.status !== "applied") {
+    return {
+      outcome: "reserved",
+      reasonCodes: uniqueStrings([
+        "cleaner_runtime_applied_receipt_write_failed",
+        ...stored.reasons,
+      ]),
+    };
+  }
+  const local = await appendCodexCleanerCommitted({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+    cleanPlanId: params.prepared.execution.cleanPlanId,
+    mutationPlanId: params.prepared.execution.mutationPlan.planId,
+    epochId: params.epoch.epochId,
+    updatedAt: params.epoch.updatedAt,
+  });
+  if (local.outcome !== "transitioned" && local.outcome !== "unchanged") {
+    return {
+      outcome: "reserved",
+      reasonCodes: uniqueStrings([
+        "cleaner_runtime_applied_schedule_write_failed",
+        ...local.reasons,
+      ]),
+    };
+  }
+  return { outcome: "applied", reasonCodes: [] };
+}
+
+type CodexCleanerCommitRecovery =
+  | { outcome: "none"; reasonCodes: [] }
+  | {
+      outcome: "recovered";
+      commit: {
+        cleanPlanId: string;
+        mutationPlanId: string;
+        epochId: string;
+        updatedAt: string;
+      };
+      reasonCodes: [];
+    }
+  | { outcome: "terminal"; receipt: ContextCleanReceipt; reasonCodes: string[] }
+  | { outcome: "reserved"; reasonCodes: string[] };
+
+function asScheduledReceiptForRecovery(
+  receipt: ContextCleanReceipt,
+): ContextCleanScheduledReceipt | undefined {
+  if (receipt.status === "scheduled") return { ...receipt, status: "scheduled" };
+  if (receipt.status !== "applied") return undefined;
+  const {
+    appliedSavedTokens: _appliedSavedTokens,
+    appliedSavedChars: _appliedSavedChars,
+    evidence: _evidence,
+    ...scheduled
+  } = receipt;
+  return { ...scheduled, status: "scheduled", fallbackUsed: false };
+}
+
+async function recoverCodexCleanerCommittedEpoch(params: {
+  stateDir: string;
+  sessionId: string;
+  schedule: CodexCleanerScheduledRecord | CodexCleanerCommittedRecord;
+}): Promise<CodexCleanerCommitRecovery> {
+  const recovered = await recoverContextCleanState({
+    stateDir: params.stateDir,
+    planId: params.schedule.cleanPlanId,
+  });
+  if (recovered.bypassed) {
+    return {
+      outcome: "reserved",
+      reasonCodes: uniqueStrings([
+        "cleaner_runtime_receipt_recovery_failed",
+        ...recovered.reasons,
+      ]),
+    };
+  }
+  const [storedPlan, storedReceipt, epochs] = await Promise.all([
+    readContextCleanPlan({ stateDir: params.stateDir, planId: params.schedule.cleanPlanId }),
+    readContextCleanReceipt({ stateDir: params.stateDir, planId: params.schedule.cleanPlanId }),
+    readCodexRebaseEpochJournal(params.stateDir, params.sessionId),
+  ]);
+  if (storedPlan.bypassed || storedReceipt.bypassed) {
+    return {
+      outcome: "reserved",
+      reasonCodes: uniqueStrings([
+        "cleaner_runtime_receipt_recovery_unavailable",
+        ...storedPlan.reasons,
+        ...storedReceipt.reasons,
+      ]),
+    };
+  }
+  if (epochs.readError || epochs.malformedLineCount > 0) {
+    return {
+      outcome: "reserved",
+      reasonCodes: ["cleaner_runtime_epoch_journal_unavailable"],
+    };
+  }
+  if (!storedPlan.value || !storedReceipt.value) {
+    return params.schedule.status === "committed"
+      ? { outcome: "reserved", reasonCodes: ["cleaner_runtime_committed_receipt_missing"] }
+      : { outcome: "none", reasonCodes: [] };
+  }
+  const record = storedPlan.value.plan;
+  const receipt = storedReceipt.value;
+  if (record.hostId !== "codex"
+    || record.sessionId !== params.sessionId
+    || record.baseRevision !== params.schedule.baseRevision
+    || record.planId !== params.schedule.cleanPlanId
+    || storedPlan.value.status !== receipt.status
+    || receipt.hostId !== "codex"
+    || receipt.sessionId !== params.sessionId
+    || receipt.planId !== params.schedule.cleanPlanId
+    || !sameStringSet(receipt.selectedTaskIds, params.schedule.selectedTaskIds)) {
+    return { outcome: "reserved", reasonCodes: ["cleaner_runtime_receipt_identity_invalid"] };
+  }
+  if (receipt.status === "stale" || receipt.status === "cancelled" || receipt.status === "failed") {
+    return { outcome: "terminal", receipt, reasonCodes: receipt.reasons };
+  }
+  const scheduledReceipt = asScheduledReceiptForRecovery(receipt);
+  const storedExecution = scheduledReceipt && deriveContextCleanStoredExecution({
+    record: storedPlan.value,
+    selectedTaskIds: params.schedule.selectedTaskIds,
+  });
+  if (!scheduledReceipt || !storedExecution) {
+    return { outcome: "reserved", reasonCodes: ["cleaner_runtime_receipt_scope_invalid"] };
+  }
+  const execution: ContextCleanPreparedExecution = {
+    cleanPlanId: storedPlan.value.plan.planId,
+    hostId: storedPlan.value.plan.hostId,
+    sessionId: storedPlan.value.plan.sessionId,
+    baseRevision: storedPlan.value.plan.baseRevision,
+    selectedTasks: storedExecution.selectedTasks,
+    mutationPlan: storedExecution.mutationPlan,
+    scheduledReceipt,
+  };
+  const matchingEpoch = epochs.epochs.find((epoch) => (
+    epoch.status === "committed"
+    && epoch.planId === execution.mutationPlan.planId
+    && (params.schedule.status !== "committed" || epoch.epochId === params.schedule.epochId)
+  ));
+  if (!matchingEpoch) {
+    return params.schedule.status === "committed"
+      ? { outcome: "reserved", reasonCodes: ["cleaner_runtime_committed_epoch_missing"] }
+      : { outcome: "none", reasonCodes: [] };
+  }
+  const built = buildCodexCleanerAppliedReceipt({ execution, epoch: matchingEpoch });
+  if (!built.receipt) return { outcome: "reserved", reasonCodes: built.reasons };
+  if (receipt.status === "applied") {
+    if (!sameCanonicalValue(receipt, built.receipt)) {
+      return { outcome: "reserved", reasonCodes: ["cleaner_runtime_applied_receipt_evidence_invalid"] };
+    }
+  } else {
+    const stored = await receiptBridge(params.stateDir).recordCleanReceipt(built.receipt);
+    if (stored.bypassed || stored.value?.status !== "applied") {
+      return {
+        outcome: "reserved",
+        reasonCodes: uniqueStrings([
+          "cleaner_runtime_applied_receipt_write_failed",
+          ...stored.reasons,
+        ]),
+      };
+    }
+  }
+  return {
+    outcome: "recovered",
+    commit: {
+      cleanPlanId: execution.cleanPlanId,
+      mutationPlanId: execution.mutationPlan.planId,
+      epochId: matchingEpoch.epochId,
+      updatedAt: matchingEpoch.updatedAt,
+    },
+    reasonCodes: [],
+  };
+}
+
 async function persistExistingTerminal(params: {
   stateDir: string;
   sessionId: string;
@@ -294,9 +508,6 @@ export async function prepareCodexCleanerRebase(params: {
   if (initial.outcome === "bypassed") {
     return { outcome: "reserved", reasonCodes: initial.reasons };
   }
-  if (initial.outcome === "committed") {
-    return { outcome: "committed", reasonCodes: ["cleaner_runtime_already_committed"] };
-  }
   if (initial.outcome === "terminal") {
     return { outcome: "terminal", reasonCodes: initial.record.reasons };
   }
@@ -317,81 +528,86 @@ export async function prepareCodexCleanerRebase(params: {
   } | undefined;
   try {
     const currentSchedule = await readCodexCleanerSchedule(params);
-    if (currentSchedule.outcome !== "ready") {
-      decision = currentSchedule.outcome === "missing"
-        ? { outcome: "reserved", reasonCodes: ["cleaner_runtime_schedule_changed"] }
-        : currentSchedule.outcome === "bypassed"
-          ? { outcome: "reserved", reasonCodes: currentSchedule.reasons }
-          : currentSchedule.outcome === "committed"
-            ? { outcome: "committed", reasonCodes: ["cleaner_runtime_already_committed"] }
-            : { outcome: "terminal", reasonCodes: currentSchedule.record.reasons };
-    } else if (!sameCanonicalValue(initial.record, currentSchedule.record)) {
+    if (currentSchedule.outcome === "missing") {
+      decision = { outcome: "reserved", reasonCodes: ["cleaner_runtime_schedule_changed"] };
+    } else if (currentSchedule.outcome === "bypassed") {
+      decision = { outcome: "reserved", reasonCodes: currentSchedule.reasons };
+    } else if (currentSchedule.outcome === "terminal") {
+      decision = { outcome: "terminal", reasonCodes: currentSchedule.record.reasons };
+    } else if (currentSchedule.outcome === "ready"
+      && initial.outcome === "ready"
+      && !sameCanonicalValue(initial.record, currentSchedule.record)) {
       decision = { outcome: "reserved", reasonCodes: ["cleaner_runtime_schedule_changed"] };
     } else {
-      let context;
-      try {
-        context = await executionContext(params);
-      } catch {
+      const recovery = await recoverCodexCleanerCommittedEpoch({
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        schedule: currentSchedule.record,
+      });
+      if (recovery.outcome === "recovered") {
+        recoveredCommit = recovery.commit;
         decision = {
-          outcome: "reserved",
-          reasonCodes: ["cleaner_runtime_execution_context_unavailable"],
+          outcome: "committed",
+          reasonCodes: ["cleaner_runtime_already_committed"],
         };
-        return decision;
-      }
-      const bridge = executionBridge({
-        ...params,
-        backendRequest: context.backendRequest,
-        snapshot: context.snapshot,
-      });
-      const prepared = await bridge.prepareScheduledClean({
-        cleanPlanId: currentSchedule.record.cleanPlanId,
-        sessionId: currentSchedule.record.sessionId,
-        baseRevision: currentSchedule.record.baseRevision,
-        selectedTaskIds: currentSchedule.record.selectedTaskIds,
-      });
-      if (prepared.outcome === "terminal") {
+      } else if (recovery.outcome === "terminal") {
         decision = {
           outcome: "terminal",
-          receipt: prepared.receipt,
-          reasonCodes: prepared.receipt.reasons.length > 0
-            ? prepared.receipt.reasons
+          receipt: recovery.receipt,
+          reasonCodes: recovery.reasonCodes.length > 0
+            ? recovery.reasonCodes
             : ["cleaner_runtime_terminal_receipt"],
         };
-      } else if (prepared.outcome !== "ready") {
-        const stale = prepared.outcome === "bypassed"
-          ? staleReasonCodes(prepared.reasons)
-          : undefined;
-        if (stale && prepared.outcome === "bypassed"
-          && isScheduledReceipt(prepared.receipt)) {
-          scheduledReceipt = prepared.receipt;
-          decision = { outcome: "reserved", reasonCodes: stale };
-        } else {
-          decision = { outcome: "reserved", reasonCodes: prepared.reasons };
-        }
+      } else if (recovery.outcome === "reserved") {
+        decision = { outcome: "reserved", reasonCodes: recovery.reasonCodes };
+      } else if (currentSchedule.outcome === "committed") {
+        decision = {
+          outcome: "reserved",
+          reasonCodes: ["cleaner_runtime_committed_receipt_missing"],
+        };
       } else {
-        scheduledReceipt = prepared.execution.scheduledReceipt;
-        const epochs = await readCodexRebaseEpochJournal(params.stateDir, params.sessionId);
-        const committedEpoch = epochs.epochs.find((epoch) => (
-          epoch.status === "committed"
-          && epoch.planId === prepared.execution.mutationPlan.planId
-        ));
-        if (epochs.readError || epochs.malformedLineCount > 0) {
+        let context;
+        try {
+          context = await executionContext(params);
+        } catch {
           decision = {
             outcome: "reserved",
-            reasonCodes: ["cleaner_runtime_epoch_journal_unavailable"],
+            reasonCodes: ["cleaner_runtime_execution_context_unavailable"],
           };
-        } else if (committedEpoch) {
-          recoveredCommit = {
-            cleanPlanId: prepared.execution.cleanPlanId,
-            mutationPlanId: prepared.execution.mutationPlan.planId,
-            epochId: committedEpoch.epochId,
-            updatedAt: committedEpoch.updatedAt,
-          };
+          return decision;
+        }
+        const bridge = executionBridge({
+          ...params,
+          backendRequest: context.backendRequest,
+          snapshot: context.snapshot,
+        });
+        const prepared = await bridge.prepareScheduledClean({
+          cleanPlanId: currentSchedule.record.cleanPlanId,
+          sessionId: currentSchedule.record.sessionId,
+          baseRevision: currentSchedule.record.baseRevision,
+          selectedTaskIds: currentSchedule.record.selectedTaskIds,
+        });
+        if (prepared.outcome === "terminal") {
           decision = {
-            outcome: "committed",
-            reasonCodes: ["cleaner_runtime_already_committed"],
+            outcome: "terminal",
+            receipt: prepared.receipt,
+            reasonCodes: prepared.receipt.reasons.length > 0
+              ? prepared.receipt.reasons
+              : ["cleaner_runtime_terminal_receipt"],
           };
+        } else if (prepared.outcome !== "ready") {
+          const stale = prepared.outcome === "bypassed"
+            ? staleReasonCodes(prepared.reasons)
+            : undefined;
+          if (stale && prepared.outcome === "bypassed"
+            && isScheduledReceipt(prepared.receipt)) {
+            scheduledReceipt = prepared.receipt;
+            decision = { outcome: "reserved", reasonCodes: stale };
+          } else {
+            decision = { outcome: "reserved", reasonCodes: prepared.reasons };
+          }
         } else {
+          scheduledReceipt = prepared.execution.scheduledReceipt;
           const applied = await codexSharedContextRewriteBackend.apply({
             snapshot: context.snapshot,
             plan: prepared.execution.mutationPlan,

--- a/components/adapters/codex/src/proxy-runtime.ts
+++ b/components/adapters/codex/src/proxy-runtime.ts
@@ -19,6 +19,7 @@ import {
   startHostGatewayRuntimeServer,
   setForwardResponseHeaders,
 } from "@lightrsi/host-adapter";
+import { readContextCleanReceipt } from "@lightrsi/cleaner";
 import { configureStatePathResolver } from "@lightrsi/artifact-store";
 import type { TokenPilotCodexConfig } from "./config.js";
 import {
@@ -98,16 +99,14 @@ import type {
   CodexRebaseRequestResult,
 } from "./context-rewrite/types.js";
 import {
+  finalizeCodexCleanerAppliedReceipt,
   finalizeCodexCleanerHandoffFailure,
   isCodexCleanerStaleReasonCode,
   prepareCodexCleanerRebase,
   revalidateCodexCleanerPreparedRebase,
   type CodexCleanerPreparedRebase,
 } from "./context-cleaner/runtime.js";
-import {
-  appendCodexCleanerCommitted,
-  readCodexCleanerSchedule,
-} from "./context-cleaner/scheduler.js";
+import { readCodexCleanerSchedule } from "./context-cleaner/scheduler.js";
 
 export type CodexProxyRuntime = {
   baseUrl: string;
@@ -581,8 +580,17 @@ export async function startCodexResponsesProxy(params: {
         stateDir: config.stateDir,
         sessionId,
       });
+      const committedCleanerReceipt = cleanerSchedule.outcome === "committed"
+        ? await readContextCleanReceipt({
+          stateDir: config.stateDir,
+          planId: cleanerSchedule.record.cleanPlanId,
+        })
+        : undefined;
       const manualCleanerReserved = cleanerSchedule.outcome === "ready"
-        || cleanerSchedule.outcome === "bypassed";
+        || cleanerSchedule.outcome === "bypassed"
+        || (cleanerSchedule.outcome === "committed"
+          && (committedCleanerReceipt?.bypassed
+            || committedCleanerReceipt?.value?.status !== "applied"));
       const mutationPlan = manualCleanerReserved || lifecyclePlanningConfigured
         ? undefined
         : activeMutationPlan(config);
@@ -1453,21 +1461,25 @@ export async function startCodexResponsesProxy(params: {
             if (result.outcome === "committed"
               && cleanerPreparedRebase
               && result.epoch?.status === "committed") {
-              const localCommit = await appendCodexCleanerCommitted({
+              const finalized = await finalizeCodexCleanerAppliedReceipt({
                 stateDir: config.stateDir,
                 sessionId,
-                cleanPlanId: cleanerPreparedRebase.execution.cleanPlanId,
-                mutationPlanId: cleanerPreparedRebase.execution.mutationPlan.planId,
-                epochId: result.epoch.epochId,
-                updatedAt: result.epoch.updatedAt,
+                prepared: cleanerPreparedRebase,
+                epoch: result.epoch,
               });
-              if (localCommit.outcome !== "transitioned"
-                && localCommit.outcome !== "unchanged") {
+              await appendTrace(config.stateDir, {
+                stage: "context_cleaner_applied_receipt_finalized",
+                sessionId,
+                model,
+                outcome: finalized.outcome,
+                reasonCodes: finalized.reasonCodes,
+              });
+              if (finalized.outcome !== "applied") {
                 await appendTrace(config.stateDir, {
-                  stage: "context_cleaner_local_commit_failed",
+                  stage: "context_cleaner_applied_receipt_failed",
                   sessionId,
                   model,
-                  reasonCodes: localCommit.reasons,
+                  reasonCodes: finalized.reasonCodes,
                 });
               }
             }

--- a/components/adapters/codex/tests/context-cleaner-runtime.test.ts
+++ b/components/adapters/codex/tests/context-cleaner-runtime.test.ts
@@ -34,11 +34,13 @@ import {
   type CodexLifecycleBackendRequestBase,
 } from "../src/context-rewrite/index.js";
 import {
+  finalizeCodexCleanerAppliedReceipt,
   finalizeCodexCleanerHandoffFailure,
   prepareCodexCleanerRebase,
   revalidateCodexCleanerPreparedRebase,
 } from "../src/context-cleaner/runtime.js";
 import {
+  appendCodexCleanerCommitted,
   readCodexCleanerSchedule,
   scheduleCodexCleanerPlan,
 } from "../src/context-cleaner/scheduler.js";
@@ -491,6 +493,7 @@ test("Codex cleaner runtime repairs the crash window after a committed rebase ep
       epochId: "epoch-crash-window",
       oldPreviousResponseId: "response-parent",
       oldRevision: first.prepared.rebaseRequest.oldRevision,
+      accounting: first.prepared.rebaseRequest.accounting,
     });
     await commitCodexRebaseEpoch({
       stateDir,
@@ -498,17 +501,51 @@ test("Codex cleaner runtime repairs the crash window after a committed rebase ep
       epochId: "epoch-crash-window",
       newResponseId: "response-after-clean",
       newRevision: first.prepared.rebaseRequest.rebaseRevision,
+      accounting: first.prepared.rebaseRequest.accounting,
       updatedAt: "2026-08-22T00:00:05.000Z",
     });
+    assert.equal((await appendCodexCleanerCommitted({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: CLEAN_PLAN_ID,
+      mutationPlanId: first.prepared.execution.mutationPlan.planId,
+      epochId: "epoch-crash-window",
+      updatedAt: "2026-08-22T00:00:05.000Z",
+    })).outcome, "transitioned");
 
+    const postCommitView = sourceView("post-commit-revision");
     const recovered = await prepareCodexCleanerRebase({
       stateDir,
       sessionId: SESSION_ID,
-      view: seeded.view,
-      backendRequest: seeded.request,
+      view: postCommitView,
+      backendRequest: backendRequest(postCommitView),
       now: "2026-08-22T00:00:06.000Z",
     });
     assert.equal(recovered.outcome, "committed");
+    const receipt = await readContextCleanReceipt({ stateDir, planId: CLEAN_PLAN_ID });
+    assert.equal(receipt.value?.status, "applied");
+    if (receipt.value?.status === "applied") {
+      assert.equal(
+        receipt.value.appliedSavedChars,
+        first.prepared.rebaseRequest.accounting.actuallyRemovedChars,
+      );
+      assert.equal(receipt.value.appliedSavedTokens, null);
+      assert.equal(receipt.value.evidence.previousRevision, REVISION);
+      assert.equal(
+        receipt.value.evidence.nextRevision,
+        first.prepared.rebaseRequest.rebaseRevision,
+      );
+      assert.deepEqual(
+        receipt.value.evidence.itemIds,
+        first.prepared.execution.mutationPlan.operations.flatMap(
+          (operation) => operation.targetItemIds,
+        ),
+      );
+      assert.deepEqual(
+        receipt.value.evidence.operationIds,
+        first.prepared.execution.mutationPlan.operations.map((operation) => operation.id),
+      );
+    }
     const local = await readCodexCleanerSchedule({ stateDir, sessionId: SESSION_ID });
     assert.equal(local.outcome, "committed");
     if (local.outcome === "committed") {
@@ -518,6 +555,59 @@ test("Codex cleaner runtime repairs the crash window after a committed rebase ep
         first.prepared.execution.mutationPlan.planId,
       );
     }
+  });
+});
+
+test("Codex cleaner finalizer rejects malformed actual accounting without applying", async () => {
+  await withTempState(async (stateDir) => {
+    const seeded = await seedScheduledClean(stateDir);
+    const prepared = await prepareCodexCleanerRebase({
+      stateDir,
+      sessionId: SESSION_ID,
+      view: seeded.view,
+      backendRequest: seeded.request,
+    });
+    assert.equal(prepared.outcome, "ready");
+    if (prepared.outcome !== "ready") return;
+
+    const invalidAccounting = {
+      ...prepared.prepared.rebaseRequest.accounting,
+      actuallyRemovedChars: 1.5,
+    };
+    await appendPendingCodexRebaseEpoch({
+      stateDir,
+      sessionId: SESSION_ID,
+      planId: prepared.prepared.execution.mutationPlan.planId,
+      epochId: "epoch-invalid-accounting",
+      oldPreviousResponseId: "response-parent",
+      oldRevision: prepared.prepared.rebaseRequest.oldRevision,
+      accounting: invalidAccounting,
+    });
+    const epoch = await commitCodexRebaseEpoch({
+      stateDir,
+      sessionId: SESSION_ID,
+      epochId: "epoch-invalid-accounting",
+      newResponseId: "response-invalid-accounting",
+      newRevision: prepared.prepared.rebaseRequest.rebaseRevision,
+      accounting: invalidAccounting,
+      updatedAt: "2026-08-22T00:00:05.000Z",
+    });
+    const finalized = await finalizeCodexCleanerAppliedReceipt({
+      stateDir,
+      sessionId: SESSION_ID,
+      prepared: prepared.prepared,
+      epoch,
+    });
+    assert.equal(finalized.outcome, "reserved");
+    assert.ok(finalized.reasonCodes.includes("cleaner_receipt_epoch_invalid"));
+    assert.equal(
+      (await readContextCleanReceipt({ stateDir, planId: CLEAN_PLAN_ID })).value?.status,
+      "scheduled",
+    );
+    assert.equal(
+      (await readCodexCleanerSchedule({ stateDir, sessionId: SESSION_ID })).outcome,
+      "ready",
+    );
   });
 });
 
@@ -753,10 +843,17 @@ test("Codex proxy gives the scheduled manual cleaner exclusive ownership of the 
         (await readCodexCleanerSchedule({ stateDir, sessionId })).outcome,
         "committed",
       );
-      assert.equal(
-        (await readContextCleanReceipt({ stateDir, planId: cleanPlanId })).value?.status,
-        "scheduled",
-      );
+      const appliedReceipt = await readContextCleanReceipt({ stateDir, planId: cleanPlanId });
+      assert.equal(appliedReceipt.value?.status, "applied");
+      if (appliedReceipt.value?.status === "applied") {
+        assert.equal(appliedReceipt.value.fallbackUsed, false);
+        assert.ok(appliedReceipt.value.appliedSavedChars > 0);
+        assert.equal(appliedReceipt.value.appliedSavedTokens, null);
+        assert.equal(appliedReceipt.value.evidence.previousRevision, snapshot.revision);
+        assert.ok(appliedReceipt.value.evidence.nextRevision.trim());
+        assert.equal(appliedReceipt.value.evidence.operationIds.length, 1);
+        assert.deepEqual(appliedReceipt.value.evidence.itemIds, [selectedItem.stableItemId]);
+      }
 
       const estimatorCallsAfterManualCommit = estimator.calls();
       assert.equal((await send({

--- a/components/packages/features/cleaner/src/host-execution-bridge.ts
+++ b/components/packages/features/cleaner/src/host-execution-bridge.ts
@@ -187,6 +187,29 @@ function buildMutationPlan(params: {
   };
 }
 
+/**
+ * Reconstructs the immutable mutation scope from the persisted plan. Hosts use
+ * this for recovery only; it never accepts item ids or digests from a caller.
+ */
+export function deriveContextCleanStoredExecution(params: {
+  record: ContextCleanPlanRecord;
+  selectedTaskIds: readonly string[];
+}): {
+  selectedTasks: ApprovedContextCleanTask[];
+  mutationPlan: ContextMutationPlan;
+} | undefined {
+  if (!uniqueNonBlankStrings([...params.selectedTaskIds])) return undefined;
+  const selectedTasks = selectedTasksFromPlan(
+    params.record,
+    params.selectedTaskIds,
+  );
+  if (!selectedTasks) return undefined;
+  return {
+    selectedTasks,
+    mutationPlan: buildMutationPlan({ record: params.record, selectedTasks }),
+  };
+}
+
 async function readStoredExecutionState(params: {
   stateDir: string;
   planId: string;
@@ -278,10 +301,14 @@ async function prepareScheduledClean(params: {
     return bypassed(["clean_execution_not_scheduled"], stored.receipt);
   }
 
-  const selectedTasks = selectedTasksFromPlan(stored.record, request.selectedTaskIds);
-  if (!selectedTasks) {
+  const storedExecution = deriveContextCleanStoredExecution({
+    record: stored.record,
+    selectedTaskIds: request.selectedTaskIds,
+  });
+  if (!storedExecution) {
     return bypassed(["clean_execution_plan_selection_invalid"], stored.receipt);
   }
+  const { selectedTasks, mutationPlan } = storedExecution;
 
   let current: ContextCleanExecutionSnapshot;
   try {
@@ -331,7 +358,6 @@ async function prepareScheduledClean(params: {
     }
   }
 
-  const mutationPlan = buildMutationPlan({ record: stored.record, selectedTasks });
   const revalidation = revalidateContextMutationPlan({
     snapshot: current.snapshot,
     plan: mutationPlan,

--- a/components/packages/features/cleaner/src/index.ts
+++ b/components/packages/features/cleaner/src/index.ts
@@ -39,5 +39,6 @@ export type {
 } from "./token-accounting.js";
 export {
   createContextCleanerHostExecutionBridge,
+  deriveContextCleanStoredExecution,
   type CreateContextCleanerHostExecutionBridgeParams,
 } from "./host-execution-bridge.js";

--- a/components/packages/features/cleaner/tests/host-execution-bridge.test.ts
+++ b/components/packages/features/cleaner/tests/host-execution-bridge.test.ts
@@ -10,7 +10,9 @@ import {
   contextCleanReceiptFilePath,
   contextCleanTransactionFilePath,
   createContextCleanerHostExecutionBridge,
+  deriveContextCleanStoredExecution,
   readContextCleanReceipt,
+  readContextCleanPlan,
   saveContextCleanPlan,
   transitionContextCleanState,
 } from "../src/index.js";
@@ -78,6 +80,31 @@ test("execution bridge expands only the frozen scheduled task scope", async () =
       second.execution.mutationPlan.planId,
     );
     assert.equal("adapterMetadata" in first.execution.mutationPlan, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("stored execution derivation is deterministic and rejects duplicate task selections", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-execution-derived-"));
+  try {
+    await saveScheduledPlan(root);
+    const stored = await readContextCleanPlan({ stateDir: root, planId: "clean-plan-1" });
+    assert.ok(stored.value);
+    const first = deriveContextCleanStoredExecution({
+      record: stored.value,
+      selectedTaskIds: ["task-a"],
+    });
+    const second = deriveContextCleanStoredExecution({
+      record: stored.value,
+      selectedTaskIds: ["task-a"],
+    });
+    assert.deepEqual(first, second);
+    assert.equal(first?.mutationPlan.sourceModuleId, "cleaner_manual");
+    assert.equal(deriveContextCleanStoredExecution({
+      record: stored.value,
+      selectedTaskIds: ["task-a", "task-a"],
+    }), undefined);
   } finally {
     await rm(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Record an `applied` Cleaner receipt only after a committed Codex rebase.
- Preserve actual saved chars/tokens, revision transition, operation IDs, and item IDs as rewrite evidence.
- Recover interrupted receipt finalization from the frozen shared plan and committed rebase epoch.
- Keep shared Cleaner state authoritative; local schedule markers are written only after the shared applied receipt.
- Add coverage for applied evidence, crash recovery after revision changes, and malformed actual accounting.

## Verification

- `pnpm check:boundaries`
- WSL isolated journal concurrency test: passed 3/3
- WSL release-package test: passed
- WSL isolated daemon test: passed

Local Windows dependencies currently lack linked `tsx` / `typescript`. The default-parallel WSL adapter suite still has intermittent journal-lock and daemon-start failures; serial full-suite verification is pending.