### PR TITLE
feat(adapters): expose cleaner doctor and report state

### DIFF
--- a/components/adapters/claude-code/src/context-cleaner/observability.ts
+++ b/components/adapters/claude-code/src/context-cleaner/observability.ts
@@ -1,0 +1,170 @@
+import {
+  readContextCleanPlan,
+  readContextCleanReceipt,
+  type ContextCleanReceipt,
+} from "@lightrsi/cleaner";
+import type { ModelContextRewriteMode } from "@lightrsi/host-adapter";
+
+import { readClaudeCleanerSchedule } from "./scheduler.js";
+
+type CleanerSavings = {
+  tokens: number | null;
+  chars: number;
+};
+
+export type ClaudeCleanerObservability = {
+  availability: "available" | "degraded";
+  planStore: "available" | "missing" | "unknown";
+  pendingPlan: "none" | "scheduled" | "unknown";
+  lastReceipt: ContextCleanReceipt["status"] | "none" | "unknown";
+  rewriteMode: ModelContextRewriteMode;
+  savings: {
+    estimated?: CleanerSavings;
+    scheduled?: CleanerSavings;
+    applied?: CleanerSavings;
+  };
+  fallbackCount: number | null;
+};
+
+function unavailable(): ClaudeCleanerObservability {
+  return {
+    availability: "degraded",
+    planStore: "unknown",
+    pendingPlan: "unknown",
+    lastReceipt: "unknown",
+    rewriteMode: "request_overlay",
+    savings: {},
+    fallbackCount: null,
+  };
+}
+
+export function emptyClaudeCleanerObservability(): ClaudeCleanerObservability {
+  return {
+    availability: "available",
+    planStore: "unknown",
+    pendingPlan: "none",
+    lastReceipt: "none",
+    rewriteMode: "request_overlay",
+    savings: {},
+    fallbackCount: 0,
+  };
+}
+
+function estimatedSavings(receipt: ContextCleanReceipt): CleanerSavings {
+  return {
+    tokens: receipt.estimatedSavedTokens,
+    chars: receipt.estimatedSavedChars,
+  };
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && new Set(left).size === left.length
+    && new Set(right).size === right.length
+    && left.every((value) => right.includes(value));
+}
+
+function belongsToCurrentSchedule(params: {
+  hostId: "claude-code";
+  sessionId: string;
+  cleanPlanId: string;
+  planBaseRevision: string;
+  scheduleBaseRevision: string;
+  scheduleSelectedTaskIds: readonly string[];
+  scheduleStatus: "scheduled" | "committed" | "terminal";
+  terminalReceiptStatus?: "stale" | "cancelled" | "failed";
+  receipt: ContextCleanReceipt;
+}): boolean {
+  return params.receipt.planId === params.cleanPlanId
+    && params.receipt.hostId === params.hostId
+    && params.receipt.sessionId === params.sessionId
+    && params.planBaseRevision === params.scheduleBaseRevision
+    && sameStringSet(params.receipt.selectedTaskIds, params.scheduleSelectedTaskIds)
+    && (params.scheduleStatus !== "committed" || params.receipt.status === "applied")
+    && (params.scheduleStatus !== "terminal"
+      || params.terminalReceiptStatus === params.receipt.status);
+}
+
+/**
+ * Reads only metadata for the current scheduled Cleaner plan. The adapter
+ * journal supplies an opaque plan id; the shared store remains read-by-id and
+ * is never scanned here.
+ */
+export async function readClaudeCleanerObservability(params: {
+  stateDir: string;
+  sessionId: string;
+}): Promise<ClaudeCleanerObservability> {
+  const schedule = await readClaudeCleanerSchedule(params);
+  if (schedule.outcome === "bypassed") return unavailable();
+  if (schedule.outcome === "missing") {
+    return emptyClaudeCleanerObservability();
+  }
+
+  const cleanPlanId = schedule.record.cleanPlanId;
+  const plan = await readContextCleanPlan({ stateDir: params.stateDir, planId: cleanPlanId });
+  if (plan.bypassed) return unavailable();
+  if (!plan.value) {
+    return {
+      availability: "degraded",
+      planStore: "missing",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    };
+  }
+  if (plan.value.plan.hostId !== "claude-code" || plan.value.plan.sessionId !== params.sessionId) {
+    return unavailable();
+  }
+
+  const receipt = await readContextCleanReceipt({ stateDir: params.stateDir, planId: cleanPlanId });
+  if (receipt.bypassed) return unavailable();
+  if (!receipt.value) {
+    return {
+      availability: "degraded",
+      planStore: "available",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    };
+  }
+  if (!belongsToCurrentSchedule({
+    hostId: "claude-code",
+    sessionId: params.sessionId,
+    cleanPlanId,
+    planBaseRevision: plan.value.plan.baseRevision,
+    scheduleBaseRevision: schedule.record.baseRevision,
+    scheduleSelectedTaskIds: schedule.record.selectedTaskIds,
+    scheduleStatus: schedule.record.status,
+    terminalReceiptStatus: schedule.record.status === "terminal"
+      ? schedule.record.receiptStatus
+      : undefined,
+    receipt: receipt.value,
+  }) || plan.value.status !== receipt.value.status) {
+    return unavailable();
+  }
+
+  const savings: ClaudeCleanerObservability["savings"] = {
+    estimated: estimatedSavings(receipt.value),
+  };
+  if (receipt.value.status === "scheduled") {
+    savings.scheduled = estimatedSavings(receipt.value);
+  } else if (receipt.value.status === "applied") {
+    savings.applied = {
+      tokens: receipt.value.appliedSavedTokens,
+      chars: receipt.value.appliedSavedChars,
+    };
+  }
+  return {
+    availability: "available",
+    planStore: "available",
+    pendingPlan: receipt.value.status === "scheduled" ? "scheduled" : "none",
+    lastReceipt: receipt.value.status,
+    rewriteMode: "request_overlay",
+    savings,
+    fallbackCount: receipt.value.fallbackUsed ? 1 : 0,
+  };
+}

--- a/components/adapters/claude-code/src/doctor.ts
+++ b/components/adapters/claude-code/src/doctor.ts
@@ -22,6 +22,12 @@ import {
 import { resolveClaudeCodeHookCommandForInstall } from "./install.js";
 import { resolveClaudeCodeMcpServerSpecForInstall } from "./install.js";
 import { inspectClaudeTaskStateEstimatorConfig } from "./context-rewrite/estimator-config.js";
+import {
+  emptyClaudeCleanerObservability,
+  readClaudeCleanerObservability,
+  type ClaudeCleanerObservability,
+} from "./context-cleaner/observability.js";
+import { resolveLatestClaudeCodeSessionId } from "./session-state.js";
 
 export type ClaudeCodeDoctorReport = {
   settingsPath: string;
@@ -61,6 +67,7 @@ export type ClaudeCodeDoctorReport = {
   coreRuntimeHealthy: boolean;
   recoveryMcpHealthy: boolean;
   degradedMode: boolean;
+  cleaner?: ClaudeCleanerObservability;
 };
 
 const HOOK_EVENT_NAMES = [
@@ -106,6 +113,7 @@ function remediationLines(report: ClaudeCodeDoctorReport): string[] {
 }
 
 export function formatClaudeCodeDoctorReport(report: ClaudeCodeDoctorReport): string {
+  const cleaner = report.cleaner ?? emptyClaudeCleanerObservability();
   const lines = [
     "TokenPilot Claude Code doctor:",
     `- tokenpilot config: ${report.tokenPilotConfigPath}`,
@@ -145,6 +153,11 @@ export function formatClaudeCodeDoctorReport(report: ClaudeCodeDoctorReport): st
     `- state dir exists: ${report.stateDirExists ? "yes" : "no"}`,
     `- session state available: ${report.sessionStateAvailable ? "yes" : "no"}`,
     `- ux effects available: ${report.uxEffectsAvailable ? "yes" : "no"}`,
+    `- Cleaner capability: ${cleaner.availability}`,
+    `- Cleaner plan store: ${cleaner.planStore}`,
+    `- Cleaner pending plan: ${cleaner.pendingPlan}`,
+    `- Cleaner last receipt: ${cleaner.lastReceipt}`,
+    `- Cleaner rewrite mode: ${cleaner.rewriteMode}`,
   ];
   if (report.degradedMode) {
     lines.push(
@@ -172,6 +185,10 @@ export async function inspectClaudeCodeDoctor(params: {
   const proxyBaseUrl = proxyBaseUrlForPort(params.config.proxyPort);
   const expectedHookCommand = resolveClaudeCodeHookCommandForInstall();
   const expectedMcpSpec = resolveClaudeCodeMcpServerSpecForInstall(params.config.stateDir);
+  const latestSessionId = await resolveLatestClaudeCodeSessionId(params.config.stateDir);
+  const cleaner = latestSessionId
+    ? await readClaudeCleanerObservability({ stateDir: params.config.stateDir, sessionId: latestSessionId })
+    : emptyClaudeCleanerObservability();
   let settingsInstalled = false;
   let routedViaGateway = false;
   let toolSearchEnabled = false;
@@ -297,5 +314,6 @@ export async function inspectClaudeCodeDoctor(params: {
     coreRuntimeHealthy,
     recoveryMcpHealthy,
     degradedMode: coreRuntimeHealthy && !recoveryMcpHealthy,
+    cleaner,
   };
 }

--- a/components/adapters/claude-code/src/session-report.ts
+++ b/components/adapters/claude-code/src/session-report.ts
@@ -17,6 +17,10 @@ import {
   loadClaudeCodeSessionSnapshot,
   resolveLatestClaudeCodeSessionId,
 } from "./session-state.js";
+import {
+  readClaudeCleanerObservability,
+  type ClaudeCleanerObservability,
+} from "./context-cleaner/observability.js";
 
 export type ClaudeCodeSessionTopology = {
   sessionId: string;
@@ -38,6 +42,23 @@ export type ClaudeCodeSessionTopology = {
   updatedAt?: string;
   turnCount: number;
 };
+
+function formatCleanerSavings(
+  value: ClaudeCleanerObservability["savings"]["estimated"],
+  availability: ClaudeCleanerObservability["availability"],
+): string {
+  if (!value) return availability === "degraded" ? "unknown" : "none";
+  return `${value.tokens === null ? "tokens unavailable" : `${value.tokens} tokens`}, ${value.chars} chars`;
+}
+
+function buildClaudeCleanerReportLines(observation: ClaudeCleanerObservability): string[] {
+  return [
+    `- Cleaner estimated savings: ${formatCleanerSavings(observation.savings.estimated, observation.availability)}`,
+    `- Cleaner scheduled savings: ${formatCleanerSavings(observation.savings.scheduled, observation.availability)}`,
+    `- Cleaner applied savings: ${formatCleanerSavings(observation.savings.applied, observation.availability)}`,
+    `- Cleaner fallback count: ${observation.fallbackCount ?? "unknown"}`,
+  ];
+}
 
 export async function resolveClaudeCodeSessionTopology(
   stateDir: string,
@@ -104,8 +125,11 @@ export async function renderClaudeCodeSessionReport(stateDir: string, sessionRef
   const cacheAuditSummary = cacheAuditRecords.length > 0
     ? summarizeClaudeCodeCacheAudit(cacheAuditRecords)
     : null;
+  const cleanerReportLines = buildClaudeCleanerReportLines(
+    await readClaudeCleanerObservability({ stateDir, sessionId: topology.sessionId }),
+  );
 
-  return renderSessionReport({
+  const baseReport = await renderSessionReport({
     stateDir,
     title: "TokenPilot Claude Code report:",
     sessionId: topology.sessionId,
@@ -117,4 +141,5 @@ export async function renderClaudeCodeSessionReport(stateDir: string, sessionRef
       readAggregate: readUxSessionAggregate,
     },
   });
+  return `${baseReport}\n${cleanerReportLines.join("\n")}`;
 }

--- a/components/adapters/claude-code/tests/context-cleaner-observability.test.ts
+++ b/components/adapters/claude-code/tests/context-cleaner-observability.test.ts
@@ -1,0 +1,394 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  contextCleanReceiptFilePath,
+  saveContextCleanPlan,
+  transitionContextCleanState,
+  type ContextCleanPendingReceipt,
+  type ContextCleanPlan,
+} from "@lightrsi/cleaner";
+
+import {
+  appendClaudeCleanerCommitted,
+  appendClaudeCleanerTerminal,
+  claudeCleanerScheduleJournalPath,
+  scheduleClaudeCleanerPlan,
+} from "../src/context-cleaner/scheduler.js";
+import { readClaudeCleanerObservability } from "../src/context-cleaner/observability.js";
+import { normalizeTokenPilotClaudeCodeConfig } from "../src/config.js";
+import { formatClaudeCodeDoctorReport, inspectClaudeCodeDoctor } from "../src/doctor.js";
+import { renderClaudeCodeSessionReport } from "../src/session-report.js";
+import { upsertClaudeCodeSessionSnapshot } from "../src/session-state.js";
+
+const SESSION_ID = "claude-cleaner-observability-session";
+const PLAN_ID = "claude-cleaner-observability-plan";
+const REVISION = "claude-cleaner-observability-revision";
+const TIMESTAMP = "2026-08-31T00:00:00.000Z";
+
+async function withTempState(run: (stateDir: string) => Promise<void>): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-claude-cleaner-observability-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function plan(baseRevision = REVISION): ContextCleanPlan {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: PLAN_ID,
+    hostId: "claude-code",
+    sessionId: SESSION_ID,
+    baseRevision,
+    usedTokens: null,
+    usedChars: 400,
+    protectedTokens: null,
+    protectedChars: 329,
+    unassignedTokens: null,
+    unassignedChars: 0,
+    tokenCountMode: "chars_only",
+    tokenCountMethod: "utf16_chars",
+    createdAt: TIMESTAMP,
+    tasks: [{
+      taskId: "PRIVATE_TASK_ID",
+      label: "PRIVATE_TASK_LABEL",
+      description: "PRIVATE_TASK_DESCRIPTION",
+      summary: "PRIVATE_TASK_SUMMARY",
+      lifecycleState: "completed",
+      itemIds: ["PRIVATE_ITEM_ID"],
+      itemDigests: { PRIVATE_ITEM_ID: "PRIVATE_ITEM_DIGEST" },
+      tokenCount: null,
+      charCount: 71,
+      tokenPercent: null,
+      recommendation: "clean",
+      reasonCodes: ["PRIVATE_REASON"],
+      selectable: true,
+    }],
+  };
+}
+
+function scheduledReceipt(): ContextCleanPendingReceipt {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: PLAN_ID,
+    hostId: "claude-code",
+    sessionId: SESSION_ID,
+    status: "scheduled",
+    selectedTaskIds: ["PRIVATE_TASK_ID"],
+    estimatedSavedTokens: null,
+    estimatedSavedChars: 71,
+    tokenCountMode: "chars_only",
+    deferredTaskIds: [],
+    fallbackUsed: false,
+    reasons: [],
+    updatedAt: TIMESTAMP,
+  };
+}
+
+async function writeScheduledCleanerState(
+  stateDir: string,
+  options: {
+    planBaseRevision?: string;
+    scheduleBaseRevision?: string;
+    scheduleSelectedTaskIds?: string[];
+  } = {},
+): Promise<void> {
+  assert.equal((await saveContextCleanPlan({
+    stateDir,
+    plan: plan(options.planBaseRevision),
+  })).outcome, "stored");
+  await transitionContextCleanState({
+    stateDir,
+    receipt: { ...scheduledReceipt(), status: "approved" },
+  });
+  await transitionContextCleanState({ stateDir, receipt: scheduledReceipt() });
+  assert.equal((await scheduleClaudeCleanerPlan({
+    stateDir,
+    sessionId: SESSION_ID,
+    cleanPlanId: PLAN_ID,
+    baseRevision: options.scheduleBaseRevision ?? REVISION,
+    selectedTaskIds: options.scheduleSelectedTaskIds ?? ["PRIVATE_TASK_ID"],
+    scheduledAt: TIMESTAMP,
+  })).outcome, "stored");
+}
+
+test("reports a scheduled Claude clean with estimate-only metadata", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "available",
+      planStore: "available",
+      pendingPlan: "scheduled",
+      lastReceipt: "scheduled",
+      rewriteMode: "request_overlay",
+      savings: {
+        estimated: { tokens: null, chars: 71 },
+        scheduled: { tokens: null, chars: 71 },
+      },
+      fallbackCount: 0,
+    });
+    assert.doesNotMatch(JSON.stringify(observation), /PRIVATE_/u);
+  });
+});
+
+test("reports actual Claude savings only after the shared receipt is applied", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await transitionContextCleanState({
+      stateDir,
+      receipt: {
+        ...scheduledReceipt(),
+        status: "applied",
+        appliedSavedTokens: null,
+        appliedSavedChars: 59,
+        evidence: {
+          previousRevision: REVISION,
+          nextRevision: "next-revision",
+          operationIds: ["PRIVATE_OPERATION_ID"],
+          itemIds: ["PRIVATE_ITEM_ID"],
+        },
+        updatedAt: "2026-08-31T00:00:01.000Z",
+      },
+    });
+    assert.equal((await appendClaudeCleanerCommitted({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      mutationPlanId: "PRIVATE_MUTATION_PLAN",
+      overlayId: "PRIVATE_OVERLAY",
+      updatedAt: "2026-08-31T00:00:01.000Z",
+    })).outcome, "transitioned");
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "available",
+      planStore: "available",
+      pendingPlan: "none",
+      lastReceipt: "applied",
+      rewriteMode: "request_overlay",
+      savings: {
+        estimated: { tokens: null, chars: 71 },
+        applied: { tokens: null, chars: 59 },
+      },
+      fallbackCount: 0,
+    });
+    assert.doesNotMatch(JSON.stringify(observation), /PRIVATE_/u);
+  });
+});
+
+test("counts a terminal Claude fallback without reporting applied savings", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await transitionContextCleanState({
+      stateDir,
+      receipt: {
+        ...scheduledReceipt(),
+        status: "failed",
+        fallbackUsed: true,
+        reasons: ["PRIVATE_FALLBACK_REASON"],
+        updatedAt: "2026-08-31T00:00:01.000Z",
+      },
+    });
+    assert.equal((await appendClaudeCleanerTerminal({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      receiptStatus: "failed",
+      reasons: ["PRIVATE_FALLBACK_REASON"],
+      updatedAt: "2026-08-31T00:00:01.000Z",
+    })).outcome, "transitioned");
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "available",
+      planStore: "available",
+      pendingPlan: "none",
+      lastReceipt: "failed",
+      rewriteMode: "request_overlay",
+      savings: { estimated: { tokens: null, chars: 71 } },
+      fallbackCount: 1,
+    });
+    assert.doesNotMatch(JSON.stringify(observation), /PRIVATE_/u);
+  });
+});
+
+test("degrades safely when a Claude schedule references a missing shared plan", async () => {
+  await withTempState(async (stateDir) => {
+    assert.equal((await scheduleClaudeCleanerPlan({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      baseRevision: REVISION,
+      selectedTaskIds: ["PRIVATE_TASK_ID"],
+      scheduledAt: TIMESTAMP,
+    })).outcome, "stored");
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "missing",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades safely when a Claude schedule has no matching shared receipt", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await rm(contextCleanReceiptFilePath(stateDir, PLAN_ID));
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "available",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades when a Claude schedule revision diverges from its shared plan", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir, {
+      planBaseRevision: "PRIVATE_DIFFERENT_REVISION",
+    });
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades when a Claude schedule selection diverges from its frozen receipt", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir, {
+      scheduleSelectedTaskIds: ["PRIVATE_OTHER_TASK"],
+    });
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades when a Claude terminal schedule conflicts with its receipt", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await transitionContextCleanState({
+      stateDir,
+      receipt: {
+        ...scheduledReceipt(),
+        status: "failed",
+        fallbackUsed: true,
+        reasons: ["PRIVATE_FALLBACK_REASON"],
+        updatedAt: "2026-08-31T00:00:01.000Z",
+      },
+    });
+    assert.equal((await appendClaudeCleanerTerminal({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      receiptStatus: "cancelled",
+      reasons: ["PRIVATE_FALLBACK_REASON"],
+      updatedAt: "2026-08-31T00:00:01.000Z",
+    })).outcome, "transitioned");
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("fails open when the Claude cleaner schedule journal is corrupt", async () => {
+  await withTempState(async (stateDir) => {
+    const path = claudeCleanerScheduleJournalPath(stateDir, SESSION_ID);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "not-json\\n", "utf8");
+
+    const observation = await readClaudeCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "request_overlay",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("renders Claude Cleaner doctor and report metadata without task content", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await upsertClaudeCodeSessionSnapshot(stateDir, SESSION_ID, {
+      latestResponseId: "message-observability",
+      latestModel: "claude-test",
+    });
+
+    const doctor = await inspectClaudeCodeDoctor({
+      config: normalizeTokenPilotClaudeCodeConfig({ stateDir, proxyPort: 43124 }),
+      settingsPath: join(stateDir, "settings.json"),
+      tokenPilotConfigPath: join(stateDir, "tokenpilot.json"),
+      mcpConfigPath: join(stateDir, "mcp.json"),
+    });
+    const doctorText = formatClaudeCodeDoctorReport(doctor);
+    const reportText = await renderClaudeCodeSessionReport(stateDir, SESSION_ID);
+
+    assert.match(doctorText, /Cleaner capability: available/i);
+    assert.match(doctorText, /Cleaner plan store: available/i);
+    assert.match(doctorText, /Cleaner pending plan: scheduled/i);
+    assert.match(doctorText, /Cleaner last receipt: scheduled/i);
+    assert.match(doctorText, /Cleaner rewrite mode: request_overlay/i);
+    assert.match(reportText, /Cleaner estimated savings: tokens unavailable, 71 chars/i);
+    assert.match(reportText, /Cleaner scheduled savings: tokens unavailable, 71 chars/i);
+    assert.match(reportText, /Cleaner applied savings: none/i);
+    assert.match(reportText, /Cleaner fallback count: 0/i);
+    assert.doesNotMatch(`${doctorText}\n${reportText}`, /PRIVATE_/u);
+  });
+});

--- a/components/adapters/codex/src/context-cleaner/observability.ts
+++ b/components/adapters/codex/src/context-cleaner/observability.ts
@@ -1,0 +1,170 @@
+import {
+  readContextCleanPlan,
+  readContextCleanReceipt,
+  type ContextCleanReceipt,
+} from "@lightrsi/cleaner";
+import type { ModelContextRewriteMode } from "@lightrsi/host-adapter";
+
+import { readCodexCleanerSchedule } from "./scheduler.js";
+
+type CleanerSavings = {
+  tokens: number | null;
+  chars: number;
+};
+
+export type CodexCleanerObservability = {
+  availability: "available" | "degraded";
+  planStore: "available" | "missing" | "unknown";
+  pendingPlan: "none" | "scheduled" | "unknown";
+  lastReceipt: ContextCleanReceipt["status"] | "none" | "unknown";
+  rewriteMode: ModelContextRewriteMode;
+  savings: {
+    estimated?: CleanerSavings;
+    scheduled?: CleanerSavings;
+    applied?: CleanerSavings;
+  };
+  fallbackCount: number | null;
+};
+
+function unavailable(): CodexCleanerObservability {
+  return {
+    availability: "degraded",
+    planStore: "unknown",
+    pendingPlan: "unknown",
+    lastReceipt: "unknown",
+    rewriteMode: "response_chain_rebase",
+    savings: {},
+    fallbackCount: null,
+  };
+}
+
+export function emptyCodexCleanerObservability(): CodexCleanerObservability {
+  return {
+    availability: "available",
+    planStore: "unknown",
+    pendingPlan: "none",
+    lastReceipt: "none",
+    rewriteMode: "response_chain_rebase",
+    savings: {},
+    fallbackCount: 0,
+  };
+}
+
+function estimatedSavings(receipt: ContextCleanReceipt): CleanerSavings {
+  return {
+    tokens: receipt.estimatedSavedTokens,
+    chars: receipt.estimatedSavedChars,
+  };
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length
+    && new Set(left).size === left.length
+    && new Set(right).size === right.length
+    && left.every((value) => right.includes(value));
+}
+
+function belongsToCurrentSchedule(params: {
+  hostId: "codex";
+  sessionId: string;
+  cleanPlanId: string;
+  planBaseRevision: string;
+  scheduleBaseRevision: string;
+  scheduleSelectedTaskIds: readonly string[];
+  scheduleStatus: "scheduled" | "committed" | "terminal";
+  terminalReceiptStatus?: "stale" | "cancelled" | "failed";
+  receipt: ContextCleanReceipt;
+}): boolean {
+  return params.receipt.planId === params.cleanPlanId
+    && params.receipt.hostId === params.hostId
+    && params.receipt.sessionId === params.sessionId
+    && params.planBaseRevision === params.scheduleBaseRevision
+    && sameStringSet(params.receipt.selectedTaskIds, params.scheduleSelectedTaskIds)
+    && (params.scheduleStatus !== "committed" || params.receipt.status === "applied")
+    && (params.scheduleStatus !== "terminal"
+      || params.terminalReceiptStatus === params.receipt.status);
+}
+
+/**
+ * Reads only metadata for the current scheduled Cleaner plan. The adapter
+ * journal supplies an opaque plan id; the shared store remains read-by-id and
+ * is never scanned here.
+ */
+export async function readCodexCleanerObservability(params: {
+  stateDir: string;
+  sessionId: string;
+}): Promise<CodexCleanerObservability> {
+  const schedule = await readCodexCleanerSchedule(params);
+  if (schedule.outcome === "bypassed") return unavailable();
+  if (schedule.outcome === "missing") {
+    return emptyCodexCleanerObservability();
+  }
+
+  const cleanPlanId = schedule.record.cleanPlanId;
+  const plan = await readContextCleanPlan({ stateDir: params.stateDir, planId: cleanPlanId });
+  if (plan.bypassed) return unavailable();
+  if (!plan.value) {
+    return {
+      availability: "degraded",
+      planStore: "missing",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    };
+  }
+  if (plan.value.plan.hostId !== "codex" || plan.value.plan.sessionId !== params.sessionId) {
+    return unavailable();
+  }
+
+  const receipt = await readContextCleanReceipt({ stateDir: params.stateDir, planId: cleanPlanId });
+  if (receipt.bypassed) return unavailable();
+  if (!receipt.value) {
+    return {
+      availability: "degraded",
+      planStore: "available",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    };
+  }
+  if (!belongsToCurrentSchedule({
+    hostId: "codex",
+    sessionId: params.sessionId,
+    cleanPlanId,
+    planBaseRevision: plan.value.plan.baseRevision,
+    scheduleBaseRevision: schedule.record.baseRevision,
+    scheduleSelectedTaskIds: schedule.record.selectedTaskIds,
+    scheduleStatus: schedule.record.status,
+    terminalReceiptStatus: schedule.record.status === "terminal"
+      ? schedule.record.receiptStatus
+      : undefined,
+    receipt: receipt.value,
+  }) || plan.value.status !== receipt.value.status) {
+    return unavailable();
+  }
+
+  const savings: CodexCleanerObservability["savings"] = {
+    estimated: estimatedSavings(receipt.value),
+  };
+  if (receipt.value.status === "scheduled") {
+    savings.scheduled = estimatedSavings(receipt.value);
+  } else if (receipt.value.status === "applied") {
+    savings.applied = {
+      tokens: receipt.value.appliedSavedTokens,
+      chars: receipt.value.appliedSavedChars,
+    };
+  }
+  return {
+    availability: "available",
+    planStore: "available",
+    pendingPlan: receipt.value.status === "scheduled" ? "scheduled" : "none",
+    lastReceipt: receipt.value.status,
+    rewriteMode: "response_chain_rebase",
+    savings,
+    fallbackCount: receipt.value.fallbackUsed ? 1 : 0,
+  };
+}

--- a/components/adapters/codex/src/doctor.ts
+++ b/components/adapters/codex/src/doctor.ts
@@ -28,8 +28,14 @@ import {
   resolveCodexTaskStateEstimator,
   type CodexEstimatorDiagnostic,
 } from "./context-rewrite/estimator-config.js";
+import {
+  emptyCodexCleanerObservability,
+  readCodexCleanerObservability,
+  type CodexCleanerObservability,
+} from "./context-cleaner/observability.js";
 import { readDaemonStatus } from "./daemon.js";
 import { resolveCodexHookCommandForInstall, resolveCodexMcpServerSpecForInstall } from "./install.js";
+import { resolveLatestCodexSessionId } from "./session-state.js";
 
 export type CodexDoctorReport = {
   configPath: string;
@@ -67,6 +73,7 @@ export type CodexDoctorReport = {
   rebaseCapabilityTrusted?: boolean;
   rebaseCapabilityIssue?: string;
   taskStateEstimator?: CodexEstimatorDiagnostic;
+  cleaner?: CodexCleanerObservability;
 };
 
 export type CodexProviderDiagnostic = {
@@ -157,6 +164,7 @@ async function checkHealth(baseUrl: string): Promise<boolean> {
 }
 
 export function formatCodexDoctorReport(report: CodexDoctorReport): string {
+  const cleaner = report.cleaner ?? emptyCodexCleanerObservability();
   const taskStateEstimator = report.taskStateEstimator ?? {
     status: "disabled" as const,
     model: null,
@@ -215,6 +223,11 @@ export function formatCodexDoctorReport(report: CodexDoctorReport): string {
     `- task-state estimator eviction lookahead turns: ${taskStateEstimator.evictionLookaheadTurns}`,
     `- task-state estimator missing fields: ${taskStateEstimator.missingFields.length > 0 ? taskStateEstimator.missingFields.join(", ") : "(none)"}`,
     `- CDR-05 rebase capability cache: ${rebaseCapabilitySummary}`,
+    `- Cleaner capability: ${cleaner.availability}`,
+    `- Cleaner plan store: ${cleaner.planStore}`,
+    `- Cleaner pending plan: ${cleaner.pendingPlan}`,
+    `- Cleaner last receipt: ${cleaner.lastReceipt}`,
+    `- Cleaner rewrite mode: ${cleaner.rewriteMode}`,
   ];
   const fixes: string[] = [];
   if (!report.adapterEnabled) {
@@ -332,6 +345,10 @@ export async function inspectCodexDoctor(params: {
     config: params.config.taskStateEstimator,
     env: process.env,
   }));
+  const latestSessionId = await resolveLatestCodexSessionId(params.config.stateDir);
+  const cleaner = latestSessionId
+    ? await readCodexCleanerObservability({ stateDir: params.config.stateDir, sessionId: latestSessionId })
+    : emptyCodexCleanerObservability();
   return {
     configPath: params.configPath,
     hooksConfigPath: params.hooksConfigPath,
@@ -368,5 +385,6 @@ export async function inspectCodexDoctor(params: {
     rebaseCapabilityTrusted,
     rebaseCapabilityIssue,
     taskStateEstimator,
+    cleaner,
   };
 }

--- a/components/adapters/codex/src/session-report.ts
+++ b/components/adapters/codex/src/session-report.ts
@@ -20,6 +20,10 @@ import type {
   CodexRebaseEpochStatus,
 } from "./context-rewrite/types.js";
 import {
+  readCodexCleanerObservability,
+  type CodexCleanerObservability,
+} from "./context-cleaner/observability.js";
+import {
   loadCodexRecentTurnBindings,
   loadCodexSessionSnapshot,
   resolveCanonicalCodexSessionId,
@@ -73,6 +77,23 @@ function latestCooldown(cooldowns: CodexRebaseCooldown[]): CodexRebaseCooldown |
 
 function formatCharsAndTokens(chars: number, tokens: number): string {
   return `${chars} chars (~${tokens} tokens)`;
+}
+
+function formatCleanerSavings(
+  value: CodexCleanerObservability["savings"]["estimated"],
+  availability: CodexCleanerObservability["availability"],
+): string {
+  if (!value) return availability === "degraded" ? "unknown" : "none";
+  return `${value.tokens === null ? "tokens unavailable" : `${value.tokens} tokens`}, ${value.chars} chars`;
+}
+
+function buildCodexCleanerReportLines(observation: CodexCleanerObservability): string[] {
+  return [
+    `- Cleaner estimated savings: ${formatCleanerSavings(observation.savings.estimated, observation.availability)}`,
+    `- Cleaner scheduled savings: ${formatCleanerSavings(observation.savings.scheduled, observation.availability)}`,
+    `- Cleaner applied savings: ${formatCleanerSavings(observation.savings.applied, observation.availability)}`,
+    `- Cleaner fallback count: ${observation.fallbackCount ?? "unknown"}`,
+  ];
 }
 
 function formatCodexRebaseAccounting(epoch: CodexRebaseEpoch): string | undefined {
@@ -215,6 +236,9 @@ export async function renderCodexSessionReport(stateDir: string, sessionRef?: st
     ? summarizeCodexCacheAudit(cacheAuditRecords)
     : null;
   const rebaseReportLines = await buildCodexRebaseReportLines(stateDir, topology.sessionId);
+  const cleanerReportLines = buildCodexCleanerReportLines(
+    await readCodexCleanerObservability({ stateDir, sessionId: topology.sessionId }),
+  );
 
   const baseReport = await renderSessionReport({
     stateDir,
@@ -228,7 +252,5 @@ export async function renderCodexSessionReport(stateDir: string, sessionRef?: st
       readAggregate: readUxSessionAggregate,
     },
   });
-  return rebaseReportLines.length > 0
-    ? `${baseReport}\n${rebaseReportLines.join("\n")}`
-    : baseReport;
+  return `${baseReport}\n${[...rebaseReportLines, ...cleanerReportLines].join("\n")}`;
 }

--- a/components/adapters/codex/tests/context-cleaner-observability.test.ts
+++ b/components/adapters/codex/tests/context-cleaner-observability.test.ts
@@ -1,0 +1,394 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import test from "node:test";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  contextCleanReceiptFilePath,
+  saveContextCleanPlan,
+  transitionContextCleanState,
+  type ContextCleanPendingReceipt,
+  type ContextCleanPlan,
+} from "@lightrsi/cleaner";
+
+import {
+  appendCodexCleanerCommitted,
+  appendCodexCleanerTerminal,
+  codexCleanerScheduleJournalPath,
+  scheduleCodexCleanerPlan,
+} from "../src/context-cleaner/scheduler.js";
+import { readCodexCleanerObservability } from "../src/context-cleaner/observability.js";
+import { normalizeTokenPilotCodexConfig } from "../src/config.js";
+import { formatCodexDoctorReport, inspectCodexDoctor } from "../src/doctor.js";
+import { renderCodexSessionReport } from "../src/session-report.js";
+import { upsertCodexSessionSnapshot } from "../src/session-state.js";
+
+const SESSION_ID = "codex-cleaner-observability-session";
+const PLAN_ID = "codex-cleaner-observability-plan";
+const REVISION = "codex-cleaner-observability-revision";
+const TIMESTAMP = "2026-08-31T00:00:00.000Z";
+
+async function withTempState(run: (stateDir: string) => Promise<void>): Promise<void> {
+  const stateDir = await mkdtemp(join(tmpdir(), "lightrsi-codex-cleaner-observability-"));
+  try {
+    await run(stateDir);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function plan(baseRevision = REVISION): ContextCleanPlan {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: PLAN_ID,
+    hostId: "codex",
+    sessionId: SESSION_ID,
+    baseRevision,
+    usedTokens: 100,
+    usedChars: 400,
+    protectedTokens: 83,
+    protectedChars: 329,
+    unassignedTokens: 0,
+    unassignedChars: 0,
+    tokenCountMode: "exact",
+    tokenCountMethod: "test-tokenizer",
+    createdAt: TIMESTAMP,
+    tasks: [{
+      taskId: "PRIVATE_TASK_ID",
+      label: "PRIVATE_TASK_LABEL",
+      description: "PRIVATE_TASK_DESCRIPTION",
+      summary: "PRIVATE_TASK_SUMMARY",
+      lifecycleState: "completed",
+      itemIds: ["PRIVATE_ITEM_ID"],
+      itemDigests: { PRIVATE_ITEM_ID: "PRIVATE_ITEM_DIGEST" },
+      tokenCount: 17,
+      charCount: 71,
+      tokenPercent: 17,
+      recommendation: "clean",
+      reasonCodes: ["PRIVATE_REASON"],
+      selectable: true,
+    }],
+  };
+}
+
+function scheduledReceipt(): ContextCleanPendingReceipt {
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    planId: PLAN_ID,
+    hostId: "codex",
+    sessionId: SESSION_ID,
+    status: "scheduled",
+    selectedTaskIds: ["PRIVATE_TASK_ID"],
+    estimatedSavedTokens: 17,
+    estimatedSavedChars: 71,
+    tokenCountMode: "exact",
+    deferredTaskIds: [],
+    fallbackUsed: false,
+    reasons: [],
+    updatedAt: TIMESTAMP,
+  };
+}
+
+async function writeScheduledCleanerState(
+  stateDir: string,
+  options: {
+    planBaseRevision?: string;
+    scheduleBaseRevision?: string;
+    scheduleSelectedTaskIds?: string[];
+  } = {},
+): Promise<void> {
+  assert.equal((await saveContextCleanPlan({
+    stateDir,
+    plan: plan(options.planBaseRevision),
+  })).outcome, "stored");
+  await transitionContextCleanState({
+    stateDir,
+    receipt: { ...scheduledReceipt(), status: "approved" },
+  });
+  await transitionContextCleanState({ stateDir, receipt: scheduledReceipt() });
+  assert.equal((await scheduleCodexCleanerPlan({
+    stateDir,
+    sessionId: SESSION_ID,
+    cleanPlanId: PLAN_ID,
+    baseRevision: options.scheduleBaseRevision ?? REVISION,
+    selectedTaskIds: options.scheduleSelectedTaskIds ?? ["PRIVATE_TASK_ID"],
+    scheduledAt: TIMESTAMP,
+  })).outcome, "stored");
+}
+
+test("reports a scheduled Codex clean with estimate-only metadata", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "available",
+      planStore: "available",
+      pendingPlan: "scheduled",
+      lastReceipt: "scheduled",
+      rewriteMode: "response_chain_rebase",
+      savings: {
+        estimated: { tokens: 17, chars: 71 },
+        scheduled: { tokens: 17, chars: 71 },
+      },
+      fallbackCount: 0,
+    });
+    assert.doesNotMatch(JSON.stringify(observation), /PRIVATE_/u);
+  });
+});
+
+test("reports actual Codex savings only after the shared receipt is applied", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await transitionContextCleanState({
+      stateDir,
+      receipt: {
+        ...scheduledReceipt(),
+        status: "applied",
+        appliedSavedTokens: 13,
+        appliedSavedChars: 59,
+        evidence: {
+          previousRevision: REVISION,
+          nextRevision: "next-revision",
+          operationIds: ["PRIVATE_OPERATION_ID"],
+          itemIds: ["PRIVATE_ITEM_ID"],
+        },
+        updatedAt: "2026-08-31T00:00:01.000Z",
+      },
+    });
+    assert.equal((await appendCodexCleanerCommitted({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      mutationPlanId: "PRIVATE_MUTATION_PLAN",
+      epochId: "PRIVATE_EPOCH",
+      updatedAt: "2026-08-31T00:00:01.000Z",
+    })).outcome, "transitioned");
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "available",
+      planStore: "available",
+      pendingPlan: "none",
+      lastReceipt: "applied",
+      rewriteMode: "response_chain_rebase",
+      savings: {
+        estimated: { tokens: 17, chars: 71 },
+        applied: { tokens: 13, chars: 59 },
+      },
+      fallbackCount: 0,
+    });
+    assert.doesNotMatch(JSON.stringify(observation), /PRIVATE_/u);
+  });
+});
+
+test("counts a terminal Codex fallback without reporting applied savings", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await transitionContextCleanState({
+      stateDir,
+      receipt: {
+        ...scheduledReceipt(),
+        status: "failed",
+        fallbackUsed: true,
+        reasons: ["PRIVATE_FALLBACK_REASON"],
+        updatedAt: "2026-08-31T00:00:01.000Z",
+      },
+    });
+    assert.equal((await appendCodexCleanerTerminal({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      receiptStatus: "failed",
+      reasons: ["PRIVATE_FALLBACK_REASON"],
+      updatedAt: "2026-08-31T00:00:01.000Z",
+    })).outcome, "transitioned");
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "available",
+      planStore: "available",
+      pendingPlan: "none",
+      lastReceipt: "failed",
+      rewriteMode: "response_chain_rebase",
+      savings: { estimated: { tokens: 17, chars: 71 } },
+      fallbackCount: 1,
+    });
+    assert.doesNotMatch(JSON.stringify(observation), /PRIVATE_/u);
+  });
+});
+
+test("degrades safely when a Codex schedule references a missing shared plan", async () => {
+  await withTempState(async (stateDir) => {
+    assert.equal((await scheduleCodexCleanerPlan({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      baseRevision: REVISION,
+      selectedTaskIds: ["PRIVATE_TASK_ID"],
+      scheduledAt: TIMESTAMP,
+    })).outcome, "stored");
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "missing",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades safely when a Codex schedule has no matching shared receipt", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await rm(contextCleanReceiptFilePath(stateDir, PLAN_ID));
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "available",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades when a Codex schedule revision diverges from its shared plan", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir, {
+      planBaseRevision: "PRIVATE_DIFFERENT_REVISION",
+    });
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades when a Codex schedule selection diverges from its frozen receipt", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir, {
+      scheduleSelectedTaskIds: ["PRIVATE_OTHER_TASK"],
+    });
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("degrades when a Codex terminal schedule conflicts with its receipt", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await transitionContextCleanState({
+      stateDir,
+      receipt: {
+        ...scheduledReceipt(),
+        status: "failed",
+        fallbackUsed: true,
+        reasons: ["PRIVATE_FALLBACK_REASON"],
+        updatedAt: "2026-08-31T00:00:01.000Z",
+      },
+    });
+    assert.equal((await appendCodexCleanerTerminal({
+      stateDir,
+      sessionId: SESSION_ID,
+      cleanPlanId: PLAN_ID,
+      receiptStatus: "cancelled",
+      reasons: ["PRIVATE_FALLBACK_REASON"],
+      updatedAt: "2026-08-31T00:00:01.000Z",
+    })).outcome, "transitioned");
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("fails open when the Codex cleaner schedule journal is corrupt", async () => {
+  await withTempState(async (stateDir) => {
+    const path = codexCleanerScheduleJournalPath(stateDir, SESSION_ID);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "not-json\\n", "utf8");
+
+    const observation = await readCodexCleanerObservability({ stateDir, sessionId: SESSION_ID });
+
+    assert.deepEqual(observation, {
+      availability: "degraded",
+      planStore: "unknown",
+      pendingPlan: "unknown",
+      lastReceipt: "unknown",
+      rewriteMode: "response_chain_rebase",
+      savings: {},
+      fallbackCount: null,
+    });
+  });
+});
+
+test("renders Codex Cleaner doctor and report metadata without task content", async () => {
+  await withTempState(async (stateDir) => {
+    await writeScheduledCleanerState(stateDir);
+    await upsertCodexSessionSnapshot(stateDir, SESSION_ID, {
+      latestResponseId: "response-observability",
+      latestModel: "gpt-test",
+    });
+
+    const doctor = await inspectCodexDoctor({
+      config: normalizeTokenPilotCodexConfig({ stateDir, proxyPort: 43123 }),
+      configPath: join(stateDir, "config.toml"),
+      tokenPilotConfigPath: join(stateDir, "tokenpilot.json"),
+      hooksConfigPath: join(stateDir, "hooks.json"),
+    });
+    const doctorText = formatCodexDoctorReport(doctor);
+    const reportText = await renderCodexSessionReport(stateDir, SESSION_ID);
+
+    assert.match(doctorText, /Cleaner capability: available/i);
+    assert.match(doctorText, /Cleaner plan store: available/i);
+    assert.match(doctorText, /Cleaner pending plan: scheduled/i);
+    assert.match(doctorText, /Cleaner last receipt: scheduled/i);
+    assert.match(doctorText, /Cleaner rewrite mode: response_chain_rebase/i);
+    assert.match(reportText, /Cleaner estimated savings: 17 tokens, 71 chars/i);
+    assert.match(reportText, /Cleaner scheduled savings: 17 tokens, 71 chars/i);
+    assert.match(reportText, /Cleaner applied savings: none/i);
+    assert.match(reportText, /Cleaner fallback count: 0/i);
+    assert.doesNotMatch(`${doctorText}\n${reportText}`, /PRIVATE_/u);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds metadata-only Cleaner observability for the Codex and Claude Code adapters.

### Doctor

Both adapter doctor reports now expose:

- Cleaner capability availability
- shared plan-store state
- pending local clean-plan state
- last shared receipt status
- Host rewrite mode

### Session report

Both session reports now separately show:

- estimated Cleaner savings
- scheduled Cleaner savings
- applied Cleaner savings
- fallback count

### Safety and consistency

- The adapters read only the current session’s local schedule and then fetch the referenced shared plan and receipt by plan ID.
- They do not scan shared Cleaner storage.
- Missing, corrupt, unreadable, or inconsistent schedule/plan/receipt state degrades safely to metadata-only `unknown` values.
- The reader validates host, session, plan ID, base revision, frozen selected-task set, committed/applied state, and terminal receipt status before displaying savings.
- No user context, task labels/descriptions, item IDs, digests, fingerprints, evidence payloads, or provider-native payloads are exposed.

## Scope

This PR intentionally does not add CLI clean commands, plan creation, approval bypasses, shared Cleaner persistence changes, execution changes, or OpenClaw changes.

## Validation

- `pnpm --dir components/adapters/codex typecheck`
- `pnpm --dir components/adapters/claude-code typecheck`
- Codex focused doctor/report/observability tests: 28 passing
- Claude Code focused doctor/report/observability tests: 21 passing
- `pnpm check:boundaries`
- `git diff --check`