### PR TITLE
fix(codex): disable fragile Stop hook path

### DIFF
--- a/components/adapters/codex/README.md
+++ b/components/adapters/codex/README.md
@@ -78,10 +78,11 @@ The installer will:
 - repoint that active provider's `base_url` to the local TokenPilot proxy
 - persist the original upstream provider config into `~/.codex/tokenpilot.json`
 - register a `tokenpilot_memory_fault_recover` MCP server in Codex config
-- write a conservative `startup_timeout_sec` for the recovery MCP server
-- write TokenPilot runtime config
-- register TokenPilot hooks for `SessionStart`, `PreToolUse`, `PostToolUse`, and `Stop`
-- install read-only Codex skill bridge entries under the local Codex skills directory
+ - write a conservative `startup_timeout_sec` for the recovery MCP server
+ - write TokenPilot runtime config
+ - start the local TokenPilot proxy immediately
+ - register TokenPilot hooks for `SessionStart`, `PreToolUse`, and `PostToolUse`
+ - install read-only Codex skill bridge entries under the local Codex skills directory
 - run a post-install MCP startup probe and report degraded mode if recovery MCP is still unavailable
 
 The installed Codex skill bridge currently creates these explicit skills:
@@ -305,7 +306,7 @@ Expected install shape:
 
 If Codex reports that hooks need review, trust the TokenPilot hooks in Codex, open a new session, and rerun the doctor.
 
-If Codex displays `Stop hook (failed)` or `PostToolUse hook (failed)` after a repository reorganization, rebuild and reinstall the adapter so `~/.codex/hooks.json` points at the current handler:
+If Codex displays `PostToolUse hook (failed)` after a repository reorganization, rebuild and reinstall the adapter so `~/.codex/hooks.json` points at the current handler. Reinstall also removes legacy TokenPilot `Stop` hooks:
 
 ```bash
 npm --prefix components/adapters/codex run build

--- a/components/adapters/codex/src/doctor.ts
+++ b/components/adapters/codex/src/doctor.ts
@@ -90,7 +90,6 @@ const HOOK_EVENT_NAMES = [
   "SessionStart",
   "PreToolUse",
   "PostToolUse",
-  "Stop",
 ] as const;
 
 function normalizeLocalProxyBaseUrl(value: string | undefined): string | undefined {

--- a/components/adapters/codex/src/hooks-handler.ts
+++ b/components/adapters/codex/src/hooks-handler.ts
@@ -111,8 +111,7 @@ function workspaceHintFromEvent(input: Record<string, unknown>): string | undefi
 
 function successOutputForHook(hookEventName: string): string | undefined {
   if (hookEventName === "Stop") {
-    // Stop hooks require JSON on stdout for successful exit-0 completion.
-    return "{}\n";
+    return "{\"continue\":true}\n";
   }
   return undefined;
 }
@@ -229,7 +228,14 @@ export async function processCodexHookEvent(event: Record<string, unknown>): Pro
 }
 
 async function main() {
-  const event = await readStdinJson();
+  let event: Record<string, unknown>;
+  try {
+    event = await readStdinJson();
+  } catch (err) {
+    console.error(`hook input parse failed; continuing without hook action: ${hookErrorMessage(err)}`);
+    writeSuccessOutput("Stop");
+    return;
+  }
   const output = await processCodexHookEvent(event);
   if (typeof output === "string" && output.length > 0) {
     process.stdout.write(output);

--- a/components/adapters/codex/src/install.ts
+++ b/components/adapters/codex/src/install.ts
@@ -301,19 +301,25 @@ function asHookConfig(value: unknown): Record<string, unknown> {
     : {};
 }
 
+function isTokenPilotHookGroup(item: Record<string, unknown>): boolean {
+  const hooks = Array.isArray(item.hooks) ? item.hooks : [];
+  return hooks.some((hook) => {
+    if (!hook || typeof hook !== "object") return false;
+    const command = (hook as Record<string, unknown>).command;
+    return typeof command === "string"
+      && (command.includes("hooks-handler.js") || command.includes("tokenpilot-codex-hook.cmd"));
+  });
+}
+
 function upsertTokenPilotHookGroup(groups: unknown, group: Record<string, unknown>): Record<string, unknown>[] {
   const list = Array.isArray(groups) ? groups.filter((item) => item && typeof item === "object") as Record<string, unknown>[] : [];
-  const isTokenPilotGroup = (item: Record<string, unknown>): boolean => {
-    const hooks = Array.isArray(item.hooks) ? item.hooks : [];
-    return hooks.some((hook) => {
-      if (!hook || typeof hook !== "object") return false;
-      const command = (hook as Record<string, unknown>).command;
-      return typeof command === "string"
-        && (command.includes("hooks-handler.js") || command.includes("tokenpilot-codex-hook.cmd"));
-    });
-  };
-  const filtered = list.filter((item) => !isTokenPilotGroup(item));
+  const filtered = list.filter((item) => !isTokenPilotHookGroup(item));
   return [...filtered, group];
+}
+
+function removeTokenPilotHookGroups(groups: unknown): Record<string, unknown>[] {
+  const list = Array.isArray(groups) ? groups.filter((item) => item && typeof item === "object") as Record<string, unknown>[] : [];
+  return list.filter((item) => !isTokenPilotHookGroup(item));
 }
 
 async function installHooksJson(params: {
@@ -346,9 +352,9 @@ async function installHooksJson(params: {
     matcher: ".*",
     hooks: [handler("Recording TokenPilot tool output", 10)],
   });
-  hooks.Stop = upsertTokenPilotHookGroup(hooks.Stop, {
-    hooks: [handler("Recording TokenPilot session stop", 10)],
-  });
+  const stopGroups = removeTokenPilotHookGroups(hooks.Stop);
+  if (stopGroups.length === 0) delete hooks.Stop;
+  else hooks.Stop = stopGroups;
 
   await mkdir(dirname(params.hooksConfigPath), { recursive: true });
   if (existsSync(params.hooksConfigPath)) {

--- a/components/adapters/codex/tests/doctor.test.ts
+++ b/components/adapters/codex/tests/doctor.test.ts
@@ -73,7 +73,7 @@ test("inspectCodexDoctor reports missing provider and hooks honestly", async () 
     assert.equal(report.hooksComplete, false);
     assert.equal(report.hooksMatchExpectedCommand, false);
     assert.deepEqual(report.installedHookEvents, []);
-    assert.deepEqual(report.missingHookEvents, ["SessionStart", "PreToolUse", "PostToolUse", "Stop"]);
+    assert.deepEqual(report.missingHookEvents, ["SessionStart", "PreToolUse", "PostToolUse"]);
     assert.equal(report.daemonRunning, false);
     assert.equal(report.mcpInstalled, false);
     assert.equal(report.mcpStateDirMatches, false);
@@ -184,7 +184,7 @@ test("formatCodexDoctorReport redacts credentials embedded in diagnostic URLs", 
     hooksInstalled: true,
     hooksComplete: true,
     hooksMatchExpectedCommand: true,
-    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse", "Stop"],
+    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse"],
     missingHookEvents: [],
     daemonRunning: false,
     proxyHealthy: false,
@@ -464,7 +464,7 @@ test("inspectCodexDoctor reports partial hook installs explicitly", async () => 
     assert.equal(report.hooksComplete, false);
     assert.equal(report.hooksMatchExpectedCommand, false);
     assert.deepEqual(report.installedHookEvents, ["SessionStart", "PostToolUse"]);
-    assert.deepEqual(report.missingHookEvents, ["PreToolUse", "Stop"]);
+    assert.deepEqual(report.missingHookEvents, ["PreToolUse"]);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -715,7 +715,7 @@ test("formatCodexDoctorReport shows degraded mode when core runtime is healthy b
     hooksInstalled: true,
     hooksComplete: true,
     hooksMatchExpectedCommand: true,
-    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse", "Stop"],
+    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse"],
     missingHookEvents: [],
     daemonRunning: true,
     proxyHealthy: true,
@@ -757,7 +757,7 @@ test("formatCodexDoctorReport explains first-run SessionStart remediation when t
     hooksInstalled: true,
     hooksComplete: true,
     hooksMatchExpectedCommand: true,
-    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse", "Stop"],
+    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse"],
     missingHookEvents: [],
     mcpInstalled: true,
     mcpStateDirMatches: true,
@@ -795,7 +795,7 @@ test("formatCodexDoctorReport explains disabled adapter without suggesting daemo
     hooksInstalled: true,
     hooksComplete: true,
     hooksMatchExpectedCommand: true,
-    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse", "Stop"],
+    installedHookEvents: ["SessionStart", "PreToolUse", "PostToolUse"],
     missingHookEvents: [],
     mcpInstalled: true,
     mcpStateDirMatches: true,

--- a/components/adapters/codex/tests/hooks-handler.test.ts
+++ b/components/adapters/codex/tests/hooks-handler.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -7,6 +8,30 @@ import test from "node:test";
 import { writeTokenPilotCodexConfig, normalizeTokenPilotCodexConfig } from "../src/config.js";
 import { processCodexHookEvent } from "../src/hooks-handler.js";
 import { indexCodexHostSessionAlias, upsertCodexSessionSnapshot } from "../src/session-state.js";
+
+function runHookHandler(input: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [join(__dirname, "..", "dist", "hooks-handler.js")]);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+    child.on("error", reject);
+    child.on("close", (code) => resolve({
+      code,
+      stdout: Buffer.concat(stdout).toString("utf8"),
+      stderr: Buffer.concat(stderr).toString("utf8"),
+    }));
+    child.stdin.end(input);
+  });
+}
+
+test("hook handler fails open on malformed stdin JSON", async () => {
+  const result = await runHookHandler('{"hook_event_name":"Stop","last_assistant_message":"é');
+  assert.equal(result.code, 0);
+  assert.equal(result.stdout, "{\"continue\":true}\n");
+  assert.match(result.stderr, /Unexpected end|Unterminated string|JSON/);
+});
 
 test("processCodexHookEvent records hook snapshot metadata without overriding the latest synthesized session", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-codex-hooks-handler-"));
@@ -122,7 +147,7 @@ test("processCodexHookEvent writes directly into the synthesized session after a
   }
 });
 
-test("processCodexHookEvent returns minimal JSON output for Stop hooks", async () => {
+test("processCodexHookEvent returns an allow payload for Stop hooks", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-codex-hooks-handler-stop-"));
   const originalCodexConfig = process.env.TOKENPILOT_CODEX_CONFIG;
   try {
@@ -144,7 +169,7 @@ test("processCodexHookEvent returns minimal JSON output for Stop hooks", async (
       cwd: "/repo/from-hook",
     });
 
-    assert.equal(output, "{}\n");
+    assert.equal(output, "{\"continue\":true}\n");
   } finally {
     if (originalCodexConfig === undefined) {
       delete process.env.TOKENPILOT_CODEX_CONFIG;

--- a/components/adapters/codex/tests/install.test.ts
+++ b/components/adapters/codex/tests/install.test.ts
@@ -179,11 +179,12 @@ test("installCodexTokenPilot writes provider, MCP, and hooks with expected comma
     const hooks = JSON.parse(await readFile(hooksConfigPath, "utf8")) as {
       hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
     };
-    for (const eventName of ["SessionStart", "PreToolUse", "PostToolUse", "Stop"]) {
+    for (const eventName of ["SessionStart", "PreToolUse", "PostToolUse"]) {
       const entries = hooks.hooks?.[eventName]?.[0]?.hooks;
       assert.ok(Array.isArray(entries), `${eventName} hook group missing`);
       assert.equal(String(entries[0]?.command ?? ""), result.expectedHookCommand);
     }
+    assert.equal(hooks.hooks?.Stop, undefined);
 
     const skillRaw = await readFile(join(result.commandSkillsDir, "lightrsi-report", "SKILL.md"), "utf8");
     assert.match(skillRaw, /lightrsi codex report/);
@@ -194,6 +195,49 @@ test("installCodexTokenPilot writes provider, MCP, and hooks with expected comma
   } finally {
     if (originalHome === undefined) delete process.env.HOME;
     else process.env.HOME = originalHome;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("installCodexTokenPilot removes legacy TokenPilot Stop hooks but preserves user hooks", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "lightmem2-codex-install-remove-stop-"));
+  try {
+    const codexConfigPath = join(dir, "config.toml");
+    const hooksConfigPath = join(dir, "hooks.json");
+    const tokenPilotConfigPath = join(dir, "tokenpilot.json");
+    await writeFile(codexConfigPath, [
+      "model_provider = \"OPENAI\"",
+      "",
+      "[model_providers.OPENAI]",
+      "name = \"OpenAI\"",
+      "base_url = \"https://api.openai.com/v1\"",
+      "wire_api = \"responses\"",
+      "requires_openai_auth = true",
+      "",
+    ].join("\n"), "utf8");
+    await writeFile(hooksConfigPath, JSON.stringify({
+      hooks: {
+        Stop: [
+          { matcher: ".*", hooks: [{ type: "command", command: "user-stop-hook" }] },
+          { hooks: [{ type: "command", command: "tokenpilot-codex-hook.cmd" }] },
+        ],
+      },
+    }, null, 2), "utf8");
+
+    await installCodexTokenPilot({
+      codexConfigPath,
+      hooksConfigPath,
+      tokenPilotConfigPath,
+      probeMcp: false,
+    });
+
+    const hooks = JSON.parse(await readFile(hooksConfigPath, "utf8")) as {
+      hooks?: { Stop?: Array<{ hooks?: Array<{ command?: string }> }> };
+    };
+    assert.deepEqual(hooks.hooks?.Stop, [
+      { matcher: ".*", hooks: [{ type: "command", command: "user-stop-hook" }] },
+    ]);
+  } finally {
     await rm(dir, { recursive: true, force: true });
   }
 });
@@ -393,11 +437,12 @@ test("installCodexTokenPilot writes Windows hook wrappers into hooks.json", asyn
     const hooks = JSON.parse(await readFile(hooksConfigPath, "utf8")) as {
       hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>;
     };
-    for (const eventName of ["SessionStart", "PreToolUse", "PostToolUse", "Stop"]) {
+    for (const eventName of ["SessionStart", "PreToolUse", "PostToolUse"]) {
       const entries = hooks.hooks?.[eventName]?.[0]?.hooks;
       assert.ok(Array.isArray(entries), `${eventName} hook group missing`);
       assert.match(String(entries[0]?.command ?? ""), /tokenpilot-codex-hook\.cmd"$/);
     }
+    assert.equal(hooks.hooks?.Stop, undefined);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Stop installing the fragile TokenPilot `Stop` hook.
- Remove legacy TokenPilot `Stop` groups during reinstall while preserving user hooks.
- Make malformed hook stdin fail open with exit `0` and `{"continue":true}` output.
- Align doctor checks, documentation, and regression coverage.

## Verification

- `npm --prefix components/adapters/codex run build`
- `npm --prefix components/adapters/codex run typecheck`
- `npm --prefix components/adapters/codex test` — 416 passed
- Windows `.cmd` wrapper smoke test passed for malformed and valid input.

## Context

Windows Codex can emit malformed hook JSON when non-ASCII assistant text is truncated. This change prevents the adapter from turning malformed input into a failed hook invocation while removing the affected `Stop` integration path.