### PR TITLE
feat(claude-code): apply approved clean overlays

### DIFF
--- a/components/adapters/claude-code/src/context-cleaner/applied-receipt.ts
+++ b/components/adapters/claude-code/src/context-cleaner/applied-receipt.ts
@@ -1,0 +1,93 @@
+import type {
+  ContextCleanAppliedReceipt,
+  ContextCleanPreparedExecution,
+} from "@lightrsi/cleaner";
+import type { ContextRewriteResult } from "@lightrsi/host-adapter";
+
+export type ClaudeCleanerAppliedReceiptBuildResult =
+  | { receipt: ContextCleanAppliedReceipt; reasons: [] }
+  | { receipt?: undefined; reasons: string[] };
+
+function uniqueNonBlankStrings(values: readonly string[]): boolean {
+  return values.length > 0
+    && values.every((value) => value.trim().length > 0)
+    && new Set(values).size === values.length;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && new Set(left).size === left.length
+    && new Set(right).size === right.length
+    && left.every((value) => right.includes(value));
+}
+
+function nonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function canonicalTimestamp(value: string): boolean {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+/**
+ * Builds an applied receipt only from the exact mutation that the Claude
+ * request-overlay backend produced. Estimates and partial overlays can never
+ * cross this boundary as applied savings.
+ */
+export function buildClaudeCleanerAppliedReceipt(params: {
+  execution: ContextCleanPreparedExecution;
+  rewriteResult: ContextRewriteResult;
+  overlayId: string;
+  updatedAt: string;
+}): ClaudeCleanerAppliedReceiptBuildResult {
+  const { execution, rewriteResult } = params;
+  const operationIds = execution.mutationPlan.operations.map((operation) => operation.id);
+  const itemIds = execution.mutationPlan.operations.flatMap((operation) => operation.targetItemIds);
+  if (execution.scheduledReceipt.status !== "scheduled"
+    || execution.cleanPlanId !== execution.scheduledReceipt.planId
+    || execution.hostId !== "claude-code"
+    || execution.sessionId !== execution.scheduledReceipt.sessionId
+    || execution.mutationPlan.hostId !== "claude-code"
+    || execution.mutationPlan.sessionId !== execution.sessionId
+    || execution.mutationPlan.sourceModuleId !== "cleaner_manual"
+    || !uniqueNonBlankStrings(operationIds)
+    || !uniqueNonBlankStrings(itemIds)
+    || !params.overlayId.trim()
+    || !canonicalTimestamp(params.updatedAt)) {
+    return { reasons: ["claude_cleaner_receipt_execution_invalid"] };
+  }
+  if (rewriteResult.mode !== "request_overlay"
+    || rewriteResult.planId !== execution.mutationPlan.planId
+    || !rewriteResult.applied
+    || !rewriteResult.changed
+    || rewriteResult.fallbackUsed
+    || !rewriteResult.previousRevision.trim()
+    || !rewriteResult.nextRevision.trim()
+    || rewriteResult.deferredOperationIds.length > 0
+    || !nonNegativeInteger(rewriteResult.savedChars)
+    || !sameStringSet(rewriteResult.appliedOperationIds, operationIds)
+    || !sameStringSet(rewriteResult.removedItemIds, itemIds)) {
+    return { reasons: ["claude_cleaner_receipt_rewrite_evidence_invalid"] };
+  }
+  return {
+    receipt: {
+      ...execution.scheduledReceipt,
+      status: "applied",
+      deferredTaskIds: [],
+      fallbackUsed: false,
+      reasons: [],
+      updatedAt: params.updatedAt,
+      appliedSavedTokens: null,
+      appliedSavedChars: rewriteResult.savedChars,
+      evidence: {
+        previousRevision: rewriteResult.previousRevision,
+        nextRevision: rewriteResult.nextRevision,
+        operationIds,
+        itemIds,
+        eventIds: [`claude-overlay:${params.overlayId}`],
+      },
+    },
+    reasons: [],
+  };
+}

--- a/components/adapters/claude-code/src/context-cleaner/bridge.ts
+++ b/components/adapters/claude-code/src/context-cleaner/bridge.ts
@@ -8,6 +8,7 @@ import {
 
 import { readLatestClaudeSnapshotRecord } from "../context-rewrite/snapshot-store.js";
 import { listClaudeCleanerSessions } from "./session-catalog.js";
+import { scheduleClaudeCleanerPlan } from "./scheduler.js";
 
 const CLAUDE_HOST_ID = "claude-code";
 
@@ -170,12 +171,26 @@ export function createClaudeCodeContextCleanerBridge(params: {
     },
     async executeApprovedClean(request) {
       const selectedTaskIds = validateApprovedRequest(request);
-      return validateReceipt({
+      const receipt = validateReceipt({
         receipt: await params.controlPlane.executeApprovedClean(request),
         planId: request.cleanPlanId,
         sessionId: request.sessionId,
         selectedTaskIds,
       });
+      if (receipt.status === "scheduled") {
+        const scheduled = await scheduleClaudeCleanerPlan({
+          stateDir: params.stateDir,
+          sessionId: request.sessionId,
+          cleanPlanId: request.cleanPlanId,
+          baseRevision: request.baseRevision,
+          selectedTaskIds,
+          scheduledAt: receipt.updatedAt,
+        });
+        if (scheduled.outcome !== "stored" && scheduled.outcome !== "unchanged") {
+          throw new Error(`claude_clean_schedule_failed:${scheduled.reasons.join(",")}`);
+        }
+      }
+      return receipt;
     },
     async readCleanReceipt(planId) {
       if (!planId.trim()) throw new Error("claude_clean_plan_id_invalid");

--- a/components/adapters/claude-code/src/context-cleaner/runtime.ts
+++ b/components/adapters/claude-code/src/context-cleaner/runtime.ts
@@ -1,0 +1,483 @@
+import { createHash } from "node:crypto";
+
+import {
+  createContextCleanerHostExecutionBridge,
+  type ContextCleanPreparedExecution,
+  type ContextCleanReceipt,
+  type ContextCleanTerminalReceipt,
+} from "@lightrsi/cleaner";
+import {
+  relocateContextMutationPlan,
+  revalidateContextMutationPlan,
+  validateContextMutationProtocolClosure,
+  type ContextRewriteResult,
+  type ModelContextSnapshot,
+} from "@lightrsi/host-adapter";
+
+import { applyArchivePlan } from "../context-rewrite/archive.js";
+import {
+  claudeContextRewriteBackend,
+  type ClaudeOverlayRequest,
+} from "../context-rewrite/backend.js";
+import { buildClaudeCleanerAppliedReceipt } from "./applied-receipt.js";
+import {
+  acquireClaudeCleanerScheduleLock,
+  appendClaudeCleanerCommitted,
+  appendClaudeCleanerTerminal,
+  readClaudeCleanerSchedule,
+  type ClaudeCleanerScheduledRecord,
+} from "./scheduler.js";
+
+const STALE_REASONS = new Set([
+  "clean_execution_revision_stale",
+  "clean_execution_item_stale",
+  "clean_execution_protected_item_targeted",
+  "clean_execution_task_attribution_stale",
+  "clean_execution_task_not_evictable",
+  "clean_execution_revalidation_failed",
+  "clean_execution_protocol_closure_failed",
+  "claude_cleaner_relocation_incomplete",
+  "claude_cleaner_current_scope_invalid",
+  "claude_cleaner_overlay_incomplete",
+]);
+
+type ClaudeCleanerPreparedOverlay = {
+  outcome: "prepared";
+  suppressAutomaticEviction: true;
+  execution: ContextCleanPreparedExecution;
+  request: ClaudeOverlayRequest;
+  rewriteResult: ContextRewriteResult;
+  overlayId: string;
+  release(): Promise<void>;
+};
+
+export type ClaudeCleanerOverlayResult =
+  | { outcome: "absent"; suppressAutomaticEviction: false; reasonCodes: [] }
+  | ClaudeCleanerPreparedOverlay
+  | { outcome: "terminal"; suppressAutomaticEviction: true; reasonCodes: string[] }
+  | { outcome: "reserved"; suppressAutomaticEviction: true; reasonCodes: string[] };
+
+export type ClaudeCleanerOverlayFinalization =
+  | { outcome: "applied"; reasonCodes: string[] }
+  | { outcome: "reserved"; reasonCodes: string[] };
+
+function uniqueReasons(reasons: readonly string[]): string[] {
+  return [...new Set(reasons.filter((reason) => reason.trim().length > 0))];
+}
+
+function overlayId(execution: ContextCleanPreparedExecution, revision: string): string {
+  return createHash("sha256")
+    .update(JSON.stringify({
+      cleanPlanId: execution.cleanPlanId,
+      mutationPlanId: execution.mutationPlan.planId,
+      revision,
+      operationIds: execution.mutationPlan.operations.map((operation) => operation.id),
+    }))
+    .digest("hex")
+    .slice(0, 24);
+}
+
+function staleReasonCodes(reasons: readonly string[]): string[] | undefined {
+  const normalized = uniqueReasons(reasons);
+  return normalized.some((reason) => STALE_REASONS.has(reason)) ? normalized : undefined;
+}
+
+function terminalReceipt(params: {
+  scheduledReceipt: ContextCleanPreparedExecution["scheduledReceipt"];
+  status: ContextCleanTerminalReceipt["status"];
+  reasons: string[];
+  updatedAt: string;
+}): ContextCleanTerminalReceipt {
+  return {
+    ...params.scheduledReceipt,
+    status: params.status,
+    deferredTaskIds: [...params.scheduledReceipt.selectedTaskIds],
+    fallbackUsed: params.status === "failed",
+    reasons: uniqueReasons(params.reasons),
+    updatedAt: params.updatedAt,
+  };
+}
+
+async function persistTerminal(params: {
+  stateDir: string;
+  sessionId: string;
+  execution: ContextCleanPreparedExecution;
+  status: "stale" | "failed";
+  reasonCodes: string[];
+  updatedAt: string;
+}): Promise<ClaudeCleanerOverlayResult> {
+  const receipt = terminalReceipt({
+    scheduledReceipt: params.execution.scheduledReceipt,
+    status: params.status,
+    reasons: params.reasonCodes,
+    updatedAt: params.updatedAt,
+  });
+  const bridge = createContextCleanerHostExecutionBridge({
+    stateDir: params.stateDir,
+    hostId: "claude-code",
+    async readExecutionSnapshot() {
+      throw new Error("terminal receipt does not read an execution snapshot");
+    },
+  });
+  const stored = await bridge.recordCleanReceipt(receipt);
+  if (stored.bypassed || stored.value?.status !== params.status) {
+    return {
+      outcome: "reserved",
+      suppressAutomaticEviction: true,
+      reasonCodes: uniqueReasons(["claude_cleaner_terminal_receipt_write_failed", ...stored.reasons]),
+    };
+  }
+  const local = await appendClaudeCleanerTerminal({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+    cleanPlanId: params.execution.cleanPlanId,
+    receiptStatus: params.status,
+    reasons: receipt.reasons,
+    updatedAt: params.updatedAt,
+  });
+  if (local.outcome !== "transitioned" && local.outcome !== "unchanged") {
+    return {
+      outcome: "reserved",
+      suppressAutomaticEviction: true,
+      reasonCodes: uniqueReasons(["claude_cleaner_terminal_schedule_write_failed", ...local.reasons]),
+    };
+  }
+  return { outcome: "terminal", suppressAutomaticEviction: true, reasonCodes: receipt.reasons };
+}
+
+function currentScopeIsSafe(params: {
+  execution: ContextCleanPreparedExecution;
+  snapshot: ModelContextSnapshot;
+  activeTaskIds: readonly string[];
+  evictableTaskIds: readonly string[];
+}): boolean {
+  const active = new Set(params.activeTaskIds);
+  const evictable = new Set(params.evictableTaskIds);
+  const items = new Map(params.snapshot.items.map((item) => [item.stableId, item]));
+  return params.execution.mutationPlan.operations.every((operation) => {
+    const taskIds = operation.taskIds ?? [];
+    return taskIds.length > 0
+      && taskIds.every((taskId) => !active.has(taskId) && evictable.has(taskId))
+      && operation.targetItemIds.every((itemId) => {
+        const item = items.get(itemId);
+        return item !== undefined
+          && item.kind !== "system"
+          && item.kind !== "developer"
+          && item.role !== "system"
+          && item.role !== "developer"
+          && taskIds.some((taskId) => item.taskIds?.includes(taskId));
+      });
+  });
+}
+
+function archivePreservedFullScope(execution: ContextCleanPreparedExecution): boolean {
+  return execution.mutationPlan.operations.every((operation) => (
+    operation.targetItemIds.length > 0
+    && Object.keys(operation.targetItemFingerprints ?? {}).length === operation.targetItemIds.length
+  ));
+}
+
+async function prepareLockedOverlay(params: {
+  stateDir: string;
+  sessionId: string;
+  baseSnapshot: ModelContextSnapshot;
+  currentSnapshot: ModelContextSnapshot;
+  request: ClaudeOverlayRequest;
+  activeTaskIds: readonly string[];
+  evictableTaskIds: readonly string[];
+  schedule: ClaudeCleanerScheduledRecord;
+  now: string;
+  release(): Promise<void>;
+}): Promise<ClaudeCleanerOverlayResult> {
+  const bridge = createContextCleanerHostExecutionBridge({
+    stateDir: params.stateDir,
+    hostId: "claude-code",
+    async readExecutionSnapshot() {
+      return {
+        snapshot: params.baseSnapshot,
+        activeTaskIds: params.activeTaskIds,
+        evictableTaskIds: params.evictableTaskIds,
+      };
+    },
+  });
+  const shared = await bridge.prepareScheduledClean({
+    cleanPlanId: params.schedule.cleanPlanId,
+    sessionId: params.sessionId,
+    baseRevision: params.schedule.baseRevision,
+    selectedTaskIds: [...params.schedule.selectedTaskIds],
+  });
+  if (shared.outcome === "terminal") {
+    await params.release();
+    if (shared.receipt.status === "stale" || shared.receipt.status === "cancelled" || shared.receipt.status === "failed") {
+      await appendClaudeCleanerTerminal({
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        cleanPlanId: params.schedule.cleanPlanId,
+        receiptStatus: shared.receipt.status,
+        reasons: shared.receipt.reasons.length > 0 ? shared.receipt.reasons : ["claude_cleaner_terminal_replayed"],
+        updatedAt: shared.receipt.updatedAt,
+      });
+    }
+    return { outcome: "terminal", suppressAutomaticEviction: true, reasonCodes: shared.receipt.reasons };
+  }
+  if (shared.outcome !== "ready") {
+    const stale = shared.outcome === "bypassed" ? staleReasonCodes(shared.reasons) : undefined;
+    if (shared.outcome === "bypassed" && stale && shared.receipt?.status === "scheduled") {
+      const execution = {
+        cleanPlanId: shared.receipt.planId,
+        hostId: shared.receipt.hostId,
+        sessionId: shared.receipt.sessionId,
+        baseRevision: params.schedule.baseRevision,
+        selectedTasks: [],
+        mutationPlan: { ...params.baseSnapshot, operations: [] } as never,
+        scheduledReceipt: shared.receipt,
+      } as ContextCleanPreparedExecution;
+      await params.release();
+      return persistTerminal({
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        execution,
+        status: "stale",
+        reasonCodes: stale,
+        updatedAt: params.now,
+      });
+    }
+    await params.release();
+    return {
+      outcome: "reserved",
+      suppressAutomaticEviction: true,
+      reasonCodes: shared.reasons,
+    };
+  }
+
+  const relocation = relocateContextMutationPlan({
+    snapshot: params.currentSnapshot,
+    plan: shared.execution.mutationPlan,
+  });
+  const execution: ContextCleanPreparedExecution = {
+    ...shared.execution,
+    mutationPlan: relocation.plan,
+  };
+  if (relocation.deferredOperationIds.length > 0
+    || relocation.plan.operations.length !== shared.execution.mutationPlan.operations.length
+    || !currentScopeIsSafe({
+      execution,
+      snapshot: params.currentSnapshot,
+      activeTaskIds: params.activeTaskIds,
+      evictableTaskIds: params.evictableTaskIds,
+    })) {
+    await params.release();
+    return persistTerminal({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      execution: shared.execution,
+      status: "stale",
+      reasonCodes: relocation.deferredOperationIds.length > 0
+        ? ["claude_cleaner_relocation_incomplete", ...relocation.reasons]
+        : ["claude_cleaner_current_scope_invalid"],
+      updatedAt: params.now,
+    });
+  }
+  const revalidation = revalidateContextMutationPlan({
+    snapshot: params.currentSnapshot,
+    plan: execution.mutationPlan,
+  });
+  const closure = validateContextMutationProtocolClosure({
+    snapshot: params.currentSnapshot,
+    plan: execution.mutationPlan,
+    activeTaskIds: params.activeTaskIds,
+    evictableTaskIds: params.evictableTaskIds,
+    candidateOperationIds: revalidation.applicableOperationIds,
+  });
+  if (!revalidation.valid
+    || revalidation.deferredOperationIds.length > 0
+    || revalidation.applicableOperationIds.length !== execution.mutationPlan.operations.length
+    || !closure.valid
+    || closure.deferredOperationIds.length > 0
+    || closure.applicableOperationIds.length !== execution.mutationPlan.operations.length) {
+    await params.release();
+    return persistTerminal({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      execution: shared.execution,
+      status: "stale",
+      reasonCodes: ["clean_execution_revalidation_failed", ...revalidation.reasons, ...closure.reasons],
+      updatedAt: params.now,
+    });
+  }
+
+  const archivePlan = structuredClone(execution.mutationPlan);
+  const archivedExecution: ContextCleanPreparedExecution = { ...execution, mutationPlan: archivePlan };
+  try {
+    await applyArchivePlan({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      snapshot: params.currentSnapshot,
+      plan: archivePlan,
+      request: params.request,
+    });
+    if (!archivePreservedFullScope(archivedExecution)) {
+      await params.release();
+      return persistTerminal({
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        execution: shared.execution,
+        status: "failed",
+        reasonCodes: ["claude_cleaner_archive_incomplete"],
+        updatedAt: params.now,
+      });
+    }
+    const applied = await claudeContextRewriteBackend.apply({
+      snapshot: params.currentSnapshot,
+      plan: archivePlan,
+      request: params.request,
+    });
+    const expectedOperationIds = archivePlan.operations.map((operation) => operation.id);
+    const expectedItemIds = archivePlan.operations.flatMap((operation) => operation.targetItemIds);
+    if (!applied.result.applied
+      || !applied.result.changed
+      || applied.result.fallbackUsed
+      || applied.result.deferredOperationIds.length > 0
+      || applied.result.appliedOperationIds.length !== expectedOperationIds.length
+      || applied.result.removedItemIds.length !== expectedItemIds.length) {
+      await params.release();
+      return persistTerminal({
+        stateDir: params.stateDir,
+        sessionId: params.sessionId,
+        execution: shared.execution,
+        status: "stale",
+        reasonCodes: ["claude_cleaner_overlay_incomplete"],
+        updatedAt: params.now,
+      });
+    }
+    return {
+      outcome: "prepared",
+      suppressAutomaticEviction: true,
+      execution: archivedExecution,
+      request: applied.request,
+      rewriteResult: applied.result,
+      overlayId: overlayId(archivedExecution, params.currentSnapshot.revision),
+      release: params.release,
+    };
+  } catch {
+    await params.release();
+    return persistTerminal({
+      stateDir: params.stateDir,
+      sessionId: params.sessionId,
+      execution: shared.execution,
+      status: "failed",
+      reasonCodes: ["claude_cleaner_overlay_apply_failed"],
+      updatedAt: params.now,
+    });
+  }
+}
+
+export async function prepareClaudeCleanerOverlay(params: {
+  stateDir: string;
+  sessionId: string;
+  baseSnapshot: ModelContextSnapshot;
+  currentSnapshot: ModelContextSnapshot;
+  request: ClaudeOverlayRequest;
+  activeTaskIds: readonly string[];
+  evictableTaskIds: readonly string[];
+  now?: string;
+}): Promise<ClaudeCleanerOverlayResult> {
+  const initial = await readClaudeCleanerSchedule({
+    stateDir: params.stateDir,
+    sessionId: params.sessionId,
+  });
+  if (initial.outcome === "missing") {
+    return { outcome: "absent", suppressAutomaticEviction: false, reasonCodes: [] };
+  }
+  if (initial.outcome !== "ready") {
+    return {
+      outcome: initial.outcome === "terminal" || initial.outcome === "committed" ? "terminal" : "reserved",
+      suppressAutomaticEviction: true,
+      reasonCodes: initial.outcome === "terminal" ? initial.record.reasons : initial.reasons,
+    };
+  }
+  const lock = await acquireClaudeCleanerScheduleLock(params);
+  if (!lock) {
+    return { outcome: "reserved", suppressAutomaticEviction: true, reasonCodes: ["claude_cleaner_runtime_lock_busy"] };
+  }
+  const current = await readClaudeCleanerSchedule({ stateDir: params.stateDir, sessionId: params.sessionId });
+  if (current.outcome !== "ready" || current.record.cleanPlanId !== initial.record.cleanPlanId) {
+    await lock.release();
+    return {
+      outcome: current.outcome === "terminal" || current.outcome === "committed" ? "terminal" : "reserved",
+      suppressAutomaticEviction: true,
+      reasonCodes: current.outcome === "ready" ? ["claude_cleaner_runtime_schedule_changed"] : current.reasons,
+    };
+  }
+  return prepareLockedOverlay({
+    ...params,
+    schedule: current.record,
+    now: params.now ?? new Date().toISOString(),
+    release: () => lock.release(),
+  });
+}
+
+/** Completes a prepared overlay after gateway encoding still preserves its exact scope. */
+export async function finalizeClaudeCleanerOverlay(params: {
+  stateDir: string;
+  prepared: Extract<ClaudeCleanerOverlayResult, { outcome: "prepared" }>;
+  now?: string;
+}): Promise<ClaudeCleanerOverlayFinalization> {
+  let released = false;
+  const release = async (): Promise<void> => {
+    if (released) return;
+    released = true;
+    await params.prepared.release();
+  };
+  try {
+    const built = buildClaudeCleanerAppliedReceipt({
+      execution: params.prepared.execution,
+      rewriteResult: params.prepared.rewriteResult,
+      overlayId: params.prepared.overlayId,
+      updatedAt: params.now ?? new Date().toISOString(),
+    });
+    if (!built.receipt) return { outcome: "reserved", reasonCodes: built.reasons };
+    const bridge = createContextCleanerHostExecutionBridge({
+      stateDir: params.stateDir,
+      hostId: "claude-code",
+      async readExecutionSnapshot() {
+        throw new Error("applied receipt does not read an execution snapshot");
+      },
+    });
+    const stored = await bridge.recordCleanReceipt(built.receipt);
+    if (stored.bypassed || stored.value?.status !== "applied") {
+      return {
+        outcome: "reserved",
+        reasonCodes: uniqueReasons(["claude_cleaner_applied_receipt_write_failed", ...stored.reasons]),
+      };
+    }
+    // The shared state transition is now terminal and serializes retries. Drop
+    // the reservation before appending the local marker, whose own transition
+    // acquires the same non-reentrant session lock.
+    await release();
+    const local = await appendClaudeCleanerCommitted({
+      stateDir: params.stateDir,
+      sessionId: params.prepared.execution.sessionId,
+      cleanPlanId: params.prepared.execution.cleanPlanId,
+      mutationPlanId: params.prepared.execution.mutationPlan.planId,
+      overlayId: params.prepared.overlayId,
+      updatedAt: built.receipt.updatedAt,
+    });
+    if (local.outcome !== "transitioned" && local.outcome !== "unchanged") {
+      return {
+        outcome: "applied",
+        reasonCodes: uniqueReasons(["claude_cleaner_applied_schedule_write_failed", ...local.reasons]),
+      };
+    }
+    return { outcome: "applied", reasonCodes: [] };
+  } finally {
+    await release();
+  }
+}
+
+/** Releases a reserved candidate when a later gateway stage must retain the original request. */
+export async function abandonClaudeCleanerOverlay(
+  prepared: Extract<ClaudeCleanerOverlayResult, { outcome: "prepared" }>,
+): Promise<void> {
+  await prepared.release();
+}

--- a/components/adapters/claude-code/src/context-cleaner/scheduler.ts
+++ b/components/adapters/claude-code/src/context-cleaner/scheduler.ts
@@ -1,0 +1,422 @@
+import { createHash } from "node:crypto";
+import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { appendJsonl } from "@lightrsi/host-adapter";
+
+export const CLAUDE_CLEANER_SCHEDULE_SCHEMA = "lightrsi.claude-code.cleaner-schedule/v1" as const;
+
+type ClaudeCleanerScheduleIdentity = {
+  schema: typeof CLAUDE_CLEANER_SCHEDULE_SCHEMA;
+  hostId: "claude-code";
+  sessionId: string;
+  cleanPlanId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+  scheduledAt: string;
+  updatedAt: string;
+};
+
+export type ClaudeCleanerScheduledRecord = ClaudeCleanerScheduleIdentity & {
+  status: "scheduled";
+};
+
+/** Adapter-local execution marker; shared Cleaner owns the plan and receipt. */
+export type ClaudeCleanerCommittedRecord = ClaudeCleanerScheduleIdentity & {
+  status: "committed";
+  mutationPlanId: string;
+  overlayId: string;
+};
+
+export type ClaudeCleanerTerminalRecord = ClaudeCleanerScheduleIdentity & {
+  status: "terminal";
+  receiptStatus: "stale" | "cancelled" | "failed";
+  reasons: string[];
+};
+
+export type ClaudeCleanerScheduleRecord =
+  | ClaudeCleanerScheduledRecord
+  | ClaudeCleanerCommittedRecord
+  | ClaudeCleanerTerminalRecord;
+
+export type ClaudeCleanerScheduleReadResult =
+  | { outcome: "missing"; reasons: [] }
+  | { outcome: "ready"; record: ClaudeCleanerScheduledRecord; reasons: [] }
+  | { outcome: "committed"; record: ClaudeCleanerCommittedRecord; reasons: [] }
+  | { outcome: "terminal"; record: ClaudeCleanerTerminalRecord; reasons: [] }
+  | { outcome: "bypassed"; reasons: string[] };
+
+export type ClaudeCleanerScheduleWriteResult = {
+  outcome: "stored" | "transitioned" | "unchanged" | "missing" | "conflict" | "bypassed";
+  record?: ClaudeCleanerScheduleRecord;
+  reasons: string[];
+};
+
+type ClaudeCleanerScheduleJournal = {
+  records: ClaudeCleanerScheduleRecord[];
+  malformedLineCount: number;
+  readError?: string;
+};
+
+const LOCK_TIMEOUT_MS = 1_000;
+const LOCK_RETRY_MS = 10;
+const LOCK_STALE_MS = 30 * 60 * 1_000;
+
+function nonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function canonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function uniqueNonBlankStrings(value: unknown): value is string[] {
+  return Array.isArray(value)
+    && value.length > 0
+    && value.every(nonBlankString)
+    && new Set(value).size === value.length;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && new Set(left).size === left.length
+    && left.every((value) => right.includes(value));
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function sameIdentity(
+  left: ClaudeCleanerScheduleIdentity,
+  right: ClaudeCleanerScheduleIdentity,
+): boolean {
+  return left.hostId === right.hostId
+    && left.sessionId === right.sessionId
+    && left.cleanPlanId === right.cleanPlanId
+    && left.baseRevision === right.baseRevision
+    && left.scheduledAt === right.scheduledAt
+    && sameStringSet(left.selectedTaskIds, right.selectedTaskIds);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function canonicalRecord(value: unknown): ClaudeCleanerScheduleRecord | undefined {
+  const record = asRecord(value);
+  if (!record
+    || record.schema !== CLAUDE_CLEANER_SCHEDULE_SCHEMA
+    || record.hostId !== "claude-code"
+    || !nonBlankString(record.sessionId)
+    || !nonBlankString(record.cleanPlanId)
+    || !nonBlankString(record.baseRevision)
+    || !uniqueNonBlankStrings(record.selectedTaskIds)
+    || !canonicalTimestamp(record.scheduledAt)
+    || !canonicalTimestamp(record.updatedAt)) return undefined;
+
+  const identity: ClaudeCleanerScheduleIdentity = {
+    schema: CLAUDE_CLEANER_SCHEDULE_SCHEMA,
+    hostId: "claude-code",
+    sessionId: record.sessionId,
+    cleanPlanId: record.cleanPlanId,
+    baseRevision: record.baseRevision,
+    selectedTaskIds: [...record.selectedTaskIds],
+    scheduledAt: record.scheduledAt,
+    updatedAt: record.updatedAt,
+  };
+  if (record.status === "scheduled") return { ...identity, status: "scheduled" };
+  if (record.status === "committed"
+    && nonBlankString(record.mutationPlanId)
+    && nonBlankString(record.overlayId)) {
+    return { ...identity, status: "committed", mutationPlanId: record.mutationPlanId, overlayId: record.overlayId };
+  }
+  if (record.status === "terminal"
+    && (record.receiptStatus === "stale" || record.receiptStatus === "cancelled" || record.receiptStatus === "failed")
+    && uniqueNonBlankStrings(record.reasons)) {
+    return { ...identity, status: "terminal", receiptStatus: record.receiptStatus, reasons: [...record.reasons] };
+  }
+  return undefined;
+}
+
+function validTransition(
+  previous: ClaudeCleanerScheduleRecord | undefined,
+  next: ClaudeCleanerScheduleRecord,
+): boolean {
+  if (!previous) return next.status === "scheduled";
+  if (!sameIdentity(previous, next)) return false;
+  if (previous.status === "scheduled") return true;
+  return JSON.stringify(previous) === JSON.stringify(next);
+}
+
+function scheduleSessionDir(stateDir: string, sessionId: string): string {
+  const key = createHash("sha256").update(sessionId).digest("hex");
+  return join(stateDir, "claude-context", "cleaner-schedules", `session-${key}`);
+}
+
+export function claudeCleanerScheduleJournalPath(stateDir: string, sessionId: string): string {
+  return join(scheduleSessionDir(stateDir, sessionId), "schedule.jsonl");
+}
+
+function scheduleLockPath(stateDir: string, sessionId: string): string {
+  return join(scheduleSessionDir(stateDir, sessionId), "schedule.lock");
+}
+
+export async function acquireClaudeCleanerScheduleLock(params: {
+  stateDir: string;
+  sessionId: string;
+}): Promise<{ release(): Promise<void> } | undefined> {
+  const path = scheduleLockPath(params.stateDir, params.sessionId);
+  const token = `${process.pid}:${Date.now()}:${Math.random()}`;
+  const startedAt = Date.now();
+  await mkdir(scheduleSessionDir(params.stateDir, params.sessionId), { recursive: true });
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  while (!handle) {
+    try {
+      handle = await open(path, "wx");
+      await handle.writeFile(token, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") return undefined;
+      try {
+        const info = await stat(path);
+        if (Date.now() - info.mtimeMs > LOCK_STALE_MS) await unlink(path);
+      } catch (statError) {
+        if ((statError as NodeJS.ErrnoException).code !== "ENOENT") return undefined;
+      }
+      if (Date.now() - startedAt >= LOCK_TIMEOUT_MS) return undefined;
+      await delay(LOCK_RETRY_MS);
+    }
+  }
+  return {
+    async release() {
+      await handle?.close().catch(() => undefined);
+      try {
+        if (await readFile(path, "utf8") === token) await unlink(path);
+      } catch {
+        // A missing/replaced lock belongs to recovery or another owner.
+      }
+    },
+  };
+}
+
+async function readScheduleJournal(
+  stateDir: string,
+  sessionId: string,
+): Promise<ClaudeCleanerScheduleJournal> {
+  let raw: string;
+  try {
+    raw = await readFile(claudeCleanerScheduleJournalPath(stateDir, sessionId), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { records: [], malformedLineCount: 0 };
+    }
+    return { records: [], malformedLineCount: 0, readError: String(error) };
+  }
+
+  const latestByPlanId = new Map<string, ClaudeCleanerScheduleRecord>();
+  let malformedLineCount = 0;
+  for (const line of raw.split(/\r?\n/u).filter(Boolean)) {
+    try {
+      const entry = canonicalRecord(JSON.parse(line) as unknown);
+      const previous = entry ? latestByPlanId.get(entry.cleanPlanId) : undefined;
+      if (!entry || entry.sessionId !== sessionId || !validTransition(previous, entry)) {
+        malformedLineCount += 1;
+        continue;
+      }
+      latestByPlanId.set(entry.cleanPlanId, entry);
+    } catch {
+      malformedLineCount += 1;
+    }
+  }
+  return { records: [...latestByPlanId.values()], malformedLineCount };
+}
+
+function journalFailureReasons(journal: ClaudeCleanerScheduleJournal): string[] | undefined {
+  if (journal.readError) return ["claude_cleaner_schedule_journal_unavailable"];
+  if (journal.malformedLineCount > 0) return ["claude_cleaner_schedule_journal_malformed"];
+  return undefined;
+}
+
+export async function readClaudeCleanerSchedule(params: {
+  stateDir: string;
+  sessionId: string;
+}): Promise<ClaudeCleanerScheduleReadResult> {
+  if (!nonBlankString(params.stateDir) || !nonBlankString(params.sessionId)) {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_request_invalid"] };
+  }
+  const journal = await readScheduleJournal(params.stateDir, params.sessionId);
+  const reasons = journalFailureReasons(journal);
+  if (reasons) return { outcome: "bypassed", reasons };
+  const scheduled = journal.records.filter(
+    (record): record is ClaudeCleanerScheduledRecord => record.status === "scheduled",
+  );
+  if (scheduled.length > 1) {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_pending_conflict"] };
+  }
+  if (scheduled[0]) return { outcome: "ready", record: scheduled[0], reasons: [] };
+  const latest = journal.records.at(-1);
+  if (!latest) return { outcome: "missing", reasons: [] };
+  if (latest.status === "committed") return { outcome: "committed", record: latest, reasons: [] };
+  if (latest.status === "terminal") return { outcome: "terminal", record: latest, reasons: [] };
+  return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_pending_conflict"] };
+}
+
+function validScheduleParams(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+  scheduledAt: string;
+}): boolean {
+  return nonBlankString(params.stateDir)
+    && nonBlankString(params.sessionId)
+    && nonBlankString(params.cleanPlanId)
+    && nonBlankString(params.baseRevision)
+    && uniqueNonBlankStrings(params.selectedTaskIds)
+    && canonicalTimestamp(params.scheduledAt);
+}
+
+export async function scheduleClaudeCleanerPlan(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  baseRevision: string;
+  selectedTaskIds: string[];
+  scheduledAt?: string;
+}): Promise<ClaudeCleanerScheduleWriteResult> {
+  const scheduledAt = params.scheduledAt ?? new Date().toISOString();
+  if (!validScheduleParams({ ...params, scheduledAt })) {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_request_invalid"] };
+  }
+  const record: ClaudeCleanerScheduledRecord = {
+    schema: CLAUDE_CLEANER_SCHEDULE_SCHEMA,
+    hostId: "claude-code",
+    sessionId: params.sessionId,
+    cleanPlanId: params.cleanPlanId,
+    baseRevision: params.baseRevision,
+    selectedTaskIds: [...params.selectedTaskIds],
+    status: "scheduled",
+    scheduledAt,
+    updatedAt: scheduledAt,
+  };
+  const lock = await acquireClaudeCleanerScheduleLock(params);
+  if (!lock) return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_lock_busy"] };
+  try {
+    const journal = await readScheduleJournal(params.stateDir, params.sessionId);
+    const reasons = journalFailureReasons(journal);
+    if (reasons) return { outcome: "bypassed", reasons };
+    const existing = journal.records.find((entry) => entry.cleanPlanId === params.cleanPlanId);
+    if (existing) {
+      return existing.status === "scheduled" && sameIdentity(existing, record)
+        ? { outcome: "unchanged", record: existing, reasons: [] }
+        : { outcome: "conflict", record: existing, reasons: ["claude_cleaner_schedule_identity_conflict"] };
+    }
+    if (journal.records.some((entry) => entry.status === "scheduled")) {
+      return { outcome: "conflict", reasons: ["claude_cleaner_schedule_pending_conflict"] };
+    }
+    await appendJsonl(claudeCleanerScheduleJournalPath(params.stateDir, params.sessionId), record);
+    return { outcome: "stored", record, reasons: [] };
+  } catch {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_write_failed"] };
+  } finally {
+    await lock.release();
+  }
+}
+
+async function transitionSchedule(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  updatedAt: string;
+  build(previous: ClaudeCleanerScheduledRecord): ClaudeCleanerScheduleRecord;
+  matchesExisting(existing: ClaudeCleanerScheduleRecord): boolean;
+}): Promise<ClaudeCleanerScheduleWriteResult> {
+  if (!nonBlankString(params.stateDir)
+    || !nonBlankString(params.sessionId)
+    || !nonBlankString(params.cleanPlanId)
+    || !canonicalTimestamp(params.updatedAt)) {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_request_invalid"] };
+  }
+  const lock = await acquireClaudeCleanerScheduleLock(params);
+  if (!lock) return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_lock_busy"] };
+  try {
+    const journal = await readScheduleJournal(params.stateDir, params.sessionId);
+    const reasons = journalFailureReasons(journal);
+    if (reasons) return { outcome: "bypassed", reasons };
+    const existing = journal.records.find((record) => record.cleanPlanId === params.cleanPlanId);
+    if (!existing) return { outcome: "missing", reasons: ["claude_cleaner_schedule_missing"] };
+    if (existing.status !== "scheduled") {
+      return params.matchesExisting(existing)
+        ? { outcome: "unchanged", record: existing, reasons: [] }
+        : { outcome: "conflict", record: existing, reasons: ["claude_cleaner_schedule_terminal_conflict"] };
+    }
+    const next = canonicalRecord(params.build(existing));
+    if (!next || !validTransition(existing, next)) {
+      return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_transition_invalid"] };
+    }
+    await appendJsonl(claudeCleanerScheduleJournalPath(params.stateDir, params.sessionId), next);
+    return { outcome: "transitioned", record: next, reasons: [] };
+  } catch {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_write_failed"] };
+  } finally {
+    await lock.release();
+  }
+}
+
+export async function appendClaudeCleanerCommitted(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  mutationPlanId: string;
+  overlayId: string;
+  updatedAt?: string;
+}): Promise<ClaudeCleanerScheduleWriteResult> {
+  if (!nonBlankString(params.mutationPlanId) || !nonBlankString(params.overlayId)) {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_request_invalid"] };
+  }
+  const updatedAt = params.updatedAt ?? new Date().toISOString();
+  return transitionSchedule({
+    ...params,
+    updatedAt,
+    build(previous) {
+      return { ...previous, status: "committed", mutationPlanId: params.mutationPlanId, overlayId: params.overlayId, updatedAt };
+    },
+    matchesExisting(existing) {
+      return existing.status === "committed"
+        && existing.mutationPlanId === params.mutationPlanId
+        && existing.overlayId === params.overlayId;
+    },
+  });
+}
+
+export async function appendClaudeCleanerTerminal(params: {
+  stateDir: string;
+  sessionId: string;
+  cleanPlanId: string;
+  receiptStatus: "stale" | "cancelled" | "failed";
+  reasons: string[];
+  updatedAt?: string;
+}): Promise<ClaudeCleanerScheduleWriteResult> {
+  if (!uniqueNonBlankStrings(params.reasons)) {
+    return { outcome: "bypassed", reasons: ["claude_cleaner_schedule_request_invalid"] };
+  }
+  const updatedAt = params.updatedAt ?? new Date().toISOString();
+  return transitionSchedule({
+    ...params,
+    updatedAt,
+    build(previous) {
+      return { ...previous, status: "terminal", receiptStatus: params.receiptStatus, reasons: [...params.reasons], updatedAt };
+    },
+    matchesExisting(existing) {
+      return existing.status === "terminal"
+        && existing.receiptStatus === params.receiptStatus
+        && sameStrings(existing.reasons, params.reasons);
+    },
+  });
+}

--- a/components/adapters/claude-code/src/context-rewrite/backend.ts
+++ b/components/adapters/claude-code/src/context-rewrite/backend.ts
@@ -87,8 +87,17 @@ function messagesRevision(messages: RuntimeMessage[]): string {
     .digest("hex")}`;
 }
 
-function isRewritableBlock(block: Record<string, unknown>): boolean {
-  return block.type === "tool_result" || block.type === "text";
+function isRewritableBlock(
+  block: Record<string, unknown>,
+  sourceModuleId: string,
+): boolean {
+  return block.type === "tool_result"
+    || block.type === "text"
+    // A Cleaner approval freezes both sides of a closed pair. Keep the
+    // protocol identifiers, but remove the historical tool input as part of
+    // that exact, user-approved scope. Automatic eviction keeps its existing
+    // result-only behavior.
+    || (block.type === "tool_use" && sourceModuleId === "cleaner_manual");
 }
 
 function claudeToolClosureReasons(
@@ -109,6 +118,7 @@ function claudeToolClosureReasons(
   const itemById = new Map(snapshot.items.map((item) => [item.stableId, item]));
   const reasons = new Map<string, string>();
   for (const operation of plan.operations) {
+    const targetIds = new Set(operation.targetItemIds);
     for (const targetId of operation.targetItemIds) {
       const item = itemById.get(targetId);
       if (!item || (item.kind !== "tool_call" && item.kind !== "tool_result")) continue;
@@ -119,6 +129,14 @@ function claudeToolClosureReasons(
       if ((calls.get(item.callId) ?? 0) !== 1 || (results.get(item.callId) ?? 0) !== 1) {
         reasons.set(operation.id, `operation ${operation.id} targets an incomplete tool pair`);
         break;
+      }
+      if (plan.sourceModuleId === "cleaner_manual") {
+        const pair = snapshot.items.filter((candidate) => candidate.callId === item.callId
+          && (candidate.kind === "tool_call" || candidate.kind === "tool_result"));
+        if (pair.some((candidate) => !targetIds.has(candidate.stableId))) {
+          reasons.set(operation.id, `operation ${operation.id} targets only part of a tool pair`);
+          break;
+        }
       }
     }
   }
@@ -150,6 +168,14 @@ function recoveryRefForBlock(
 }
 
 function stubBlock(block: Record<string, unknown>, recoveryRef?: string): Record<string, unknown> {
+  if (block.type === "tool_use") {
+    return {
+      type: "tool_use",
+      id: block.id,
+      name: block.name,
+      input: {},
+    };
+  }
   if (block.type === "tool_result") {
     return {
       type: "tool_result",
@@ -320,8 +346,10 @@ export const claudeContextRewriteBackend: ModelContextRewriteBackend<ClaudeOverl
           }
           if (!Array.isArray(message.content)) continue;
           const block = asBlockRecord(message.content[blockIdx]);
-          if (!block || !isRewritableBlock(block)) continue;
-          // tool_use is half of a pair; leave it so closure stays intact.
+          if (!block || !isRewritableBlock(block, plan.sourceModuleId)) continue;
+          // A manual Cleaner scope contains both sides of a valid pair. Its
+          // tool-use stub retains id/name and an object input, so the rewritten
+          // Messages history remains structurally closed.
           const recoveryRef = recoveryRefForBlock(block, op.archiveRefs);
           const stub = stubBlock(block, recoveryRef);
           savedChars += Math.max(0, blockCharCount(block) - blockCharCount(stub));

--- a/components/adapters/claude-code/src/gateway-runtime.ts
+++ b/components/adapters/claude-code/src/gateway-runtime.ts
@@ -38,7 +38,10 @@ import {
 import { loadSessionTaskRegistry, persistSessionTaskRegistry } from "@lightrsi/history";
 import { claudeContextRewriteBackend, relocateContextMutationPlan } from "./context-rewrite/backend.js";
 import { applyArchivePlan } from "./context-rewrite/archive.js";
-import { saveLatestClaudeSnapshot } from "./context-rewrite/snapshot-store.js";
+import {
+  readLatestClaudeSnapshotRecord,
+  saveLatestClaudeSnapshot,
+} from "./context-rewrite/snapshot-store.js";
 import { appendOverlayHistory } from "./context-rewrite/overlay-history.js";
 import { resolveClaudeTaskStateEstimator } from "./context-rewrite/estimator-config.js";
 import { prepareSemanticDelta } from "./context-rewrite/semantic-pipeline.js";
@@ -65,6 +68,12 @@ import { resolveLatestClaudeCodeSessionId } from "./session-state.js";
 import { lookupRealSessionId, recordSessionMapping } from "./context-rewrite/session-map.js";
 import { initializeClaudeCodeTokenPilotPreset } from "./preset.js";
 import { attributeClaudeSnapshotTasks } from "./context-cleaner/snapshot.js";
+import {
+  abandonClaudeCleanerOverlay,
+  finalizeClaudeCleanerOverlay,
+  prepareClaudeCleanerOverlay,
+} from "./context-cleaner/runtime.js";
+import { readClaudeCleanerSchedule } from "./context-cleaner/scheduler.js";
 
 export type ClaudeCodeGatewayRuntime = {
   baseUrl: string;
@@ -367,24 +376,56 @@ export async function startClaudeCodeGatewayRuntime(params: {
       let lifecyclePlannerStatus: "completed" | "deferred" | "bypassed" | "not_configured" = "not_configured";
       let lifecyclePlannerReasonCodes: string[] = [];
       let lifecycleRegistryVersion: number | undefined;
+      let manualCleanerOverlay: Extract<
+        Awaited<ReturnType<typeof prepareClaudeCleanerOverlay>>,
+        { outcome: "prepared" }
+      > | undefined;
+      let manualCleanerSuppressesAutomaticEviction = false;
 
-      // Lifecycle planner (estimator-driven). Runs UNCONDITIONALLY (independent
-      // of the eviction toggle) so registry updates happen every turn, exactly
-      // where the old runSemanticPipeline used to. Only the plannerPlan -> overlay
-      // execution below is gated by evictionEnabled. Fail-open: any error leaves
-      // plannerPlan undefined and the request proceeds unchanged.
+      // A scheduled manual clean owns the next safe rewrite boundary. Check the
+      // adapter-local marker before lifecycle analysis so an automatic planner
+      // cannot race it or advance task state on the same request. A malformed
+      // or unreadable marker is also fail-closed for automatic eviction.
+      try {
+        const manualSchedule = await readClaudeCleanerSchedule({
+          stateDir: config.stateDir,
+          sessionId,
+        });
+        if (manualSchedule.outcome === "ready" || manualSchedule.outcome === "bypassed") {
+          manualCleanerSuppressesAutomaticEviction = true;
+          lifecyclePlannerStatus = "deferred";
+          lifecyclePlannerReasonCodes = [
+            manualSchedule.outcome === "ready"
+              ? "manual_cleaner_schedule_pending"
+              : "manual_cleaner_schedule_unavailable",
+          ];
+        }
+      } catch (error) {
+        manualCleanerSuppressesAutomaticEviction = true;
+        lifecyclePlannerStatus = "deferred";
+        lifecyclePlannerReasonCodes = ["manual_cleaner_schedule_unavailable"];
+        logger.warn(`context cleaner schedule check failed (ignored): ${String(error)}`);
+      }
+
+      // Lifecycle planner (estimator-driven) runs independently of the eviction
+      // toggle so registry updates happen every ordinary turn. A pending manual
+      // Cleaner schedule is the one exception: it exclusively owns this request
+      // boundary. Fail-open: any planner error leaves plannerPlan undefined and
+      // the request proceeds unchanged.
       let plannerPlan: ReturnType<typeof buildContextMutationPlan> | undefined;
       let lifecycleEstimator: ReturnType<typeof resolveClaudeTaskStateEstimator>;
-      try {
-        lifecycleEstimator = (params.dependencies?.resolveEstimator ?? resolveClaudeTaskStateEstimator)({
-          config: config.taskStateEstimator,
-          env: process.env,
-        });
-      } catch (error) {
-        lifecycleEstimator = undefined;
-        lifecyclePlannerStatus = "bypassed";
-        lifecyclePlannerReasonCodes = ["estimator_resolver_error"];
-        logger.warn(`lifecycle estimator resolver failed (ignored): ${String(error)}`);
+      if (!manualCleanerSuppressesAutomaticEviction) {
+        try {
+          lifecycleEstimator = (params.dependencies?.resolveEstimator ?? resolveClaudeTaskStateEstimator)({
+            config: config.taskStateEstimator,
+            env: process.env,
+          });
+        } catch (error) {
+          lifecycleEstimator = undefined;
+          lifecyclePlannerStatus = "bypassed";
+          lifecyclePlannerReasonCodes = ["estimator_resolver_error"];
+          logger.warn(`lifecycle estimator resolver failed (ignored): ${String(error)}`);
+        }
       }
       if (lifecycleEstimator) {
         try {
@@ -463,10 +504,22 @@ export async function startClaudeCodeGatewayRuntime(params: {
         }
       }
 
-      // Persist the complete inbound history only after the lifecycle registry
-      // update attempt has settled, but before any eviction/reduction overlay.
-      // The store is side work: failure is visible in logs and never blocks the
-      // model request.
+      // A scheduled manual clean must validate against the canonical snapshot
+      // from approval time. Read that base before this request replaces it.
+      let previousCleanerSnapshot: Awaited<ReturnType<typeof readLatestClaudeSnapshotRecord>>;
+      try {
+        previousCleanerSnapshot = await readLatestClaudeSnapshotRecord(config.stateDir, sessionId);
+      } catch (error) {
+        logger.warn(`context cleaner base snapshot read failed (ignored): ${String(error)}`);
+      }
+
+      // Build the current canonical snapshot after lifecycle update, then let a
+      // pending manual Cleaner plan preempt automatic eviction for this request.
+      // The snapshot persisted below remains the original inbound request.
+      let cleanerSnapshot:
+        | Awaited<ReturnType<typeof claudeContextRewriteBackend.readSnapshot>>
+        | undefined;
+      let cleanerRegistry: Awaited<ReturnType<typeof loadSessionTaskRegistry>> | undefined;
       try {
         const baseCleanerSnapshot = await claudeContextRewriteBackend.readSnapshot({
           sessionId,
@@ -476,9 +529,9 @@ export async function startClaudeCodeGatewayRuntime(params: {
             messages: plannerMessages as unknown as RuntimeMessage[],
           },
         });
-        let cleanerSnapshot = baseCleanerSnapshot;
+        cleanerSnapshot = baseCleanerSnapshot;
         try {
-          const cleanerRegistry = await loadSessionTaskRegistry(config.stateDir, sessionId);
+          cleanerRegistry = await loadSessionTaskRegistry(config.stateDir, sessionId);
           cleanerSnapshot = attributeClaudeSnapshotTasks({
             snapshot: baseCleanerSnapshot,
             messages: plannerMessages,
@@ -489,19 +542,57 @@ export async function startClaudeCodeGatewayRuntime(params: {
           // registry recovery fails so Cleaner can still inspect unassigned context.
           logger.warn(`context cleaner task attribution failed (ignored): ${String(error)}`);
         }
-        const saveResult = await (
-          params.dependencies?.saveSnapshot ?? saveLatestClaudeSnapshot
-        )(config.stateDir, sessionId, cleanerSnapshot, { model: envelope.model });
-        if (!saveResult.saved) {
-          logger.warn(
-            `context cleaner snapshot persistence failed (ignored): ${saveResult.reason}`,
-          );
-        }
       } catch (error) {
-        logger.warn(`context cleaner snapshot persistence failed (ignored): ${String(error)}`);
+        logger.warn(`context cleaner snapshot preparation failed (ignored): ${String(error)}`);
       }
 
-      if (evictionEnabled) {
+      if (cleanerSnapshot && cleanerRegistry) {
+        const manual = await prepareClaudeCleanerOverlay({
+          stateDir: config.stateDir,
+          sessionId,
+          baseSnapshot: previousCleanerSnapshot?.snapshot ?? cleanerSnapshot,
+          currentSnapshot: cleanerSnapshot,
+          request: {
+            sessionId,
+            revision: cleanerSnapshotRevision,
+            messages: plannerMessages as RuntimeMessage[],
+          },
+          activeTaskIds: cleanerRegistry.activeTaskIds,
+          evictableTaskIds: cleanerRegistry.evictableTaskIds,
+        });
+        manualCleanerSuppressesAutomaticEviction = manual.suppressAutomaticEviction;
+        if (manual.outcome === "prepared") {
+          manualCleanerOverlay = manual;
+          payload = { ...(payload as Record<string, unknown>), messages: manual.request.messages };
+          envelope = codec.decodeRequest(payload, {
+            headers: req.headers as Record<string, string | string[] | undefined>,
+          });
+        } else if (manual.outcome === "reserved") {
+          logger.warn(`context cleaner manual overlay deferred (ignored): ${manual.reasonCodes.join(",")}`);
+        }
+      } else if (!manualCleanerSuppressesAutomaticEviction) {
+        const schedule = await readClaudeCleanerSchedule({ stateDir: config.stateDir, sessionId });
+        manualCleanerSuppressesAutomaticEviction = schedule.outcome === "ready";
+      }
+
+      // Persist the complete original inbound history after manual Cleaner has
+      // consumed the previous baseline, but before any automatic overlay.
+      if (cleanerSnapshot) {
+        try {
+          const saveResult = await (
+            params.dependencies?.saveSnapshot ?? saveLatestClaudeSnapshot
+          )(config.stateDir, sessionId, cleanerSnapshot, { model: envelope.model });
+          if (!saveResult.saved) {
+            logger.warn(
+              `context cleaner snapshot persistence failed (ignored): ${saveResult.reason}`,
+            );
+          }
+        } catch (error) {
+          logger.warn(`context cleaner snapshot persistence failed (ignored): ${String(error)}`);
+        }
+      }
+
+      if (evictionEnabled && !manualCleanerSuppressesAutomaticEviction) {
         try {
           const candidatePayload = (
             params.dependencies?.cloneRequestPayload ?? structuredClone
@@ -775,6 +866,29 @@ export async function startClaudeCodeGatewayRuntime(params: {
         if (encoded.bypassed) {
           evictionBypassReason = "encode_error";
           logger.warn("context overlay bypassed category=encode_error");
+        }
+        if (manualCleanerOverlay) {
+          if (encoded.bypassed) {
+            await abandonClaudeCleanerOverlay(manualCleanerOverlay);
+            manualCleanerOverlay = undefined;
+          } else {
+            const finalized = await finalizeClaudeCleanerOverlay({
+              stateDir: config.stateDir,
+              prepared: manualCleanerOverlay,
+            });
+            manualCleanerOverlay = undefined;
+            if (finalized.outcome !== "applied") {
+              // Receipt persistence is part of the manual-clean transaction.
+              // Never send an unrecorded overlay; preserve the caller payload.
+              payload = JSON.parse(body) as Record<string, unknown>;
+              envelope = codec.decodeRequest(payload, {
+                headers: req.headers as Record<string, string | string[] | undefined>,
+              });
+              logger.warn(`context cleaner manual overlay bypassed (ignored): ${finalized.reasonCodes.join(",")}`);
+            } else if (finalized.reasonCodes.length > 0) {
+              logger.warn(`context cleaner manual overlay local recovery needed: ${finalized.reasonCodes.join(",")}`);
+            }
+          }
         }
       }
       const reducedRequestText = typeof prepared.envelope.metadata?.inputText === "string"

--- a/components/adapters/claude-code/tests/context-cleaner-applied-receipt.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-applied-receipt.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  type ContextCleanPreparedExecution,
+} from "@lightrsi/cleaner";
+import {
+  MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+  type ContextRewriteResult,
+} from "@lightrsi/host-adapter";
+
+import { buildClaudeCleanerAppliedReceipt } from "../src/context-cleaner/applied-receipt.js";
+
+function execution(): ContextCleanPreparedExecution {
+  return {
+    cleanPlanId: "clean-plan-1",
+    hostId: "claude-code",
+    sessionId: "claude-session-1",
+    baseRevision: "revision-before",
+    selectedTasks: [{
+      taskId: "task-completed",
+      itemIds: ["item-1"],
+      itemDigests: { "item-1": "digest-1" },
+    }],
+    mutationPlan: {
+      schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+      planId: "mutation-plan-1",
+      hostId: "claude-code",
+      sessionId: "claude-session-1",
+      baseRevision: "revision-before",
+      sourceModuleId: "cleaner_manual",
+      createdAt: "2026-08-28T00:00:00.000Z",
+      operations: [{
+        id: "operation-1",
+        type: "replace",
+        targetItemIds: ["item-1"],
+        targetItemFingerprints: { "item-1": "digest-1" },
+        rationale: "user approved completed task cleanup",
+        estimatedSavedChars: 99,
+      }],
+    },
+    scheduledReceipt: {
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      planId: "clean-plan-1",
+      hostId: "claude-code",
+      sessionId: "claude-session-1",
+      status: "scheduled",
+      selectedTaskIds: ["task-completed"],
+      estimatedSavedTokens: null,
+      estimatedSavedChars: 99,
+      tokenCountMode: "chars_only",
+      deferredTaskIds: [],
+      fallbackUsed: false,
+      reasons: [],
+      updatedAt: "2026-08-28T00:00:00.000Z",
+    },
+  };
+}
+
+function rewrite(overrides: Partial<ContextRewriteResult> = {}): ContextRewriteResult {
+  return {
+    schemaVersion: MODEL_CONTEXT_REWRITE_SCHEMA_VERSION,
+    mode: "request_overlay",
+    planId: "mutation-plan-1",
+    applied: true,
+    changed: true,
+    previousRevision: "revision-before",
+    nextRevision: "revision-after",
+    appliedOperationIds: ["operation-1"],
+    deferredOperationIds: [],
+    removedItemIds: ["item-1"],
+    savedChars: 7,
+    fallbackUsed: false,
+    ...overrides,
+  };
+}
+
+test("records actual Claude overlay savings and complete rewrite evidence", () => {
+  const built = buildClaudeCleanerAppliedReceipt({
+    execution: execution(),
+    rewriteResult: rewrite(),
+    overlayId: "claude-overlay-1",
+    updatedAt: "2026-08-28T00:00:01.000Z",
+  });
+
+  assert.deepEqual(built.reasons, []);
+  assert.equal(built.receipt?.status, "applied");
+  assert.equal(built.receipt?.appliedSavedChars, 7);
+  assert.equal(built.receipt?.appliedSavedTokens, null);
+  assert.deepEqual(built.receipt?.evidence, {
+    previousRevision: "revision-before",
+    nextRevision: "revision-after",
+    operationIds: ["operation-1"],
+    itemIds: ["item-1"],
+    eventIds: ["claude-overlay:claude-overlay-1"],
+  });
+});
+
+test("rejects a partial or fallback Claude overlay instead of issuing applied", () => {
+  for (const candidate of [
+    rewrite({ removedItemIds: [], savedChars: 0, applied: false, changed: false }),
+    rewrite({ fallbackUsed: true }),
+    rewrite({ appliedOperationIds: ["other-operation"] }),
+  ]) {
+    const built = buildClaudeCleanerAppliedReceipt({
+      execution: execution(),
+      rewriteResult: candidate,
+      overlayId: "claude-overlay-1",
+      updatedAt: "2026-08-28T00:00:01.000Z",
+    });
+    assert.equal(built.receipt, undefined);
+    assert.deepEqual(built.reasons, ["claude_cleaner_receipt_rewrite_evidence_invalid"]);
+  }
+});

--- a/components/adapters/claude-code/tests/context-cleaner-bridge.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-bridge.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@lightrsi/host-adapter";
 
 import { createClaudeCodeContextCleanerBridge } from "../src/context-cleaner/index.js";
+import { readClaudeCleanerSchedule } from "../src/context-cleaner/scheduler.js";
 import { saveLatestClaudeSnapshot } from "../src/context-rewrite/snapshot-store.js";
 import { upsertClaudeCodeSessionSnapshot } from "../src/session-state.js";
 
@@ -163,11 +164,12 @@ test("Claude cleaner bridge rejects a session without a canonical snapshot", asy
 });
 
 test("Claude cleaner bridge preserves approved targets and receipt evidence", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-bridge-schedule-"));
   let captured: ExecuteApprovedContextCleanParams | undefined;
   const applied = appliedReceipt();
   const cancelled = terminalReceipt("cancelled");
   const bridge = createClaudeCodeContextCleanerBridge({
-    stateDir: "unused-state-dir",
+    stateDir,
     controlPlane: {
       async executeApprovedClean(request) {
         captured = request;
@@ -177,20 +179,30 @@ test("Claude cleaner bridge preserves approved targets and receipt evidence", as
       async cancelCleanPlan() { return cancelled; },
     },
   });
-  const request = approval();
+  try {
+    const request = approval();
 
-  const scheduled = await bridge.executeApprovedClean(request);
-  assert.strictEqual(captured, request);
-  assert.equal(scheduled.status, "scheduled");
-  assert.equal("appliedSavedChars" in scheduled, false);
-  assert.strictEqual(await bridge.readCleanReceipt(PLAN), applied);
-  assert.deepEqual(applied.evidence, {
-    previousRevision: "revision-before",
-    nextRevision: "revision-after",
-    operationIds: ["operation-1"],
-    itemIds: ["item-1"],
-  });
-  assert.strictEqual(await bridge.cancelCleanPlan(PLAN), cancelled);
+    const scheduled = await bridge.executeApprovedClean(request);
+    assert.strictEqual(captured, request);
+    assert.equal(scheduled.status, "scheduled");
+    assert.equal("appliedSavedChars" in scheduled, false);
+    const local = await readClaudeCleanerSchedule({ stateDir, sessionId: SESSION });
+    assert.equal(local.outcome, "ready");
+    if (local.outcome === "ready") {
+      assert.equal(local.record.cleanPlanId, PLAN);
+      assert.deepEqual(local.record.selectedTaskIds, ["task-1"]);
+    }
+    assert.strictEqual(await bridge.readCleanReceipt(PLAN), applied);
+    assert.deepEqual(applied.evidence, {
+      previousRevision: "revision-before",
+      nextRevision: "revision-after",
+      operationIds: ["operation-1"],
+      itemIds: ["item-1"],
+    });
+    assert.strictEqual(await bridge.cancelCleanPlan(PLAN), cancelled);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
 });
 
 test("Claude cleaner bridge rejects cross-host or mutated approvals before execution", async () => {

--- a/components/adapters/claude-code/tests/context-cleaner-gateway.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-gateway.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  readContextCleanReceipt,
+  saveContextCleanPlan,
+  transitionContextCleanState,
+  type ContextCleanPendingReceipt,
+  type ContextCleanPlan,
+} from "@lightrsi/cleaner";
+import type { HostGatewayForwarder } from "@lightrsi/host-adapter";
+import type { SessionTaskRegistry } from "@lightrsi/history";
+
+import { attributeClaudeSnapshotTasks } from "../src/context-cleaner/snapshot.js";
+import { scheduleClaudeCleanerPlan } from "../src/context-cleaner/scheduler.js";
+import { normalizeTokenPilotClaudeCodeConfig } from "../src/config.js";
+import { startClaudeCodeGatewayRuntime } from "../src/gateway-runtime.js";
+import { createConsoleLogger } from "../src/logger.js";
+import { buildClaudeContextSnapshot } from "../src/context-rewrite/snapshot.js";
+import { saveLatestClaudeSnapshot } from "../src/context-rewrite/snapshot-store.js";
+import { persistSessionTaskRegistry } from "@lightrsi/history";
+
+const SESSION = "claude-cleaner-gateway-session";
+const PLAN = "claude-cleaner-gateway-plan";
+const REVISION = "claude-cleaner-gateway-base-revision";
+const NOW = "2026-08-29T00:00:00.000Z";
+
+async function reserveUnusedPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close(() => reject(new Error("failed to reserve test port")));
+        return;
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+function registry(): SessionTaskRegistry {
+  return {
+    sessionId: SESSION,
+    version: 1,
+    tasks: {
+      "task-completed": {
+        taskId: "task-completed",
+        title: "completed",
+        objective: "completed",
+        lifecycle: "completed",
+        completionEvidence: [],
+        unresolvedQuestions: [],
+        span: {
+          firstTurnAbsId: `${SESSION}:t1`,
+          lastTurnAbsId: `${SESSION}:t1`,
+          supportingTurnAbsIds: [`${SESSION}:t1`],
+          lastEstimatorTurnAbsId: `${SESSION}:t1`,
+        },
+      },
+    },
+    activeTaskIds: [],
+    completedTaskIds: ["task-completed"],
+    evictableTaskIds: ["task-completed"],
+    taskToBlockIds: {},
+    blockToTaskIds: {
+      "anthropic-tool-result:toolu_cleaner_gateway": ["task-completed"],
+    },
+    turnToTaskIds: {},
+    lastProcessedTurnSeq: 1,
+  };
+}
+
+test("scheduled Claude clean preempts lifecycle eviction and forwards its exact overlay", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-gateway-"));
+  const stateDir = join(root, "state");
+  const proxyPort = await reserveUnusedPort();
+  const historicalMessages = [
+    {
+      role: "assistant",
+      content: [{
+        type: "tool_use",
+        id: "toolu_cleaner_gateway",
+        name: "Read",
+        input: { path: "/repo/old-file.txt" },
+      }],
+    },
+    {
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "toolu_cleaner_gateway",
+        content: "EVICT_GATEWAY_TOOL_RESULT_".repeat(80),
+      }],
+    },
+    { role: "assistant", content: [{ type: "text", text: "old task complete" }] },
+    { role: "user", content: [{ type: "text", text: "APPROVAL_CURRENT_REQUEST" }] },
+  ];
+  const baseSnapshot = attributeClaudeSnapshotTasks({
+    snapshot: buildClaudeContextSnapshot({
+      sessionId: SESSION,
+      revision: REVISION,
+      messages: historicalMessages as never,
+    }),
+    messages: historicalMessages,
+    registry: registry(),
+  });
+  const approvedItems = baseSnapshot.items.filter(
+    (item) => item.taskIds?.includes("task-completed"),
+  );
+  const unassignedChars = baseSnapshot.items
+    .filter((item) => item.taskIds === undefined)
+    .reduce((total, item) => total + item.chars, 0);
+  const plan: ContextCleanPlan = {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: PLAN,
+    hostId: "claude-code",
+    sessionId: SESSION,
+    baseRevision: REVISION,
+    usedTokens: null,
+    usedChars: baseSnapshot.items.reduce((total, item) => total + item.chars, 0),
+    protectedTokens: null,
+    protectedChars: 0,
+    unassignedTokens: null,
+    unassignedChars,
+    tokenCountMode: "chars_only",
+    tokenCountMethod: "utf16_chars",
+    createdAt: NOW,
+    tasks: [{
+      taskId: "task-completed",
+      label: "completed",
+      description: "completed task",
+      summary: "completed",
+      lifecycleState: "completed",
+      itemIds: approvedItems.map((item) => item.stableId),
+      itemDigests: Object.fromEntries(approvedItems.map((item) => [item.stableId, item.fingerprint])),
+      tokenCount: null,
+      charCount: approvedItems.reduce((total, item) => total + item.chars, 0),
+      tokenPercent: null,
+      recommendation: "clean",
+      reasonCodes: ["completed"],
+      selectable: true,
+    }],
+  };
+
+  const forwarded: Array<Record<string, unknown>> = [];
+  const forwarder: HostGatewayForwarder = {
+    async requestRaw() { throw new Error("requestRaw not used"); },
+    async request(params) {
+      forwarded.push(params.payload as Record<string, unknown>);
+      return {
+        status: 200,
+        headers: { "content-type": "application/json" },
+        text: JSON.stringify({
+          id: "msg_cleaner_gateway",
+          type: "message",
+          role: "assistant",
+          content: [{ type: "text", text: "ok" }],
+          stop_reason: "end_turn",
+        }),
+      };
+    },
+    async requestStream() { throw new Error("stream not used"); },
+  };
+  let resolverCalls = 0;
+  const runtime = await startClaudeCodeGatewayRuntime({
+    config: normalizeTokenPilotClaudeCodeConfig({
+      stateDir,
+      proxyPort,
+      modules: { stabilizer: false, reduction: false, eviction: true },
+      eviction: { enabled: true, minBlockChars: 1 },
+      taskStateEstimator: { enabled: true, batchTurns: 1 },
+    }),
+    logger: createConsoleLogger(false),
+    forwarder,
+    dependencies: {
+      resolveEstimator() {
+        resolverCalls += 1;
+        return undefined;
+      },
+    },
+  });
+
+  try {
+    await persistSessionTaskRegistry(stateDir, registry(), { expectedVersion: 0 });
+    assert.deepEqual(await saveLatestClaudeSnapshot(stateDir, SESSION, baseSnapshot), { saved: true });
+    assert.equal((await saveContextCleanPlan({ stateDir, plan })).outcome, "stored");
+    const pending: Omit<ContextCleanPendingReceipt, "status"> = {
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      planId: PLAN,
+      hostId: "claude-code",
+      sessionId: SESSION,
+      selectedTaskIds: ["task-completed"],
+      estimatedSavedTokens: null,
+      estimatedSavedChars: plan.tasks[0]!.charCount,
+      tokenCountMode: "chars_only",
+      deferredTaskIds: [],
+      fallbackUsed: false,
+      reasons: [],
+      updatedAt: NOW,
+    };
+    await transitionContextCleanState({ stateDir, receipt: { ...pending, status: "approved" } });
+    await transitionContextCleanState({ stateDir, receipt: { ...pending, status: "scheduled" } });
+    assert.equal((await scheduleClaudeCleanerPlan({
+      stateDir,
+      sessionId: SESSION,
+      cleanPlanId: PLAN,
+      baseRevision: REVISION,
+      selectedTaskIds: ["task-completed"],
+      scheduledAt: NOW,
+    })).outcome, "stored");
+
+    const response = await fetch(`${runtime.baseUrl}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-session-id": SESSION },
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        stream: false,
+        messages: [
+          ...historicalMessages,
+          { role: "assistant", content: [{ type: "text", text: "previous response" }] },
+          { role: "user", content: [{ type: "text", text: "KEEP_CURRENT_REQUEST" }] },
+        ],
+        max_tokens: 128,
+      }),
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(resolverCalls, 0);
+    assert.equal(forwarded.length, 1);
+    const messages = forwarded[0]!.messages as Array<Record<string, unknown>>;
+    assert.deepEqual((messages[0]!.content as Array<Record<string, unknown>>)[0], {
+      type: "tool_use",
+      id: "toolu_cleaner_gateway",
+      name: "Read",
+      input: {},
+    });
+    assert.match(
+      String((messages[1]!.content as Array<Record<string, unknown>>)[0]!.content),
+      /^\[(Tool payload trimmed|evicted: earlier tool result)/,
+    );
+    assert.equal(
+      (messages.at(-1)!.content as Array<Record<string, unknown>>)[0]!.text,
+      "KEEP_CURRENT_REQUEST",
+    );
+    const receipt = await readContextCleanReceipt({ stateDir, planId: PLAN });
+    assert.equal(receipt.value?.status, "applied");
+    assert.deepEqual(receipt.value?.evidence?.itemIds, approvedItems.map((item) => item.stableId));
+  } finally {
+    await runtime.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/components/adapters/claude-code/tests/context-cleaner-runtime.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-runtime.test.ts
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  readContextCleanReceipt,
+  saveContextCleanPlan,
+  transitionContextCleanState,
+  type ContextCleanPlan,
+  type ContextCleanPendingReceipt,
+} from "@lightrsi/cleaner";
+import type { SessionTaskRegistry } from "@lightrsi/history";
+import type { RuntimeMessage } from "@lightrsi/kernel";
+import { attributeClaudeSnapshotTasks } from "../src/context-cleaner/snapshot.js";
+import { buildClaudeContextSnapshot } from "../src/context-rewrite/snapshot.js";
+import {
+  finalizeClaudeCleanerOverlay,
+  prepareClaudeCleanerOverlay,
+} from "../src/context-cleaner/runtime.js";
+import { readClaudeCleanerSchedule, scheduleClaudeCleanerPlan } from "../src/context-cleaner/scheduler.js";
+
+const SESSION = "claude-cleaner-runtime-session";
+const PLAN = "claude-clean-plan-runtime";
+const REVISION = "claude-cleaner-runtime-revision";
+const NOW = "2026-08-28T00:00:00.000Z";
+
+async function withTempState(run: (stateDir: string) => Promise<void>): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-runtime-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+test("applies one frozen historical Claude overlay and records actual evidence", async () => {
+  await withTempState(async (stateDir) => {
+    const messages: RuntimeMessage[] = [
+      { role: "assistant", content: "EVICT_ME_approved_history" },
+      { role: "user", content: "CURRENT_REQUEST" },
+    ];
+    const rawSnapshot = buildClaudeContextSnapshot({
+      sessionId: SESSION,
+      revision: REVISION,
+      messages,
+    });
+    const historical = rawSnapshot.items[0]!;
+    const baseSnapshot = {
+      ...rawSnapshot,
+      items: rawSnapshot.items.map((item, index) => ({
+        ...item,
+        ...(index === 0 ? { taskIds: ["task-completed"] } : {}),
+      })),
+    };
+    const unassignedChars = baseSnapshot.items
+      .filter((item) => item.taskIds === undefined)
+      .reduce((total, item) => total + item.chars, 0);
+    const plan: ContextCleanPlan = {
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      planId: PLAN,
+      hostId: "claude-code",
+      sessionId: SESSION,
+      baseRevision: REVISION,
+      usedTokens: null,
+      usedChars: baseSnapshot.items.reduce((total, item) => total + item.chars, 0),
+      protectedTokens: null,
+      protectedChars: 0,
+      unassignedTokens: null,
+      unassignedChars,
+      tokenCountMode: "chars_only",
+      tokenCountMethod: "utf16_chars",
+      createdAt: NOW,
+      tasks: [{
+        taskId: "task-completed",
+        label: "completed",
+        description: "completed task",
+        summary: "completed",
+        lifecycleState: "completed",
+        itemIds: [historical.stableId],
+        itemDigests: { [historical.stableId]: historical.fingerprint },
+        tokenCount: null,
+        charCount: historical.chars,
+        tokenPercent: null,
+        recommendation: "clean",
+        reasonCodes: ["completed"],
+        selectable: true,
+      }],
+    };
+    assert.equal((await saveContextCleanPlan({ stateDir, plan })).outcome, "stored");
+    const receipt: Omit<ContextCleanPendingReceipt, "status"> = {
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      planId: PLAN,
+      hostId: "claude-code",
+      sessionId: SESSION,
+      selectedTaskIds: ["task-completed"],
+      estimatedSavedTokens: null,
+      estimatedSavedChars: historical.chars,
+      tokenCountMode: "chars_only" as const,
+      deferredTaskIds: [],
+      fallbackUsed: false as const,
+      reasons: [],
+      updatedAt: NOW,
+    };
+    await transitionContextCleanState({ stateDir, receipt: { ...receipt, status: "approved" } });
+    await transitionContextCleanState({ stateDir, receipt: { ...receipt, status: "scheduled" } });
+    assert.equal((await scheduleClaudeCleanerPlan({
+      stateDir,
+      sessionId: SESSION,
+      cleanPlanId: PLAN,
+      baseRevision: REVISION,
+      selectedTaskIds: ["task-completed"],
+      scheduledAt: NOW,
+    })).outcome, "stored");
+
+    const prepared = await prepareClaudeCleanerOverlay({
+      stateDir,
+      sessionId: SESSION,
+      baseSnapshot,
+      currentSnapshot: baseSnapshot,
+      request: { sessionId: SESSION, revision: REVISION, messages },
+      activeTaskIds: ["task-current"],
+      evictableTaskIds: ["task-completed"],
+      now: "2026-08-28T00:00:01.000Z",
+    });
+
+    assert.equal(prepared.outcome, "prepared");
+    if (prepared.outcome !== "prepared") return;
+    assert.equal(prepared.request.messages[0]?.content, "[evicted: earlier content removed]");
+
+    const finalized = await finalizeClaudeCleanerOverlay({
+      stateDir,
+      prepared,
+      now: "2026-08-28T00:00:02.000Z",
+    });
+    assert.deepEqual(finalized, { outcome: "applied", reasonCodes: [] });
+    const applied = await readContextCleanReceipt({ stateDir, planId: PLAN });
+    assert.equal(applied.value?.status, "applied");
+    assert.equal(applied.value?.appliedSavedChars, prepared.rewriteResult.savedChars);
+    assert.deepEqual(applied.value?.evidence?.itemIds, [historical.stableId]);
+    assert.equal((await readClaudeCleanerSchedule({ stateDir, sessionId: SESSION })).outcome, "committed");
+  });
+});
+
+test("applies every item in an approved, closed Claude tool pair", async () => {
+  await withTempState(async (stateDir) => {
+    const messages: unknown[] = [
+      {
+        role: "assistant",
+        content: [{
+          type: "tool_use",
+          id: "toolu_cleaner_pair",
+          name: "Read",
+          input: { path: "/repo/old-file.txt" },
+        }],
+      },
+      {
+        role: "user",
+        content: [{
+          type: "tool_result",
+          tool_use_id: "toolu_cleaner_pair",
+          content: "EVICT_TOOL_RESULT_".repeat(80),
+        }],
+      },
+      { role: "user", content: "CURRENT_REQUEST" },
+    ];
+    const rawSnapshot = buildClaudeContextSnapshot({
+      sessionId: SESSION,
+      revision: REVISION,
+      messages: messages as RuntimeMessage[],
+    });
+    const registry: SessionTaskRegistry = {
+      sessionId: SESSION,
+      version: 1,
+      tasks: {
+        "task-completed": {
+          taskId: "task-completed",
+          title: "completed",
+          objective: "completed",
+          lifecycle: "completed",
+          completionEvidence: [],
+          unresolvedQuestions: [],
+          span: {
+            firstTurnAbsId: `${SESSION}:t1`,
+            lastTurnAbsId: `${SESSION}:t1`,
+            supportingTurnAbsIds: [`${SESSION}:t1`],
+            lastEstimatorTurnAbsId: `${SESSION}:t1`,
+          },
+        },
+      },
+      activeTaskIds: [],
+      completedTaskIds: ["task-completed"],
+      evictableTaskIds: ["task-completed"],
+      taskToBlockIds: {},
+      blockToTaskIds: {
+        "anthropic-tool-result:toolu_cleaner_pair": ["task-completed"],
+      },
+      turnToTaskIds: {},
+      lastProcessedTurnSeq: 1,
+    };
+    const snapshot = attributeClaudeSnapshotTasks({
+      snapshot: rawSnapshot,
+      messages,
+      registry,
+    });
+    const approvedItems = snapshot.items.filter((item) => item.taskIds?.includes("task-completed"));
+    assert.deepEqual(approvedItems.map((item) => item.kind), ["tool_call", "tool_result"]);
+    const unassignedChars = snapshot.items
+      .filter((item) => item.taskIds === undefined)
+      .reduce((total, item) => total + item.chars, 0);
+
+    const plan: ContextCleanPlan = {
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      planId: PLAN,
+      hostId: "claude-code",
+      sessionId: SESSION,
+      baseRevision: REVISION,
+      usedTokens: null,
+      usedChars: snapshot.items.reduce((total, item) => total + item.chars, 0),
+      protectedTokens: null,
+      protectedChars: 0,
+      unassignedTokens: null,
+      unassignedChars,
+      tokenCountMode: "chars_only",
+      tokenCountMethod: "utf16_chars",
+      createdAt: NOW,
+      tasks: [{
+        taskId: "task-completed",
+        label: "completed",
+        description: "completed task",
+        summary: "completed",
+        lifecycleState: "completed",
+        itemIds: approvedItems.map((item) => item.stableId),
+        itemDigests: Object.fromEntries(approvedItems.map((item) => [item.stableId, item.fingerprint])),
+        tokenCount: null,
+        charCount: approvedItems.reduce((total, item) => total + item.chars, 0),
+        tokenPercent: null,
+        recommendation: "clean",
+        reasonCodes: ["completed"],
+        selectable: true,
+      }],
+    };
+    assert.equal((await saveContextCleanPlan({ stateDir, plan })).outcome, "stored");
+    const pending: Omit<ContextCleanPendingReceipt, "status"> = {
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      planId: PLAN,
+      hostId: "claude-code",
+      sessionId: SESSION,
+      selectedTaskIds: ["task-completed"],
+      estimatedSavedTokens: null,
+      estimatedSavedChars: plan.tasks[0]!.charCount,
+      tokenCountMode: "chars_only",
+      deferredTaskIds: [],
+      fallbackUsed: false,
+      reasons: [],
+      updatedAt: NOW,
+    };
+    await transitionContextCleanState({ stateDir, receipt: { ...pending, status: "approved" } });
+    await transitionContextCleanState({ stateDir, receipt: { ...pending, status: "scheduled" } });
+    await scheduleClaudeCleanerPlan({
+      stateDir,
+      sessionId: SESSION,
+      cleanPlanId: PLAN,
+      baseRevision: REVISION,
+      selectedTaskIds: ["task-completed"],
+      scheduledAt: NOW,
+    });
+
+    const prepared = await prepareClaudeCleanerOverlay({
+      stateDir,
+      sessionId: SESSION,
+      baseSnapshot: snapshot,
+      currentSnapshot: snapshot,
+      request: { sessionId: SESSION, revision: REVISION, messages: messages as RuntimeMessage[] },
+      activeTaskIds: [],
+      evictableTaskIds: ["task-completed"],
+      now: "2026-08-28T00:00:01.000Z",
+    });
+
+    assert.equal(prepared.outcome, "prepared", JSON.stringify(prepared));
+    if (prepared.outcome !== "prepared") return;
+    assert.deepEqual(prepared.rewriteResult.removedItemIds, approvedItems.map((item) => item.stableId));
+    const toolUse = (prepared.request.messages[0]?.content as Array<Record<string, unknown>>)[0];
+    const toolResult = (prepared.request.messages[1]?.content as Array<Record<string, unknown>>)[0];
+    assert.deepEqual(toolUse, {
+      type: "tool_use",
+      id: "toolu_cleaner_pair",
+      name: "Read",
+      input: {},
+    });
+    assert.equal(toolResult?.type, "tool_result");
+    assert.equal(toolResult?.tool_use_id, "toolu_cleaner_pair");
+  });
+});

--- a/components/adapters/claude-code/tests/context-cleaner-scheduler.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-scheduler.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  readClaudeCleanerSchedule,
+  scheduleClaudeCleanerPlan,
+} from "../src/context-cleaner/scheduler.js";
+
+const SESSION = "claude-cleaner-schedule-session";
+const PLAN = "clean-plan-1";
+const REVISION = "claude-rev-base";
+const SCHEDULED_AT = "2026-08-28T00:00:00.000Z";
+
+async function withTempState(run: (stateDir: string) => Promise<void>): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-schedule-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+test("stores one replay-safe Claude schedule for the frozen selected task ids", async () => {
+  await withTempState(async (stateDir) => {
+    const request = {
+      stateDir,
+      sessionId: SESSION,
+      cleanPlanId: PLAN,
+      baseRevision: REVISION,
+      selectedTaskIds: ["task-completed"],
+      scheduledAt: SCHEDULED_AT,
+    };
+
+    const stored = await scheduleClaudeCleanerPlan(request);
+    const replayed = await scheduleClaudeCleanerPlan(request);
+    const current = await readClaudeCleanerSchedule({ stateDir, sessionId: SESSION });
+
+    assert.equal(stored.outcome, "stored");
+    assert.equal(replayed.outcome, "unchanged");
+    assert.equal(current.outcome, "ready");
+    if (current.outcome !== "ready") return;
+    assert.deepEqual(current.record.selectedTaskIds, ["task-completed"]);
+    assert.equal(current.record.cleanPlanId, PLAN);
+    assert.equal(current.record.baseRevision, REVISION);
+  });
+});


### PR DESCRIPTION
## Summary

- Schedule approved Cleaner plans locally for Claude Code and suppress automatic lifecycle eviction while a manual clean is pending.
- Revalidate the frozen plan against the current snapshot, task lifecycle, revision, fingerprints, and tool protocol closure before applying one request overlay.
- Preserve tool call/result closure, fall back to the original request when an overlay cannot be safely completed, and record applied receipts only from exact rewrite evidence and actual savings.
- Add schedule, runtime, gateway, receipt, bridge, and tool-pair regression coverage.

## Validation

- 51 PR4-focused tests passed.
- Claude Code adapter typecheck and build passed.
- Package-boundary check and workspace typecheck passed.

## Known baseline issue

The full Claude adapter suite remains unable to exit in `tests/e2e.test.ts` because of existing visual-daemon lifecycle cleanup. This reproduces on clean `main` and is outside this PR’s Claude Cleaner boundary.