### PR TITLE
Feat/cli interactive context clean flow

### DIFF
--- a/components/packages/features/cleaner/src/index.ts
+++ b/components/packages/features/cleaner/src/index.ts
@@ -43,3 +43,4 @@ export {
   type CreateContextCleanerHostExecutionBridgeParams,
 } from "./host-execution-bridge.js";
 export * from "./recommendation.js";
+export * from "./orchestrator.js";

--- a/components/packages/features/cleaner/src/orchestrator.ts
+++ b/components/packages/features/cleaner/src/orchestrator.ts
@@ -1,0 +1,322 @@
+import { createHash } from "node:crypto";
+
+import {
+  loadSessionTaskRegistry,
+  type SessionTaskRegistry,
+} from "@lightrsi/history";
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  isTerminalContextCleanStatus,
+  type ContextCleanPendingReceipt,
+  type ContextCleanPlan,
+  type ContextCleanReceipt,
+  type ContextCleanerControlPlane,
+  type ContextCleanerHostBridge,
+  type ExecuteApprovedContextCleanParams,
+} from "./contracts.js";
+import { readContextCleanPlan, saveContextCleanPlan } from "./clean-plan-store.js";
+import { readContextCleanReceipt } from "./clean-receipt-store.js";
+import { transitionContextCleanState } from "./clean-state-coordinator.js";
+import { buildContextCleanBreakdown } from "./token-accounting.js";
+import {
+  analyzeContextCleanRecommendations,
+  type ContextCleanRecommendationProvider,
+  type ContextCleanTaskEvidence,
+} from "./recommendation.js";
+
+export type ContextCleanAnalysisResult = {
+  plan: ContextCleanPlan;
+  receipt: ContextCleanPendingReceipt;
+  fallbackUsed: boolean;
+  reasons: string[];
+};
+
+export type AnalyzeContextCleanSessionParams = {
+  stateDir: string;
+  bridge: ContextCleanerHostBridge;
+  sessionId: string;
+  contextWindowTokens?: number;
+  provider?: ContextCleanRecommendationProvider;
+  loadRegistry?: (stateDir: string, sessionId: string) => Promise<SessionTaskRegistry>;
+};
+
+function canonicalPlanId(plan: Omit<ContextCleanPlan, "planId">): string {
+  const digest = createHash("sha256").update(JSON.stringify(plan)).digest("hex").slice(0, 24);
+  return `ctxclean-${digest}`;
+}
+
+function taskEvidence(registry: SessionTaskRegistry): Record<string, ContextCleanTaskEvidence> {
+  return Object.fromEntries(Object.values(registry.tasks).map((task) => [task.taskId, {
+    completionEvidence: task.completionEvidence,
+    unresolvedIssues: task.unresolvedQuestions,
+  }]));
+}
+
+function analyzedReceipt(
+  plan: ContextCleanPlan,
+  reasons: string[],
+): ContextCleanPendingReceipt {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: plan.planId,
+    hostId: plan.hostId,
+    sessionId: plan.sessionId,
+    status: "analyzed",
+    selectedTaskIds: [],
+    estimatedSavedTokens: 0,
+    estimatedSavedChars: 0,
+    tokenCountMode: plan.tokenCountMode,
+    deferredTaskIds: [],
+    reasons,
+    updatedAt: plan.createdAt,
+    fallbackUsed: false,
+  };
+}
+
+function throwStoreFailure(operation: string, reasons: string[]): never {
+  throw new Error(`${operation}:${reasons.join(",") || "unknown"}`);
+}
+
+export async function analyzeContextCleanSession(
+  params: AnalyzeContextCleanSessionParams,
+): Promise<ContextCleanAnalysisResult> {
+  const sessionId = params.sessionId.trim();
+  if (!params.stateDir.trim() || !sessionId) throw new Error("clean_analysis_identity_invalid");
+  if (params.contextWindowTokens !== undefined
+    && (!Number.isSafeInteger(params.contextWindowTokens) || params.contextWindowTokens <= 0)) {
+    throw new Error("clean_analysis_context_window_invalid");
+  }
+
+  const snapshot = await params.bridge.readCleanSnapshot(sessionId);
+  if (snapshot.hostId !== params.bridge.hostId || snapshot.sessionId !== sessionId) {
+    throw new Error("clean_analysis_snapshot_identity_mismatch");
+  }
+  if (!snapshot.revision.trim() || Number.isNaN(Date.parse(snapshot.capturedAt))) {
+    throw new Error("clean_analysis_snapshot_invalid");
+  }
+
+  const registry = await (params.loadRegistry ?? loadSessionTaskRegistry)(params.stateDir, sessionId);
+  if (registry.sessionId !== sessionId) throw new Error("clean_analysis_registry_identity_mismatch");
+
+  const breakdown = buildContextCleanBreakdown({
+    snapshot,
+    registry,
+    model: snapshot.model,
+    itemTokenCounts: snapshot.itemTokenCounts,
+  });
+  const recommended = await analyzeContextCleanRecommendations({
+    tasks: breakdown.tasks,
+    evidenceByTaskId: taskEvidence(registry),
+    provider: params.provider,
+  });
+  const planWithoutId: Omit<ContextCleanPlan, "planId"> = {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    hostId: params.bridge.hostId,
+    sessionId,
+    baseRevision: snapshot.revision,
+    ...(snapshot.model ? { model: snapshot.model } : {}),
+    ...(params.contextWindowTokens !== undefined
+      ? { contextWindowTokens: params.contextWindowTokens }
+      : {}),
+    usedTokens: breakdown.usedTokens,
+    usedChars: breakdown.usedChars,
+    protectedTokens: breakdown.protectedTokens,
+    protectedChars: breakdown.protectedChars,
+    unassignedTokens: breakdown.unassignedTokens,
+    unassignedChars: breakdown.unassignedChars,
+    tokenCountMode: breakdown.tokenCountMode,
+    tokenCountMethod: breakdown.tokenCountMethod,
+    tasks: recommended.tasks,
+    createdAt: snapshot.capturedAt,
+  };
+  const plan: ContextCleanPlan = {
+    ...planWithoutId,
+    planId: canonicalPlanId(planWithoutId),
+  };
+  const saved = await saveContextCleanPlan({ stateDir: params.stateDir, plan });
+  if (saved.bypassed) throwStoreFailure("clean_analysis_plan_store_failed", saved.reasons);
+
+  const receipt = analyzedReceipt(plan, recommended.reasons);
+  const transitioned = await transitionContextCleanState({ stateDir: params.stateDir, receipt });
+  if (transitioned.bypassed) {
+    throwStoreFailure("clean_analysis_receipt_store_failed", transitioned.reasons);
+  }
+  return {
+    plan,
+    receipt,
+    fallbackUsed: recommended.fallbackUsed,
+    reasons: recommended.reasons,
+  };
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+function sameDigests(
+  left: Readonly<Record<string, string>>,
+  right: Readonly<Record<string, string>>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return sameStrings(leftKeys, rightKeys)
+    && leftKeys.every((key) => left[key] === right[key]);
+}
+
+function validateApproval(
+  plan: ContextCleanPlan,
+  request: ExecuteApprovedContextCleanParams,
+): ContextCleanPlan["tasks"] {
+  if (request.schemaVersion !== CONTEXT_CLEAN_SCHEMA_VERSION
+    || request.cleanPlanId !== plan.planId
+    || request.hostId !== plan.hostId
+    || request.sessionId !== plan.sessionId
+    || request.baseRevision !== plan.baseRevision
+    || Number.isNaN(Date.parse(request.approvedAt))
+    || request.selectedTasks.length === 0) {
+    throw new Error("clean_approval_invalid");
+  }
+  const selectedIds = request.selectedTasks.map((task) => task.taskId);
+  if (new Set(selectedIds).size !== selectedIds.length) throw new Error("clean_approval_duplicate_task");
+  const byTaskId = new Map(plan.tasks.map((task) => [task.taskId, task]));
+  return request.selectedTasks.map((selected) => {
+    const stored = byTaskId.get(selected.taskId);
+    if (!stored) throw new Error("clean_approval_unknown_task");
+    if (!stored.selectable) throw new Error("clean_approval_task_not_selectable");
+    if (!sameStrings(selected.itemIds, stored.itemIds)
+      || !sameDigests(selected.itemDigests, stored.itemDigests)) {
+      throw new Error("clean_approval_targets_mismatch");
+    }
+    return stored;
+  });
+}
+
+function savings(tasks: ContextCleanPlan["tasks"]): { tokens: number | null; chars: number } {
+  return {
+    tokens: tasks.every((task) => task.tokenCount !== null)
+      ? tasks.reduce((total, task) => total + (task.tokenCount ?? 0), 0)
+      : null,
+    chars: tasks.reduce((total, task) => total + task.charCount, 0),
+  };
+}
+
+function pendingReceipt(params: {
+  plan: ContextCleanPlan;
+  status: "approved" | "scheduled";
+  selectedTaskIds: string[];
+  updatedAt: string;
+}): ContextCleanPendingReceipt {
+  const estimated = savings(params.plan.tasks.filter((task) => params.selectedTaskIds.includes(task.taskId)));
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: params.plan.planId,
+    hostId: params.plan.hostId,
+    sessionId: params.plan.sessionId,
+    status: params.status,
+    selectedTaskIds: params.selectedTaskIds,
+    estimatedSavedTokens: estimated.tokens,
+    estimatedSavedChars: estimated.chars,
+    tokenCountMode: params.plan.tokenCountMode,
+    deferredTaskIds: [],
+    reasons: [],
+    updatedAt: params.updatedAt,
+    fallbackUsed: false,
+  };
+}
+
+export function createContextCleanerControlPlane(params: {
+  stateDir: string;
+  now?: () => string;
+}): ContextCleanerControlPlane {
+  const now = params.now ?? (() => new Date().toISOString());
+  return {
+    async executeApprovedClean(request) {
+      const stored = await readContextCleanPlan({ stateDir: params.stateDir, planId: request.cleanPlanId });
+      if (stored.bypassed) throwStoreFailure("clean_approval_plan_unavailable", stored.reasons);
+      if (!stored.value) throw new Error("clean_approval_plan_missing");
+      const currentReceipt = await readContextCleanReceipt({
+        stateDir: params.stateDir,
+        planId: request.cleanPlanId,
+      });
+      if (currentReceipt.bypassed) {
+        throwStoreFailure("clean_approval_receipt_unavailable", currentReceipt.reasons);
+      }
+      if (isTerminalContextCleanStatus(stored.value.status)) {
+        if (!currentReceipt.value) throw new Error("clean_approval_terminal_receipt_missing");
+        return currentReceipt.value;
+      }
+      const selected = validateApproval(stored.value.plan, request);
+      const selectedTaskIds = selected.map((task) => task.taskId);
+      if (stored.value.status === "scheduled") {
+        if (!currentReceipt.value
+          || currentReceipt.value.status !== "scheduled"
+          || !sameStrings(currentReceipt.value.selectedTaskIds, selectedTaskIds)) {
+          throw new Error("clean_approval_scheduled_conflict");
+        }
+        return currentReceipt.value;
+      }
+      if (stored.value.status === "analyzed") {
+        const approved = pendingReceipt({
+          plan: stored.value.plan,
+          status: "approved",
+          selectedTaskIds,
+          updatedAt: request.approvedAt,
+        });
+        const result = await transitionContextCleanState({ stateDir: params.stateDir, receipt: approved });
+        if (result.bypassed) throwStoreFailure("clean_approval_store_failed", result.reasons);
+      } else if (stored.value.status === "approved"
+        && (!currentReceipt.value
+          || currentReceipt.value.status !== "approved"
+          || !sameStrings(currentReceipt.value.selectedTaskIds, selectedTaskIds))) {
+        throw new Error("clean_approval_selection_conflict");
+      }
+      const scheduled = pendingReceipt({
+        plan: stored.value.plan,
+        status: "scheduled",
+        selectedTaskIds,
+        updatedAt: now(),
+      });
+      const result = await transitionContextCleanState({ stateDir: params.stateDir, receipt: scheduled });
+      if (result.bypassed) throwStoreFailure("clean_schedule_store_failed", result.reasons);
+      return scheduled;
+    },
+    async readCleanReceipt(planId) {
+      const result = await readContextCleanReceipt({ stateDir: params.stateDir, planId });
+      if (result.bypassed) throwStoreFailure("clean_receipt_unavailable", result.reasons);
+      return result.value;
+    },
+    async cancelCleanPlan(planId) {
+      const planRead = await readContextCleanPlan({ stateDir: params.stateDir, planId });
+      if (planRead.bypassed) throwStoreFailure("clean_cancel_plan_unavailable", planRead.reasons);
+      if (!planRead.value) throw new Error("clean_cancel_plan_missing");
+      const receiptRead = await readContextCleanReceipt({ stateDir: params.stateDir, planId });
+      if (receiptRead.bypassed) throwStoreFailure("clean_cancel_receipt_unavailable", receiptRead.reasons);
+      if (isTerminalContextCleanStatus(planRead.value.status)) {
+        if (!receiptRead.value) throw new Error("clean_cancel_terminal_receipt_missing");
+        return receiptRead.value;
+      }
+      const current = receiptRead.value;
+      const cancelled: ContextCleanReceipt = {
+        schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+        planId,
+        hostId: planRead.value.plan.hostId,
+        sessionId: planRead.value.plan.sessionId,
+        status: "cancelled",
+        selectedTaskIds: current?.selectedTaskIds ?? [],
+        estimatedSavedTokens: current ? current.estimatedSavedTokens : 0,
+        estimatedSavedChars: current?.estimatedSavedChars ?? 0,
+        tokenCountMode: planRead.value.plan.tokenCountMode,
+        deferredTaskIds: current?.deferredTaskIds ?? [],
+        reasons: ["cancelled_by_user"],
+        updatedAt: now(),
+        fallbackUsed: false,
+      };
+      const result = await transitionContextCleanState({ stateDir: params.stateDir, receipt: cancelled });
+      if (result.bypassed) throwStoreFailure("clean_cancel_store_failed", result.reasons);
+      return cancelled;
+    },
+  };
+}

--- a/components/packages/features/cleaner/tests/orchestrator.test.ts
+++ b/components/packages/features/cleaner/tests/orchestrator.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import type { SessionTaskRegistry } from "@lightrsi/history";
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  analyzeContextCleanSession,
+  createContextCleanerControlPlane,
+  readContextCleanPlan,
+  readContextCleanReceipt,
+  type ContextCleanerHostBridge,
+  type ContextCleanRecommendationProvider,
+  type ContextCleanSnapshot,
+} from "../src/index.js";
+import { sampleSnapshot } from "./fixtures.js";
+
+const capturedAt = "2026-08-20T00:00:00.000Z";
+
+function registry(): SessionTaskRegistry {
+  const span = {
+    firstTurnAbsId: "turn-1",
+    lastTurnAbsId: "turn-2",
+    supportingTurnAbsIds: ["turn-1", "turn-2"],
+    lastEstimatorTurnAbsId: "turn-2",
+  };
+  return {
+    sessionId: "session-1",
+    version: 1,
+    tasks: {
+      "task-a": {
+        taskId: "task-a",
+        title: "Finished task",
+        objective: "Finish task A",
+        lifecycle: "evictable",
+        completionEvidence: ["Delivered"],
+        unresolvedQuestions: [],
+        span,
+      },
+      "task-current": {
+        taskId: "task-current",
+        title: "Current task",
+        objective: "Continue current task",
+        lifecycle: "active",
+        completionEvidence: [],
+        unresolvedQuestions: [],
+        span,
+      },
+    },
+    activeTaskIds: ["task-current"],
+    completedTaskIds: ["task-a"],
+    evictableTaskIds: ["task-a"],
+    taskToBlockIds: {},
+    blockToTaskIds: {},
+    turnToTaskIds: {},
+    lastProcessedTurnSeq: 2,
+  };
+}
+
+function snapshot(): ContextCleanSnapshot {
+  return {
+    ...sampleSnapshot(),
+    capturedAt,
+    model: "gpt-5.4",
+    tokenCountMode: "estimated",
+    tokenCountMethod: "fixture",
+    itemTokenCounts: { "item-a": 30, "item-b": 20, "item-current": 10 },
+  };
+}
+
+function bridge(cleanSnapshot: ContextCleanSnapshot = snapshot()): ContextCleanerHostBridge {
+  return {
+    hostId: "codex",
+    rewriteMode: "response_chain_rebase",
+    async listSessions() { return [{ sessionId: "session-1" }]; },
+    async readCleanSnapshot() { return cleanSnapshot; },
+    async executeApprovedClean() { throw new Error("unused"); },
+    async readCleanReceipt() { return undefined; },
+    async cancelCleanPlan() { throw new Error("unused"); },
+  };
+}
+
+const provider: ContextCleanRecommendationProvider = {
+  async recommend(input) {
+    return {
+      output: {
+        tasks: input.tasks.map((task) => ({
+          taskId: task.taskId,
+          label: task.label,
+          description: task.description,
+          summary: task.summary,
+          recommendation: task.lifecycleState === "completed" ? "clean" : "keep",
+          reasonCodes: task.lifecycleState === "completed" ? ["completed_and_cold"] : [],
+          confidence: 0.9,
+        })),
+      },
+    };
+  },
+};
+
+test("analysis persists an immutable plan and protects the active task", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-orchestrator-"));
+  try {
+    const result = await analyzeContextCleanSession({
+      stateDir: root,
+      bridge: bridge(),
+      sessionId: "session-1",
+      contextWindowTokens: 128_000,
+      provider,
+      async loadRegistry() { return registry(); },
+    });
+    assert.match(result.plan.planId, /^ctxclean-[a-f0-9]{24}$/);
+    assert.equal(result.plan.contextWindowTokens, 128_000);
+    assert.equal(result.fallbackUsed, false);
+    assert.deepEqual(result.plan.tasks.map((task) => [task.taskId, task.recommendation, task.selectable]), [
+      ["task-a", "clean", true],
+      ["task-current", "protected", false],
+    ]);
+    assert.equal((await readContextCleanPlan({ stateDir: root, planId: result.plan.planId })).value?.status, "analyzed");
+    assert.equal((await readContextCleanReceipt({ stateDir: root, planId: result.plan.planId })).value?.status, "analyzed");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("control plane validates exact frozen targets and schedules idempotently", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-control-plane-"));
+  try {
+    const analysis = await analyzeContextCleanSession({
+      stateDir: root,
+      bridge: bridge(),
+      sessionId: "session-1",
+      provider,
+      async loadRegistry() { return registry(); },
+    });
+    const selected = analysis.plan.tasks.find((task) => task.taskId === "task-a")!;
+    const request = {
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      cleanPlanId: analysis.plan.planId,
+      hostId: analysis.plan.hostId,
+      sessionId: analysis.plan.sessionId,
+      baseRevision: analysis.plan.baseRevision,
+      approvedAt: "2026-08-20T00:01:00.000Z",
+      selectedTasks: [{
+        taskId: selected.taskId,
+        itemIds: [...selected.itemIds].reverse(),
+        itemDigests: { ...selected.itemDigests },
+      }],
+    };
+    const controlPlane = createContextCleanerControlPlane({
+      stateDir: root,
+      now: () => "2026-08-20T00:02:00.000Z",
+    });
+    const scheduled = await controlPlane.executeApprovedClean(request);
+    assert.equal(scheduled.status, "scheduled");
+    assert.deepEqual(scheduled.selectedTaskIds, ["task-a"]);
+    assert.equal(scheduled.estimatedSavedTokens, 50);
+    assert.equal(scheduled.estimatedSavedChars, 200);
+    assert.deepEqual(await controlPlane.executeApprovedClean(request), scheduled);
+
+    await assert.rejects(
+      controlPlane.executeApprovedClean({
+        ...request,
+        selectedTasks: [{ ...request.selectedTasks[0]!, itemDigests: { "item-a": "changed" } }],
+      }),
+      /clean_approval_targets_mismatch/,
+    );
+    const cancelled = await controlPlane.cancelCleanPlan(analysis.plan.planId);
+    assert.equal(cancelled.status, "cancelled");
+    assert.deepEqual(await controlPlane.cancelCleanPlan(analysis.plan.planId), cancelled);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("missing recommendation provider fails closed without making tasks unsafe", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-fallback-"));
+  try {
+    const result = await analyzeContextCleanSession({
+      stateDir: root,
+      bridge: bridge(),
+      sessionId: "session-1",
+      async loadRegistry() { return registry(); },
+    });
+    assert.equal(result.fallbackUsed, true);
+    assert.deepEqual(result.reasons, ["recommendation_provider_unavailable"]);
+    assert.deepEqual(result.plan.tasks.map((task) => task.recommendation), ["keep", "protected"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("cancelling a chars-only plan preserves null token accounting and char savings", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-cancel-chars-"));
+  try {
+    const charSnapshot: ContextCleanSnapshot = {
+      ...sampleSnapshot(),
+      capturedAt,
+      tokenCountMode: "chars_only",
+      tokenCountMethod: "utf16_chars",
+    };
+    const analysis = await analyzeContextCleanSession({
+      stateDir: root,
+      bridge: bridge(charSnapshot),
+      sessionId: "session-1",
+      provider,
+      async loadRegistry() { return registry(); },
+    });
+    const task = analysis.plan.tasks.find((item) => item.taskId === "task-a")!;
+    const controlPlane = createContextCleanerControlPlane({
+      stateDir: root,
+      now: () => "2026-08-20T00:02:00.000Z",
+    });
+    await controlPlane.executeApprovedClean({
+      schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+      cleanPlanId: analysis.plan.planId,
+      hostId: analysis.plan.hostId,
+      sessionId: analysis.plan.sessionId,
+      baseRevision: analysis.plan.baseRevision,
+      approvedAt: "2026-08-20T00:01:00.000Z",
+      selectedTasks: [{
+        taskId: task.taskId,
+        itemIds: task.itemIds,
+        itemDigests: task.itemDigests,
+      }],
+    });
+    const cancelled = await controlPlane.cancelCleanPlan(analysis.plan.planId);
+    assert.equal(cancelled.status, "cancelled");
+    assert.equal(cancelled.estimatedSavedTokens, null);
+    assert.equal(cancelled.estimatedSavedChars, 200);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/components/products/cli/package.json
+++ b/components/products/cli/package.json
@@ -18,6 +18,7 @@
     "test": "node --import tsx --test tests/*.test.ts"
   },
   "dependencies": {
+    "@lightrsi/cleaner": "workspace:*",
     "@lightrsi/tokenpilot": "workspace:*",
     "@lightrsi/host-adapter": "workspace:*",
     "@lightrsi/product-surface": "workspace:*",

--- a/components/products/cli/src/clean-prompt.ts
+++ b/components/products/cli/src/clean-prompt.ts
@@ -1,0 +1,80 @@
+import { emitKeypressEvents } from "node:readline";
+
+import { estimateCleanSelection, type CleanPlanView } from "./clean-renderer.js";
+
+export type CleanTaskPrompt = (plan: CleanPlanView) => Promise<string[] | undefined>;
+
+export async function promptForCleanTasks(plan: CleanPlanView): Promise<string[] | undefined> {
+  const choices = plan.tasks.filter((task) => task.selectable);
+  if (choices.length === 0) return [];
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return undefined;
+
+  const selected = new Set(
+    choices.filter((task) => task.recommendation === "clean").map((task) => task.taskId),
+  );
+  let cursor = 0;
+  emitKeypressEvents(process.stdin);
+  const render = (first: boolean) => {
+    if (!first) process.stdout.write(`\u001b[${choices.length + 2}A`);
+    process.stdout.write("Select tasks to clean (↑/↓ move, space toggle, enter confirm, q cancel)\n");
+    for (const [index, task] of choices.entries()) {
+      const marker = index === cursor ? ">" : " ";
+      const checked = selected.has(task.taskId) ? "x" : " ";
+      process.stdout.write(`${marker} [${checked}] ${task.taskId} — ${task.label}\u001b[K\n`);
+    }
+    const estimate = estimateCleanSelection(plan, [...selected]);
+    const estimateText = estimate.tokens === null ? `${estimate.chars} chars` : `${estimate.tokens} tok`;
+    process.stdout.write(`Selected estimated release: ${estimateText}\u001b[K\n`);
+  };
+
+  return new Promise<string[] | undefined>((resolve, reject) => {
+    const previousRaw = process.stdin.isRaw;
+    let confirming = false;
+    const cleanup = () => {
+      process.stdin.off("keypress", onKeypress);
+      process.stdin.setRawMode?.(Boolean(previousRaw));
+      process.stdin.pause();
+      if (confirming) process.stdout.write("\n");
+      process.stdout.write("\u001b[?25h");
+    };
+    const finish = (value: string[] | undefined) => {
+      cleanup();
+      resolve(value);
+    };
+    const onKeypress = (_value: string, key: { name?: string; ctrl?: boolean }) => {
+      if (key.ctrl && key.name === "c") {
+        cleanup();
+        reject(new Error("clean_selection_interrupted"));
+        return;
+      }
+      if (confirming) {
+        if (key.name === "y") return finish(
+          choices.filter((task) => selected.has(task.taskId)).map((task) => task.taskId),
+        );
+        if (key.name === "return" || key.name === "enter" || key.name === "n"
+          || key.name === "escape" || key.name === "q") return finish(undefined);
+        return;
+      }
+      if (key.name === "q" || key.name === "escape") return finish(undefined);
+      if (key.name === "return" || key.name === "enter") {
+        if (selected.size === 0) return finish([]);
+        confirming = true;
+        process.stdout.write("Confirm clean? [y/N] ");
+        return;
+      }
+      if (key.name === "up") cursor = (cursor + choices.length - 1) % choices.length;
+      else if (key.name === "down") cursor = (cursor + 1) % choices.length;
+      else if (key.name === "space") {
+        const taskId = choices[cursor]!.taskId;
+        if (selected.has(taskId)) selected.delete(taskId);
+        else selected.add(taskId);
+      } else return;
+      render(false);
+    };
+    process.stdin.setRawMode?.(true);
+    process.stdin.resume();
+    process.stdin.on("keypress", onKeypress);
+    process.stdout.write("\u001b[?25l");
+    render(true);
+  });
+}

--- a/components/products/cli/src/clean-renderer.ts
+++ b/components/products/cli/src/clean-renderer.ts
@@ -1,0 +1,128 @@
+export type CleanTaskView = {
+  taskId: string;
+  label: string;
+  description: string;
+  lifecycleState: string;
+  tokenCount: number | null;
+  charCount: number;
+  tokenPercent: number | null;
+  recommendation: "clean" | "keep" | "protected";
+  reasonCodes: string[];
+  selectable: boolean;
+};
+
+export type CleanPlanView = {
+  planId: string;
+  hostId: string;
+  sessionId: string;
+  contextWindowTokens?: number;
+  usedTokens: number | null;
+  usedChars: number;
+  protectedTokens: number | null;
+  protectedChars: number;
+  unassignedTokens: number | null;
+  unassignedChars: number;
+  tokenCountMode: string;
+  tasks: CleanTaskView[];
+};
+
+export type CleanReceiptView = {
+  planId: string;
+  status: string;
+  selectedTaskIds: string[];
+  estimatedSavedTokens: number | null;
+  estimatedSavedChars: number;
+  appliedSavedTokens?: number | null;
+  appliedSavedChars?: number;
+  deferredTaskIds: string[];
+  reasons: string[];
+};
+
+function count(tokens: number | null, chars: number): string {
+  return tokens === null ? `${chars} chars` : `${tokens} tok`;
+}
+
+function cell(value: string, width: number): string {
+  return value.length > width ? `${value.slice(0, Math.max(0, width - 1))}…` : value.padEnd(width);
+}
+
+function risk(task: CleanTaskView): string {
+  const level = task.recommendation === "protected" ? "blocked"
+    : task.recommendation === "keep" ? "caution" : "low";
+  return task.reasonCodes.length > 0 ? `${level}: ${task.reasonCodes.join(",")}` : level;
+}
+
+export function estimateCleanSelection(plan: CleanPlanView, selectedTaskIds: readonly string[]): {
+  tokens: number | null;
+  chars: number;
+} {
+  const selected = plan.tasks.filter((task) => selectedTaskIds.includes(task.taskId));
+  return {
+    tokens: selected.length === 0
+      ? (plan.usedTokens === null ? null : 0)
+      : selected.every((task) => task.tokenCount !== null)
+      ? selected.reduce((total, task) => total + (task.tokenCount ?? 0), 0)
+      : null,
+    chars: selected.reduce((total, task) => total + task.charCount, 0),
+  };
+}
+
+export function renderCleanPlan(plan: CleanPlanView): string {
+  const rows = plan.tasks.map((task) => [
+    task.selectable ? "[ ]" : "[-]",
+    task.taskId,
+    task.description,
+    count(task.tokenCount, task.charCount),
+    task.tokenPercent === null ? "-" : `${task.tokenPercent.toFixed(1)}%`,
+    task.recommendation,
+    risk(task),
+  ]);
+  const widths = [
+    3,
+    Math.max(18, "TASK".length, ...plan.tasks.map((task) => task.taskId.length)),
+    32,
+    12,
+    7,
+    10,
+    34,
+  ];
+  const format = (row: string[]) => row.map((value, index) => cell(value, widths[index]!)).join("  ").trimEnd();
+  const recommendedTaskIds = plan.tasks
+    .filter((task) => task.selectable && task.recommendation === "clean")
+    .map((task) => task.taskId);
+  const recommended = estimateCleanSelection(plan, recommendedTaskIds);
+  const usage = plan.contextWindowTokens !== undefined && plan.contextWindowTokens > 0 && plan.usedTokens !== null
+    ? `${plan.usedTokens} / ${plan.contextWindowTokens} tok (${(plan.usedTokens / plan.contextWindowTokens * 100).toFixed(1)}%)`
+    : count(plan.usedTokens, plan.usedChars);
+  return [
+    `Context clean plan ${plan.planId}`,
+    `Host/session: ${plan.hostId} / ${plan.sessionId}`,
+    `Context usage: ${usage} (${plan.tokenCountMode})`,
+    `Protected context: ${count(plan.protectedTokens, plan.protectedChars)}`,
+    `Unassigned context: ${count(plan.unassignedTokens, plan.unassignedChars)}`,
+    "",
+    format(["", "TASK", "DESCRIPTION", "SIZE", "SHARE", "ADVICE", "RISK / REASONS"]),
+    format(widths.map((width) => "-".repeat(width))),
+    ...rows.map(format),
+    ...plan.tasks
+      .filter((task) => task.reasonCodes.length > 0)
+      .map((task) => `Reasons ${task.taskId}: ${task.reasonCodes.join(", ")}`),
+    "",
+    `Recommended selection estimate: ${count(recommended.tokens, recommended.chars)}`,
+  ].join("\n");
+}
+
+export function renderCleanReceipt(receipt: CleanReceiptView): string {
+  const lines = [
+    `Context clean ${receipt.status}: ${receipt.planId}`,
+    `Selected tasks: ${receipt.selectedTaskIds.length > 0 ? receipt.selectedTaskIds.join(", ") : "(none)"}`,
+    `Estimated savings: ${count(receipt.estimatedSavedTokens, receipt.estimatedSavedChars)}`,
+  ];
+  if (receipt.appliedSavedTokens !== undefined || receipt.appliedSavedChars !== undefined) {
+    lines.push(`Released: ${count(receipt.appliedSavedTokens ?? null, receipt.appliedSavedChars ?? 0)}`);
+  }
+  if (receipt.status === "scheduled") lines.push("Apply timing: next Host request.");
+  if (receipt.deferredTaskIds.length > 0) lines.push(`Deferred tasks: ${receipt.deferredTaskIds.join(", ")}`);
+  if (receipt.reasons.length > 0) lines.push(`Reasons: ${receipt.reasons.join(", ")}`);
+  return lines.join("\n");
+}

--- a/components/products/cli/src/clean.ts
+++ b/components/products/cli/src/clean.ts
@@ -1,0 +1,173 @@
+import { promptForCleanTasks, type CleanTaskPrompt } from "./clean-prompt.js";
+import {
+  renderCleanPlan,
+  renderCleanReceipt,
+  type CleanPlanView,
+  type CleanReceiptView,
+} from "./clean-renderer.js";
+
+export interface CleanCommandBackend {
+  analyze(sessionId: string): Promise<CleanPlanView>;
+  readPlan(planId: string): Promise<CleanPlanView | undefined>;
+  approve(planId: string, selectedTaskIds: string[]): Promise<CleanReceiptView>;
+  readReceipt(planId: string): Promise<CleanReceiptView | undefined>;
+  cancel(planId: string): Promise<CleanReceiptView>;
+}
+
+export type CleanCommandBackendResolver = (params: {
+  hostId: string;
+  sessionId?: string;
+  pathOverrides?: {
+    tokenPilotConfigPath?: string;
+    hostConfigPath?: string;
+    hostAuxConfigPath?: string;
+  };
+}) => Promise<CleanCommandBackend | undefined> | CleanCommandBackend | undefined;
+
+let backendResolver: CleanCommandBackendResolver | undefined;
+
+/** Common Host registration point. Host-specific construction remains outside the CLI controller. */
+export function registerCleanCommandBackendResolver(resolver: CleanCommandBackendResolver | undefined): void {
+  backendResolver = resolver;
+}
+
+export function resolveCleanCommandBackend(params: {
+  hostId: string;
+  sessionId?: string;
+  pathOverrides?: {
+    tokenPilotConfigPath?: string;
+    hostConfigPath?: string;
+    hostAuxConfigPath?: string;
+  };
+}): Promise<CleanCommandBackend | undefined> {
+  return Promise.resolve(backendResolver?.(params));
+}
+
+type ParsedCleanArgs = {
+  sessionId?: string;
+  planId?: string;
+  selectedTaskIds?: string[];
+  status: boolean;
+  cancel: boolean;
+};
+
+export function formatCleanUsage(): string {
+  return [
+    "Usage:",
+    "  lightrsi <host> clean [--session <session-id>]",
+    "  lightrsi <host> clean --plan <plan-id> --select <task-id[,task-id...]>",
+    "  lightrsi <host> clean --status <plan-id>",
+    "  lightrsi <host> clean --cancel <plan-id>",
+  ].join("\n");
+}
+
+function parseCleanArgs(args: string[]): ParsedCleanArgs {
+  const parsed: ParsedCleanArgs = { status: false, cancel: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--plan") {
+      const value = args[++index]?.trim();
+      if (!value) throw new Error("clean_plan_id_missing");
+      if (parsed.planId) throw new Error("clean_plan_id_duplicate");
+      parsed.planId = value;
+    } else if (argument === "--session") {
+      const value = args[++index]?.trim();
+      if (!value) throw new Error("clean_session_id_missing");
+      if (parsed.sessionId) throw new Error("clean_session_id_duplicate");
+      parsed.sessionId = value;
+    } else if (argument === "--select") {
+      const value = args[++index]?.trim();
+      if (!value) throw new Error("clean_selection_missing");
+      if (parsed.selectedTaskIds) throw new Error("clean_selection_duplicate_argument");
+      parsed.selectedTaskIds = value.split(",").map((taskId) => taskId.trim()).filter(Boolean);
+    } else if (argument === "--status" || argument === "--cancel") {
+      const action = argument === "--status" ? "status" : "cancel";
+      if (parsed[action]) throw new Error(`clean_${action}_duplicate`);
+      parsed[action] = true;
+      const possiblePlanId = args[index + 1]?.trim();
+      if (possiblePlanId && !possiblePlanId.startsWith("--")) {
+        index += 1;
+        if (parsed.planId && parsed.planId !== possiblePlanId) throw new Error("clean_plan_id_conflict");
+        parsed.planId = possiblePlanId;
+      }
+    } else if (argument === "--help" || argument === "-h") throw new Error("clean_help");
+    else throw new Error(`clean_argument_unknown:${argument}`);
+  }
+  const actions = Number(parsed.selectedTaskIds !== undefined) + Number(parsed.status) + Number(parsed.cancel);
+  if (actions > 1) throw new Error("clean_action_conflict");
+  if (actions > 0 && !parsed.planId) throw new Error("clean_plan_id_missing");
+  if (parsed.planId && actions === 0) throw new Error("clean_action_missing");
+  return parsed;
+}
+
+export function cleanSessionIdFromArgs(args: string[]): string | undefined {
+  const indexes = args.flatMap((argument, index) => argument === "--session" ? [index] : []);
+  if (indexes.length === 0) return undefined;
+  if (indexes.length > 1) throw new Error("clean_session_id_duplicate");
+  const sessionId = args[indexes[0]! + 1]?.trim();
+  if (!sessionId || sessionId.startsWith("--")) throw new Error("clean_session_id_missing");
+  return sessionId;
+}
+
+function validateSelection(plan: CleanPlanView, selectedTaskIds: string[]): string[] {
+  if (selectedTaskIds.length === 0) throw new Error("clean_selection_empty");
+  if (new Set(selectedTaskIds).size !== selectedTaskIds.length) throw new Error("clean_selection_duplicate_task");
+  const tasks = new Map(plan.tasks.map((task) => [task.taskId, task]));
+  for (const taskId of selectedTaskIds) {
+    const task = tasks.get(taskId);
+    if (!task) throw new Error(`clean_selection_unknown_task:${taskId}`);
+    if (!task.selectable) throw new Error(`clean_selection_task_protected:${taskId}`);
+  }
+  return selectedTaskIds;
+}
+
+async function approveSelection(
+  backend: CleanCommandBackend,
+  plan: CleanPlanView,
+  selectedTaskIds: string[],
+): Promise<string> {
+  const selected = validateSelection(plan, selectedTaskIds);
+  return renderCleanReceipt(await backend.approve(plan.planId, selected));
+}
+
+export async function handleCleanCommand(params: {
+  args: string[];
+  sessionId?: string;
+  backend: CleanCommandBackend;
+  interactive?: boolean;
+  prompt?: CleanTaskPrompt;
+}): Promise<{ text: string }> {
+  let parsed: ParsedCleanArgs;
+  try {
+    parsed = parseCleanArgs(params.args);
+  } catch (error) {
+    if (error instanceof Error && error.message === "clean_help") return { text: formatCleanUsage() };
+    throw error;
+  }
+
+  if (parsed.planId) {
+    if (parsed.status) {
+      const receipt = await params.backend.readReceipt(parsed.planId);
+      return { text: receipt ? renderCleanReceipt(receipt) : `Context clean receipt not found: ${parsed.planId}` };
+    }
+    if (parsed.cancel) return { text: renderCleanReceipt(await params.backend.cancel(parsed.planId)) };
+    const plan = await params.backend.readPlan(parsed.planId);
+    if (!plan) throw new Error(`clean_plan_missing:${parsed.planId}`);
+    return { text: await approveSelection(params.backend, plan, parsed.selectedTaskIds!) };
+  }
+
+  const sessionId = parsed.sessionId ?? params.sessionId?.trim();
+  if (!sessionId) throw new Error("clean_session_id_missing");
+  const plan = await params.backend.analyze(sessionId);
+  const rendered = renderCleanPlan(plan);
+  const interactive = params.interactive ?? Boolean(process.stdin.isTTY && process.stdout.isTTY);
+  if (!interactive) {
+    return {
+      text: `${rendered}\n\nAnalysis only (non-interactive). Apply with --plan ${plan.planId} --select <task-id[,task-id...]>`,
+    };
+  }
+  const selection = await (params.prompt ?? promptForCleanTasks)(plan);
+  if (selection === undefined) return { text: `${rendered}\n\nContext clean cancelled; no changes were applied.` };
+  if (selection.length === 0) return { text: `${rendered}\n\nNo tasks selected; no changes were applied.` };
+  return { text: `${rendered}\n\n${await approveSelection(params.backend, plan, selection)}` };
+}

--- a/components/products/cli/src/dispatch.ts
+++ b/components/products/cli/src/dispatch.ts
@@ -7,6 +7,12 @@ import type { CliHostPathOverrides } from "./context-store.js";
 import { CLI_HOSTS, parseCliHostId, resolveLatestCliReportHost, type CliHostId } from "./hosts/registry.js";
 import { createCliHostRuntime, registerBuiltInCliHostProducts } from "./hosts/factory.js";
 import { handleStandaloneVisualCommandWithSelection } from "./hosts/visual.js";
+import {
+  cleanSessionIdFromArgs,
+  formatCleanUsage,
+  handleCleanCommand,
+  resolveCleanCommandBackend,
+} from "./clean.js";
 import { formatCliUsage } from "./usage.js";
 
 registerBuiltInCliHostProducts();
@@ -181,6 +187,38 @@ export async function dispatchCli(argv: string[]): Promise<ProductCommandResult>
     sessionId: effectiveTarget.sessionId,
     pathOverrides: await resolvePathOverrides(effectiveTarget.host) ?? effectiveTarget.pathOverrides,
   });
+  if (commandArgs[0] === "clean") {
+    if (commandArgs.slice(1).some((argument) => argument === "--help" || argument === "-h")) {
+      return { text: formatCleanUsage() };
+    }
+    const requestedSessionId = cleanSessionIdFromArgs(commandArgs.slice(1)) ?? effectiveTarget.sessionId;
+    const resolvedSessionId = requestedSessionId
+      ? await runtime.resolveSessionId(requestedSessionId)
+      : await runtime.maybeResolveLatestSessionId();
+    const cleanPathOverrides = await resolvePathOverrides(effectiveTarget.host)
+      ?? effectiveTarget.pathOverrides;
+    const backend = await resolveCleanCommandBackend({
+      hostId: effectiveTarget.host,
+      sessionId: resolvedSessionId,
+      pathOverrides: cleanPathOverrides,
+    });
+    if (!backend) {
+      return {
+        text: `Context Cleaner is not registered for ${effectiveTarget.host} yet.`,
+      };
+    }
+    const result = await handleCleanCommand({
+      args: commandArgs.slice(1),
+      sessionId: resolvedSessionId,
+      backend,
+    });
+    await updateCliContextState({
+      host: effectiveTarget.host,
+      sessionId: resolvedSessionId,
+      pathOverrides: cleanPathOverrides,
+    });
+    return result;
+  }
   const result = await runtime.handleCommand({
     args: commandArgs.join(" "),
     sessionId: effectiveTarget.sessionId,

--- a/components/products/cli/src/hosts/claude-code.ts
+++ b/components/products/cli/src/hosts/claude-code.ts
@@ -31,6 +31,7 @@ import { resolveLatestClaudeCodeSessionId } from "../../../../adapters/claude-co
 import {
   readRecentClaudeCodeCacheAuditRecordsForSession,
 } from "../../../../adapters/claude-code/src/cache-audit.js";
+import { createClaudeCodeContextCleanerBridge } from "../../../../adapters/claude-code/src/context-cleaner/index.js";
 import {
   applyStandardRuntimeModeConfig,
   buildSessionReportResult,
@@ -40,6 +41,8 @@ import {
 } from "./shared.js";
 import { handleStandaloneVisualCommandWithSelection } from "./visual.js";
 import type { CliHostPathOverrides } from "../context-store.js";
+import type { CleanCommandBackend } from "../clean.js";
+import { createHostCleanCommandBackend } from "./cleaner.js";
 
 const CLAUDE_REDUCTION_PASS_NAMES = [
   "readStateCompaction",
@@ -63,6 +66,29 @@ function resolveClaudeCodePaths(pathOverrides?: CliHostPathOverrides): {
 
 async function loadConfig(pathOverrides?: CliHostPathOverrides): Promise<Record<string, unknown>> {
   return loadTokenPilotClaudeCodeConfig(resolveClaudeCodePaths(pathOverrides).tokenPilotConfigPath) as unknown as Record<string, unknown>;
+}
+
+export async function createClaudeCodeCleanCommandBackend(
+  pathOverrides?: CliHostPathOverrides,
+): Promise<CleanCommandBackend | undefined> {
+  const config = await loadTokenPilotClaudeCodeConfig(
+    resolveClaudeCodePaths(pathOverrides).tokenPilotConfigPath,
+  );
+  const stateDir = resolveClaudeCodeStateDir(config as unknown as Record<string, unknown>);
+  if (!stateDir) return undefined;
+  return createHostCleanCommandBackend({
+    stateDir,
+    recommendationEnabled: config.taskStateEstimator.enabled,
+    recommendationConfig: {
+      baseUrl: config.taskStateEstimator.baseUrl,
+      apiKey: config.taskStateEstimator.apiKey,
+      model: config.taskStateEstimator.model,
+      requestTimeoutMs: config.taskStateEstimator.requestTimeoutMs,
+    },
+    createBridge(controlPlane) {
+      return createClaudeCodeContextCleanerBridge({ stateDir, controlPlane });
+    },
+  });
 }
 
 async function writeConfig(nextConfig: Record<string, unknown>, pathOverrides?: CliHostPathOverrides): Promise<void> {

--- a/components/products/cli/src/hosts/cleaner.ts
+++ b/components/products/cli/src/hosts/cleaner.ts
@@ -1,0 +1,141 @@
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  analyzeContextCleanSession,
+  createApiContextCleanRecommendationProvider,
+  createContextCleanerControlPlane,
+  readContextCleanPlan,
+  type ContextCleanPlan,
+  type ContextCleanReceipt,
+  type ContextCleanerControlPlane,
+  type ContextCleanerHostBridge,
+} from "@lightrsi/cleaner";
+
+import type { CleanCommandBackend } from "../clean.js";
+import type { CleanPlanView, CleanReceiptView } from "../clean-renderer.js";
+
+type RecommendationConfig = Parameters<typeof createApiContextCleanRecommendationProvider>[0];
+
+function planView(plan: ContextCleanPlan): CleanPlanView {
+  return {
+    planId: plan.planId,
+    hostId: plan.hostId,
+    sessionId: plan.sessionId,
+    ...(plan.contextWindowTokens !== undefined
+      ? { contextWindowTokens: plan.contextWindowTokens }
+      : {}),
+    usedTokens: plan.usedTokens,
+    usedChars: plan.usedChars,
+    protectedTokens: plan.protectedTokens,
+    protectedChars: plan.protectedChars,
+    unassignedTokens: plan.unassignedTokens,
+    unassignedChars: plan.unassignedChars,
+    tokenCountMode: plan.tokenCountMode,
+    tasks: plan.tasks.map((task) => ({
+      taskId: task.taskId,
+      label: task.label,
+      description: task.description,
+      lifecycleState: task.lifecycleState,
+      tokenCount: task.tokenCount,
+      charCount: task.charCount,
+      tokenPercent: task.tokenPercent,
+      recommendation: task.recommendation,
+      reasonCodes: [...task.reasonCodes],
+      selectable: task.selectable,
+    })),
+  };
+}
+
+function receiptView(receipt: ContextCleanReceipt): CleanReceiptView {
+  return {
+    planId: receipt.planId,
+    status: receipt.status,
+    selectedTaskIds: [...receipt.selectedTaskIds],
+    estimatedSavedTokens: receipt.estimatedSavedTokens,
+    estimatedSavedChars: receipt.estimatedSavedChars,
+    ...(receipt.status === "applied"
+      ? {
+          appliedSavedTokens: receipt.appliedSavedTokens,
+          appliedSavedChars: receipt.appliedSavedChars,
+        }
+      : {}),
+    deferredTaskIds: [...receipt.deferredTaskIds],
+    reasons: [...receipt.reasons],
+  };
+}
+
+function storeFailure(operation: string, reasons: string[]): never {
+  throw new Error(`${operation}:${reasons.join(",") || "unknown"}`);
+}
+
+export function createHostCleanCommandBackend(params: {
+  stateDir: string;
+  createBridge(controlPlane: ContextCleanerControlPlane): ContextCleanerHostBridge;
+  recommendationEnabled?: boolean;
+  recommendationConfig: RecommendationConfig;
+  contextWindowTokens?: number;
+  now?: () => string;
+}): CleanCommandBackend {
+  const stateDir = params.stateDir.trim();
+  if (!stateDir) throw new Error("clean_host_state_dir_missing");
+  const controlPlane = createContextCleanerControlPlane({ stateDir, now: params.now });
+  const bridge = params.createBridge(controlPlane);
+  const provider = params.recommendationEnabled === false
+    ? undefined
+    : createApiContextCleanRecommendationProvider(params.recommendationConfig);
+
+  async function storedPlan(planId: string): Promise<ContextCleanPlan | undefined> {
+    const result = await readContextCleanPlan({ stateDir, planId });
+    if (result.bypassed) storeFailure("clean_cli_plan_unavailable", result.reasons);
+    return result.value?.plan;
+  }
+
+  return {
+    async analyze(sessionId) {
+      return planView((await analyzeContextCleanSession({
+        stateDir,
+        bridge,
+        sessionId,
+        provider,
+        contextWindowTokens: params.contextWindowTokens,
+      })).plan);
+    },
+    async readPlan(planId) {
+      const plan = await storedPlan(planId);
+      return plan ? planView(plan) : undefined;
+    },
+    async approve(planId, selectedTaskIds) {
+      const plan = await storedPlan(planId);
+      if (!plan) throw new Error(`clean_cli_plan_missing:${planId}`);
+      if (new Set(selectedTaskIds).size !== selectedTaskIds.length) {
+        throw new Error("clean_cli_selection_duplicate_task");
+      }
+      const tasksById = new Map(plan.tasks.map((task) => [task.taskId, task]));
+      const selectedTasks = selectedTaskIds.map((taskId) => {
+        const task = tasksById.get(taskId);
+        if (!task) throw new Error(`clean_cli_selection_unknown_task:${taskId}`);
+        if (!task.selectable) throw new Error(`clean_cli_selection_task_protected:${taskId}`);
+        return {
+          taskId,
+          itemIds: [...task.itemIds],
+          itemDigests: { ...task.itemDigests },
+        };
+      });
+      return receiptView(await bridge.executeApprovedClean({
+        schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+        cleanPlanId: plan.planId,
+        hostId: plan.hostId,
+        sessionId: plan.sessionId,
+        baseRevision: plan.baseRevision,
+        approvedAt: params.now?.() ?? new Date().toISOString(),
+        selectedTasks,
+      }));
+    },
+    async readReceipt(planId) {
+      const receipt = await bridge.readCleanReceipt(planId);
+      return receipt ? receiptView(receipt) : undefined;
+    },
+    async cancel(planId) {
+      return receiptView(await bridge.cancelCleanPlan(planId));
+    },
+  };
+}

--- a/components/products/cli/src/hosts/codex.ts
+++ b/components/products/cli/src/hosts/codex.ts
@@ -31,6 +31,7 @@ import {
 import {
   readRecentCodexCacheAuditRecordsForSession,
 } from "../../../../adapters/codex/src/cache-audit.js";
+import { createCodexContextCleanerBridge } from "../../../../adapters/codex/src/context-cleaner/index.js";
 import {
   applyStandardRuntimeModeConfig,
   buildSessionReportResult,
@@ -40,6 +41,8 @@ import {
 } from "./shared.js";
 import { handleStandaloneVisualCommandWithSelection } from "./visual.js";
 import type { CliHostPathOverrides } from "../context-store.js";
+import type { CleanCommandBackend } from "../clean.js";
+import { createHostCleanCommandBackend } from "./cleaner.js";
 
 const CODEX_REDUCTION_PASS_NAMES = [
   "readStateCompaction",
@@ -63,6 +66,27 @@ function resolveCodexPaths(pathOverrides?: CliHostPathOverrides): {
 
 async function loadConfig(pathOverrides?: CliHostPathOverrides): Promise<Record<string, unknown>> {
   return loadTokenPilotCodexConfig(resolveCodexPaths(pathOverrides).tokenPilotConfigPath) as unknown as Record<string, unknown>;
+}
+
+export async function createCodexCleanCommandBackend(
+  pathOverrides?: CliHostPathOverrides,
+): Promise<CleanCommandBackend | undefined> {
+  const config = await loadTokenPilotCodexConfig(resolveCodexPaths(pathOverrides).tokenPilotConfigPath);
+  const stateDir = resolveCodexStateDir(config as unknown as Record<string, unknown>);
+  if (!stateDir) return undefined;
+  return createHostCleanCommandBackend({
+    stateDir,
+    recommendationEnabled: config.taskStateEstimator.enabled,
+    recommendationConfig: {
+      baseUrl: config.taskStateEstimator.baseUrl,
+      apiKey: config.taskStateEstimator.apiKey,
+      model: config.taskStateEstimator.model,
+      requestTimeoutMs: config.taskStateEstimator.requestTimeoutMs,
+    },
+    createBridge(controlPlane) {
+      return createCodexContextCleanerBridge({ stateDir, controlPlane });
+    },
+  });
 }
 
 async function writeConfig(nextConfig: Record<string, unknown>, pathOverrides?: CliHostPathOverrides): Promise<void> {

--- a/components/products/cli/src/hosts/factory.ts
+++ b/components/products/cli/src/hosts/factory.ts
@@ -1,8 +1,9 @@
 import { createProductSurfaceCommandHandler } from "@lightrsi/product-surface";
 import { TOKENPILOT_PRODUCT_SURFACE_IDENTITY } from "@lightrsi/tokenpilot";
 import type { CliHostPathOverrides } from "../context-store.js";
-import { createClaudeCodeCliBridge } from "./claude-code.js";
-import { createCodexCliBridge } from "./codex.js";
+import { registerCleanCommandBackendResolver } from "../clean.js";
+import { createClaudeCodeCleanCommandBackend, createClaudeCodeCliBridge } from "./claude-code.js";
+import { createCodexCleanCommandBackend, createCodexCliBridge } from "./codex.js";
 import { createOpenClawCliBridge } from "./openclaw.js";
 import {
   CLI_HOSTS,
@@ -53,6 +54,11 @@ const CLI_HOST_REGISTRATIONS: CliHostRegistration[] = CLI_HOSTS.map((host) => ({
 
 export function registerBuiltInCliHostProducts(): void {
   registerCliHostProducts(CLI_HOST_REGISTRATIONS);
+  registerCleanCommandBackendResolver(({ hostId, pathOverrides }) => {
+    if (hostId === "codex") return createCodexCleanCommandBackend(pathOverrides);
+    if (hostId === "claude-code") return createClaudeCodeCleanCommandBackend(pathOverrides);
+    return undefined;
+  });
 }
 
 export function createCliHostRuntime(target: {

--- a/components/products/cli/src/usage.ts
+++ b/components/products/cli/src/usage.ts
@@ -15,6 +15,10 @@ export function formatCliUsage(): string {
     "  report",
     "  doctor",
     "  visual",
+    "  clean [--session <session-id>]",
+    "  clean --plan <plan-id> --select <task-ids>",
+    "  clean --status <plan-id>",
+    "  clean --cancel <plan-id>",
     "  mode <conservative|normal|aggressive>",
     "  settings details <on|off>",
     "  stabilizer ...",
@@ -28,6 +32,7 @@ export function formatCliUsage(): string {
     "  lightrsi report",
     "  lightrsi openclaw doctor",
     "  lightrsi claude-code doctor",
+    "  lightrsi codex session <session-id> clean",
     "  lightrsi openclaw session 123e4567-e89b-12d3-a456-426614174000 report",
     "  lightrsi use openclaw",
   ].join("\n");

--- a/components/products/cli/tests/clean-host-registration.test.ts
+++ b/components/products/cli/tests/clean-host-registration.test.ts
@@ -1,0 +1,139 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  saveContextCleanPlan,
+  type ContextCleanPlan,
+} from "@lightrsi/cleaner";
+
+import { resolveCleanCommandBackend } from "../src/clean.js";
+import { dispatchCli } from "../src/dispatch.js";
+import { createHostCleanCommandBackend } from "../src/hosts/cleaner.js";
+import { registerBuiltInCliHostProducts } from "../src/hosts/factory.js";
+
+function plan(): ContextCleanPlan {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: "plan-host-registration",
+    hostId: "codex",
+    sessionId: "session-1",
+    baseRevision: "revision-1",
+    usedTokens: 50,
+    usedChars: 200,
+    protectedTokens: 0,
+    protectedChars: 0,
+    unassignedTokens: 0,
+    unassignedChars: 0,
+    tokenCountMode: "estimated",
+    tokenCountMethod: "fixture",
+    tasks: [{
+      taskId: "task-a",
+      label: "Finished task",
+      description: "Finished task description",
+      summary: "Finished task summary",
+      lifecycleState: "completed",
+      itemIds: ["item-a"],
+      itemDigests: { "item-a": "digest-a" },
+      tokenCount: 50,
+      charCount: 200,
+      tokenPercent: 100,
+      recommendation: "clean",
+      reasonCodes: ["completed_and_cold"],
+      selectable: true,
+    }],
+    createdAt: "2026-08-30T00:00:00.000Z",
+  };
+}
+
+test("Host backend recovers frozen item targets from the stored plan", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-cli-clean-host-"));
+  try {
+    await saveContextCleanPlan({ stateDir, plan: plan() });
+    const backend = createHostCleanCommandBackend({
+      stateDir,
+      recommendationEnabled: false,
+      recommendationConfig: {},
+      now: () => "2026-08-30T00:01:00.000Z",
+      createBridge(controlPlane) {
+        return {
+          hostId: "codex",
+          rewriteMode: "response_chain_rebase",
+          async listSessions() { return []; },
+          async readCleanSnapshot() { throw new Error("unused"); },
+          executeApprovedClean(request) { return controlPlane.executeApprovedClean(request); },
+          readCleanReceipt(planId) { return controlPlane.readCleanReceipt(planId); },
+          cancelCleanPlan(planId) { return controlPlane.cancelCleanPlan(planId); },
+        };
+      },
+    });
+    const stored = await backend.readPlan(plan().planId);
+    assert.deepEqual(stored?.tasks.map((task) => task.taskId), ["task-a"]);
+    const receipt = await backend.approve(plan().planId, ["task-a"]);
+    assert.equal(receipt.status, "scheduled");
+    assert.deepEqual(receipt.selectedTaskIds, ["task-a"]);
+    assert.equal(receipt.estimatedSavedTokens, 50);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("built-in lookup creates Codex and Claude backends but leaves OpenClaw for its PR", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-cli-clean-lookup-"));
+  try {
+    const codexConfigPath = join(root, "codex-tokenpilot.json");
+    const claudeConfigPath = join(root, "claude-tokenpilot.json");
+    await writeFile(codexConfigPath, JSON.stringify({
+      stateDir: join(root, "codex-state"),
+      taskStateEstimator: { enabled: false },
+    }), "utf8");
+    await writeFile(claudeConfigPath, JSON.stringify({
+      stateDir: join(root, "claude-state"),
+      upstreamBaseUrl: "https://api.anthropic.com/v1/messages",
+      taskStateEstimator: { enabled: false },
+    }), "utf8");
+
+    registerBuiltInCliHostProducts();
+    assert.ok(await resolveCleanCommandBackend({
+      hostId: "codex",
+      pathOverrides: { tokenPilotConfigPath: codexConfigPath },
+    }));
+    assert.ok(await resolveCleanCommandBackend({
+      hostId: "claude-code",
+      pathOverrides: { tokenPilotConfigPath: claudeConfigPath },
+    }));
+    assert.equal(await resolveCleanCommandBackend({ hostId: "openclaw" }), undefined);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("real Codex clean dispatch reaches the registered backend", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-cli-clean-real-dispatch-"));
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const originalConfigPath = process.env.TOKENPILOT_CODEX_CONFIG;
+  try {
+    const configPath = join(root, "codex-tokenpilot.json");
+    process.env.HOME = root;
+    process.env.USERPROFILE = root;
+    process.env.TOKENPILOT_CODEX_CONFIG = configPath;
+    await writeFile(configPath, JSON.stringify({
+      stateDir: join(root, "codex-state"),
+      taskStateEstimator: { enabled: false },
+    }), "utf8");
+    const result = await dispatchCli(["codex", "clean", "--status", "missing-plan"]);
+    assert.equal(result.text, "Context clean receipt not found: missing-plan");
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalConfigPath === undefined) delete process.env.TOKENPILOT_CODEX_CONFIG;
+    else process.env.TOKENPILOT_CODEX_CONFIG = originalConfigPath;
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/components/products/cli/tests/clean-non-tty.test.ts
+++ b/components/products/cli/tests/clean-non-tty.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { handleCleanCommand, type CleanCommandBackend } from "../src/clean.js";
+
+test("non-interactive clean is analysis-only and never calls approve", async () => {
+  let approved = false;
+  const backend: CleanCommandBackend = {
+    async analyze() {
+      return {
+        planId: "plan-non-tty", hostId: "claude-code", sessionId: "session-1",
+        usedTokens: null, usedChars: 400, protectedTokens: null, protectedChars: 100,
+        unassignedTokens: null, unassignedChars: 0, tokenCountMode: "chars",
+        tasks: [{ taskId: "task-a", label: "Finished", description: "Finished task", lifecycleState: "completed", tokenCount: null,
+          charCount: 300, tokenPercent: null, recommendation: "clean", reasonCodes: [], selectable: true }],
+      };
+    },
+    async readPlan() { return undefined; },
+    async approve() { approved = true; throw new Error("must not approve"); },
+    async readReceipt() { return undefined; },
+    async cancel() { throw new Error("unused"); },
+  };
+  const result = await handleCleanCommand({ args: [], sessionId: "session-1", backend, interactive: false });
+  assert.equal(approved, false);
+  assert.match(result.text, /Analysis only \(non-interactive\)/);
+  assert.match(result.text, /--plan plan-non-tty --select/);
+  assert.match(result.text, /Recommended selection estimate: 300 chars/);
+});

--- a/components/products/cli/tests/clean-renderer.test.ts
+++ b/components/products/cli/tests/clean-renderer.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderCleanPlan, renderCleanReceipt } from "../src/clean-renderer.js";
+
+test("clean renderer shows task-level accounting without item ids", () => {
+  const text = renderCleanPlan({
+    planId: "plan-1",
+    hostId: "codex",
+    sessionId: "session-1",
+    contextWindowTokens: 100,
+    usedTokens: 80,
+    usedChars: 320,
+    protectedTokens: 10,
+    protectedChars: 40,
+    unassignedTokens: 0,
+    unassignedChars: 0,
+    tokenCountMode: "estimated",
+    tasks: [
+      { taskId: "task-a", label: "Finished work", description: "Finished the requested work",
+        lifecycleState: "completed", tokenCount: 60, charCount: 240, tokenPercent: 75,
+        recommendation: "clean", reasonCodes: ["completed_and_cold"], selectable: true },
+      { taskId: "task-current", label: "Current work", description: "Work in progress",
+        lifecycleState: "active", tokenCount: 20, charCount: 80, tokenPercent: 25,
+        recommendation: "protected", reasonCodes: ["deterministic_protection"], selectable: false },
+    ],
+  });
+  assert.match(text, /Context clean plan plan-1/);
+  assert.match(text, /Context usage: 80 \/ 100 tok \(80\.0%\)/);
+  assert.match(text, /Protected context: 10 tok/);
+  assert.match(text, /Unassigned context: 0 tok/);
+  assert.match(text, /\[ \].*task-a.*Finished the requested work.*60 tok.*75\.0%.*clean/);
+  assert.match(text, /\[-\].*task-current.*Work in progress.*20 tok.*25\.0%.*protected/);
+  assert.match(text, /completed_and_cold/);
+  assert.match(text, /Reasons task-a: completed_and_cold/);
+  assert.doesNotMatch(text, /item-/);
+});
+
+test("receipt renderer distinguishes estimates from applied savings", () => {
+  const text = renderCleanReceipt({
+    planId: "plan-1",
+    status: "applied",
+    selectedTaskIds: ["task-a"],
+    estimatedSavedTokens: 60,
+    estimatedSavedChars: 240,
+    appliedSavedTokens: 55,
+    appliedSavedChars: 220,
+    deferredTaskIds: [],
+    reasons: [],
+  });
+  assert.match(text, /Estimated savings: 60 tok/);
+  assert.match(text, /Released: 55 tok/);
+});

--- a/components/products/cli/tests/clean.test.ts
+++ b/components/products/cli/tests/clean.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  handleCleanCommand,
+  registerCleanCommandBackendResolver,
+  type CleanCommandBackend,
+} from "../src/clean.js";
+import type { CleanPlanView, CleanReceiptView } from "../src/clean-renderer.js";
+import { dispatchCli } from "../src/dispatch.js";
+
+function plan(): CleanPlanView {
+  return {
+    planId: "plan-1", hostId: "codex", sessionId: "session-1", usedTokens: 80,
+    usedChars: 320, protectedTokens: 10, protectedChars: 40, unassignedTokens: 0,
+    unassignedChars: 0, tokenCountMode: "estimated",
+    tasks: [
+      { taskId: "task-a", label: "Finished work", description: "Finished the work", lifecycleState: "completed", tokenCount: 60,
+        charCount: 240, tokenPercent: 75, recommendation: "clean", reasonCodes: [], selectable: true },
+      { taskId: "task-current", label: "Current work", description: "Current work", lifecycleState: "active", tokenCount: 20,
+        charCount: 80, tokenPercent: 25, recommendation: "protected", reasonCodes: [], selectable: false },
+    ],
+  };
+}
+
+function receipt(status = "scheduled", selectedTaskIds = ["task-a"]): CleanReceiptView {
+  return { planId: "plan-1", status, selectedTaskIds, estimatedSavedTokens: 60,
+    estimatedSavedChars: 240, deferredTaskIds: [], reasons: [] };
+}
+
+function backend(calls: string[]): CleanCommandBackend {
+  return {
+    async analyze(sessionId) { calls.push(`analyze:${sessionId}`); return plan(); },
+    async readPlan(planId) { calls.push(`plan:${planId}`); return planId === "plan-1" ? plan() : undefined; },
+    async approve(planId, taskIds) { calls.push(`approve:${planId}:${taskIds.join(",")}`); return receipt(); },
+    async readReceipt(planId) { calls.push(`receipt:${planId}`); return receipt(); },
+    async cancel(planId) { calls.push(`cancel:${planId}`); return receipt("cancelled"); },
+  };
+}
+
+test("interactive clean analyzes, prompts by task id, and approves selection", async () => {
+  const calls: string[] = [];
+  const result = await handleCleanCommand({
+    args: [], sessionId: "session-1", backend: backend(calls), interactive: true,
+    async prompt() { return ["task-a"]; },
+  });
+  assert.deepEqual(calls, ["analyze:session-1", "approve:plan-1:task-a"]);
+  assert.match(result.text, /Context clean scheduled/);
+  assert.match(result.text, /next Host request/);
+});
+
+test("explicit plan selection supports scripts and rejects protected tasks", async () => {
+  const calls: string[] = [];
+  const accepted = await handleCleanCommand({
+    args: ["--plan", "plan-1", "--select", "task-a"], backend: backend(calls), interactive: false,
+  });
+  assert.match(accepted.text, /Context clean scheduled/);
+  await assert.rejects(
+    handleCleanCommand({
+      args: ["--plan", "plan-1", "--select", "task-current"], backend: backend([]), interactive: false,
+    }),
+    /clean_selection_task_protected:task-current/,
+  );
+});
+
+test("status and cancel do not re-run analysis", async () => {
+  const calls: string[] = [];
+  await handleCleanCommand({ args: ["--status", "plan-1"], backend: backend(calls) });
+  await handleCleanCommand({ args: ["--cancel", "plan-1"], backend: backend(calls) });
+  assert.deepEqual(calls, ["receipt:plan-1", "cancel:plan-1"]);
+});
+
+test("dispatch registers clean without coupling the controller to a Host adapter", async () => {
+  const home = await mkdtemp(join(tmpdir(), "lightrsi-cli-clean-dispatch-"));
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  const calls: string[] = [];
+  registerCleanCommandBackendResolver(() => backend(calls));
+  try {
+    const result = await dispatchCli(["codex", "clean", "--session", "session-1"]);
+    assert.deepEqual(calls, ["analyze:session-1"]);
+    assert.match(result.text, /Context clean plan plan-1/);
+  } finally {
+    registerCleanCommandBackendResolver(undefined);
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("clean help is available before a Host backend is registered", async () => {
+  registerCleanCommandBackendResolver(undefined);
+  const result = await dispatchCli(["codex", "clean", "--help"]);
+  assert.match(result.text, /clean --status <plan-id>/);
+  assert.match(result.text, /clean \[--session <session-id>\]/);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
 
   components/products/cli:
     dependencies:
+      '@lightrsi/cleaner':
+        specifier: workspace:*
+        version: link:../../packages/features/cleaner
       '@lightrsi/host-adapter':
         specifier: workspace:*
         version: link:../../packages/foundation/host-adapter


### PR DESCRIPTION
## Summary

Add the canonical Context Cleaner CLI/TUI flow and connect it to the existing Codex and Claude Code Cleaner Host bridges.

This PR implements shared clean orchestration, interactive and non-interactive task selection, plan status and cancellation, and production CLI backend registration for Codex and Claude Code.

## What changed

### Shared Cleaner orchestration

- Add `analyzeContextCleanSession`:
  - read the canonical Host snapshot
  - load the session task registry
  - calculate task-level token/character usage
  - run the recommendation provider with safe fallback
  - persist the immutable clean plan and analyzed receipt
- Add the shared Cleaner control plane:
  - validate approved task selections
  - recover exact item IDs and digests from the stored plan
  - transition `analyzed -> approved -> scheduled`
  - support receipt reads and idempotent cancellation
- Preserve `null` token accounting for chars-only plans.

### CLI/TUI flow

Add the canonical commands:

```bash
lightrsi <host> clean --session <session-id>
lightrsi <host> clean --plan <plan-id> --select <task-id,...>
lightrsi <host> clean --status <plan-id>
lightrsi <host> clean --cancel <plan-id>
```

Interactive behavior:

- Only tasks with `selectable=true` can be selected.
- Protected tasks cannot be selected.
- Arrow keys move the cursor.
- Space toggles a task.
- Final confirmation uses `Confirm clean? [y/N]`.
- Pressing Enter without `y` cancels without scheduling a plan.

Non-interactive behavior:

- `clean --session` is analysis-only when stdin/stdout are not TTYs.
- Applying a selection requires a server-generated plan ID and task IDs.
- The CLI never accepts arbitrary item IDs or item digests.

### Rendering and receipts

The CLI displays:

- Host and session
- context usage
- protected and unassigned context
- complete task IDs
- task descriptions
- token/character usage and percentage
- recommendation, risk, and reason codes
- estimated selected savings

Receipt behavior:

- `scheduled` is displayed as applying on the next Host request.
- Actual `Released` savings are displayed only for an `applied` receipt.
- Chars-only accounting is preserved through scheduling and cancellation.

### Host registration

- Register the existing Codex Cleaner bridge.
- Register the existing Claude Code Cleaner bridge.
- Reuse each Host's existing:
  - TokenPilot `stateDir`
  - task-state estimator provider configuration
  - snapshot/session implementation
  - scheduled Host execution path
- Add `@lightrsi/cleaner` as a CLI dependency.

## Safety properties

- CLI approval accepts task IDs only.
- Item IDs and fingerprints are recovered from the immutable stored plan.
- Duplicate, unknown, protected, or mismatched selections are rejected.
- Provider failure or malformed output safely falls back to `keep/protected`.
- Non-TTY analysis never applies a plan automatically.
- Estimated savings are never reported as actual released savings.
- Chars-only plans preserve `estimatedSavedTokens: null`.

## Scope and ownership

The Cleaner orchestrator and `clean*` CLI files are part of the CLI/TUI task ownership.

The following files are shared registration areas and should receive Host-owner review:

- `components/products/cli/src/hosts/cleaner.ts`
- `components/products/cli/src/hosts/codex.ts`
- `components/products/cli/src/hosts/claude-code.ts`
- `components/products/cli/src/hosts/factory.ts`
- `components/products/cli/package.json`
- `pnpm-lock.yaml`

This PR does not modify Codex or Claude Code adapter runtime internals.

## Non-goals

- OpenClaw canonical Cleaner apply is intentionally deferred to the next PR:
  `feat(openclaw): apply approved clean plans`
- This PR does not change Codex response-chain rebase behavior.
- This PR does not change Claude Code request-overlay behavior.
- This PR does not report scheduled plans as already applied.

## Validation

Automated validation:

- `@lightrsi/cleaner`: 79/79 tests passed
- `@lightrsi/cli`: 36/36 tests passed
- Codex/Claude Cleaner bridge tests: 23/23 passed
- Cleaner typecheck passed
- CLI typecheck passed
- Codex adapter typecheck passed
- Claude Code adapter typecheck passed
- CLI bundle build passed
- Package boundary check passed
- `git diff --check` passed

Production-bundle smoke validation:

- Ran the built `dist/cli.js`, not a fake CLI backend.
- Used real Codex and Claude Code adapter persistence formats in isolated temporary state directories.
- Verified for both Hosts:
  - analysis
  - explicit task selection
  - scheduled receipt
  - status query
  - cancellation
  - terminal status query
- Verified real TTY behavior:
  - Space toggles selection
  - default Enter at `[y/N]` preserves the analyzed state
  - explicit `y` advances the plan to scheduled
- Temporary smoke state was removed after validation.

The local TokenPilot state directories did not contain captured live sessions, so smoke validation used isolated canonical Host state instead of modifying live user sessions.

## Commits

- `b516bd1 feat(cleaner): add context clean orchestration`
- `311ca30 feat(cli): add interactive context clean flow`
- `d6caa88 feat(cli): register codex and claude cleaner backends`

## Review request

Please review the shared CLI Host registration in `components/products/cli/src/hosts/**` and confirm that Codex and Claude Code bridge construction remains aligned with the existing Host ownership boundary.