### PR TITLE
feat(openclaw): apply approved clean plans

### DIFF
--- a/components/adapters/openclaw/README.md
+++ b/components/adapters/openclaw/README.md
@@ -17,6 +17,7 @@ Current adapter responsibilities:
 - request-time reduction
 - tool-result persistence
 - canonical history rewrite and eviction
+- user-approved Context Cleaner snapshot and immediate canonical apply
 - recovery protocol and recovery tool wiring
 
 ## Install
@@ -53,6 +54,22 @@ Or use the standalone CLI:
 cd /path/to/LightRSI
 lightrsi openclaw doctor
 ```
+
+Analyze an OpenClaw session without changing its context:
+
+```bash
+lightrsi openclaw clean --session <session-id>
+```
+
+Apply only tasks selected from that immutable plan:
+
+```bash
+lightrsi openclaw clean --plan <plan-id> --select <task-id,...>
+```
+
+OpenClaw archives selected task content before atomically committing the
+canonical rewrite. Unlike scheduled Codex and Claude Code rewrites, a successful
+OpenClaw command returns an `applied` receipt immediately.
 
 Development-style install should use source build + runtime sync instead of mixing release and load-path installs. The current sanity workflow is:
 

--- a/components/adapters/openclaw/README.md
+++ b/components/adapters/openclaw/README.md
@@ -29,7 +29,9 @@ cd /path/to/LightRSI/components/adapters/openclaw
 npm run install:release
 ```
 
-This installs the packaged TokenPilot runtime component into:
+This uses OpenClaw's managed plugin installer so the declared Context Engine
+capability is recorded and consented, then installs the packaged TokenPilot
+runtime component into:
 
 ```text
 ~/.openclaw/extensions/tokenpilot
@@ -71,7 +73,14 @@ plugin's native command surface:
 
 The first form resolves the current conversation's mapped TokenPilot session.
 If no mapping is available, pass the session id explicitly. Analysis never
-applies a rewrite by itself.
+applies a rewrite by itself. When the task registry is missing or behind the
+canonical conversation, this explicit analysis request first classifies the
+pending turns through OpenClaw's Host-managed, tool-free model completion
+surface. Cleaner recommendations reuse that same Host-managed completion, so
+provider credentials remain inside OpenClaw's auth store. Older Hosts
+without that surface fall back to an explicitly configured `taskStateEstimator`;
+classification or recommendation failure uses the conservative shared fallback
+and does not make any additional task selectable.
 
 Apply only tasks selected from that immutable plan:
 

--- a/components/adapters/openclaw/README.md
+++ b/components/adapters/openclaw/README.md
@@ -61,11 +61,34 @@ Analyze an OpenClaw session without changing its context:
 lightrsi openclaw clean --session <session-id>
 ```
 
+The same flow is available inside an active OpenClaw conversation through the
+plugin's native command surface:
+
+```text
+/lightrsi clean
+/lightrsi clean --session <session-id>
+```
+
+The first form resolves the current conversation's mapped TokenPilot session.
+If no mapping is available, pass the session id explicitly. Analysis never
+applies a rewrite by itself.
+
 Apply only tasks selected from that immutable plan:
 
 ```bash
 lightrsi openclaw clean --plan <plan-id> --select <task-id,...>
 ```
+
+Or apply and inspect the plan from the OpenClaw conversation:
+
+```text
+/lightrsi clean --plan <plan-id> --select <task-id,...>
+/lightrsi clean --status <plan-id>
+/lightrsi clean --cancel <plan-id>
+```
+
+`/tokenpilot clean` and `/tp clean` are equivalent aliases. Active, current,
+and unresolved tasks remain protected by the canonical Cleaner validation.
 
 OpenClaw archives selected task content before atomically committing the
 canonical rewrite. Unlike scheduled Codex and Claude Code rewrites, a successful

--- a/components/adapters/openclaw/openclaw.plugin.json
+++ b/components/adapters/openclaw/openclaw.plugin.json
@@ -3,7 +3,7 @@
   "activation": {
     "onStartup": true
   },
-  "kind": "runtime",
+  "kind": "context-engine",
   "name": "TokenPilot Runtime Optimizer",
   "version": "0.1.0-beta.1",
   "description": "Token-efficiency runtime plugin for OpenClaw with pluggable routing and optimization hooks.",

--- a/components/adapters/openclaw/package.json
+++ b/components/adapters/openclaw/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@lightrsi/artifact-store": "workspace:*",
+    "@lightrsi/cleaner": "workspace:*",
     "@lightrsi/tokenpilot": "workspace:*",
     "@lightrsi/eviction": "workspace:*",
     "@lightrsi/host-adapter": "workspace:*",

--- a/components/adapters/openclaw/scripts/install_release.sh
+++ b/components/adapters/openclaw/scripts/install_release.sh
@@ -137,7 +137,7 @@ with open(config_path, "r", encoding="utf-8") as f:
 plugins = cfg.setdefault("plugins", {})
 slots = plugins.setdefault("slots", {})
 if post_install:
-    slots["contextEngine"] = "layered-context"
+    slots["contextEngine"] = "tokenpilot"
 load_cfg = plugins.get("load")
 if isinstance(load_cfg, dict):
     paths = load_cfg.get("paths")
@@ -197,7 +197,12 @@ if post_install:
 
     tokenpilot_cfg["enabled"] = True
     tokenpilot_cfg["logLevel"] = str(tokenpilot_cfg.get("logLevel") or "info")
-    tokenpilot_cfg["proxyAutostart"] = True
+    # Context Cleaner runs through the native Context Engine and does not need
+    # the embedded model proxy. Starting that proxy during Gateway startup can
+    # register providers and rewrite model config after OpenClaw has prepared a
+    # model-runtime generation, invalidating the first (and sometimes later)
+    # turns. Keep it opt-in for release installs.
+    tokenpilot_cfg["proxyAutostart"] = False
     tokenpilot_cfg["proxyPort"] = int(tokenpilot_cfg.get("proxyPort") or 17667)
     tokenpilot_cfg["debugTapProviderTraffic"] = bool(tokenpilot_cfg.get("debugTapProviderTraffic", False))
 
@@ -393,14 +398,13 @@ PY
 sanitize_plugin_config 0
 
 archive_path="$("${SCRIPT_DIR}/pack_release.sh")"
+if command -v wslpath >/dev/null 2>&1; then
+  case "${archive_path}" in
+    [A-Za-z]:[\\/]*) archive_path="$(wslpath -u "${archive_path}")" ;;
+  esac
+fi
 prepare_config_for_install
-rm -rf "${INSTALLED_PLUGIN_PATH}"
-
-mkdir -p "${INSTALLED_PLUGIN_PATH}"
-tmp_extract_dir="$(mktemp -d)"
-tar -xzf "${archive_path}" -C "${tmp_extract_dir}"
-cp -R "${tmp_extract_dir}/package/." "${INSTALLED_PLUGIN_PATH}/"
-rm -rf "${tmp_extract_dir}"
+openclaw_cmd plugins install "${archive_path}" --force --accept-capabilities
 sanitize_plugin_config 1
 if ! openclaw_cmd gateway restart; then
   printf '%s\n' "Warning: gateway restart failed; restart it manually if needed."

--- a/components/adapters/openclaw/scripts/pack_release.sh
+++ b/components/adapters/openclaw/scripts/pack_release.sh
@@ -3,15 +3,21 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-PNPM_CMD=(pnpm)
+BUILD_CMD=(npm run build)
 if command -v node.exe >/dev/null 2>&1 && command -v cmd.exe >/dev/null 2>&1; then
-  PNPM_CMD=(cmd.exe /d /c pnpm)
+  # A repository mounted into WSL may have dependencies installed by Windows.
+  # Use the matching Windows Node toolchain without depending on a globally
+  # selected pnpm version; this package's build has no workspace orchestration.
+  BUILD_CMD=(cmd.exe /d /c npm run build)
 fi
 
 cd "${PLUGIN_DIR}"
 
 rm -f lightrsi-openclaw-adapter-*.tgz lightrsi-tokenpilot-openclaw-*.tgz tokenpilot-*.tgz
-"${PNPM_CMD[@]}" build >/dev/null 2>&1
+# install_release.sh captures stdout from this script as the archive path.
+# Keep build diagnostics visible on stderr while reserving stdout for the
+# final .tgz path printed below.
+"${BUILD_CMD[@]}" >&2
 
 PACK_TMP_DIR="$(mktemp -d "${PLUGIN_DIR}/.tokenpilot-pack-XXXXXX")"
 cleanup() {
@@ -20,6 +26,15 @@ cleanup() {
 trap cleanup EXIT
 
 NPM_CACHE_DIR="${NPM_CACHE_DIR:-${PACK_TMP_DIR}/npm-cache}"
+if command -v wslpath >/dev/null 2>&1; then
+  case "${NPM_CACHE_DIR}" in
+    [A-Za-z]:[\\/]*) NPM_CACHE_DIR="$(wslpath -u "${NPM_CACHE_DIR}")" ;;
+  esac
+elif command -v cygpath >/dev/null 2>&1; then
+  case "${NPM_CACHE_DIR}" in
+    [A-Za-z]:[\\/]*) NPM_CACHE_DIR="$(cygpath -u "${NPM_CACHE_DIR}")" ;;
+  esac
+fi
 if [[ "${NPM_CACHE_DIR}" == /* ]]; then
   mkdir -p "${NPM_CACHE_DIR}"
 fi

--- a/components/adapters/openclaw/src/commands/tokenpilot-command.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot-command.ts
@@ -1,13 +1,39 @@
 import { createProductSurfaceCommandHandler, parseCommandAction } from "@lightrsi/product-surface";
 import { TOKENPILOT_PRODUCT_SURFACE_IDENTITY } from "@lightrsi/tokenpilot";
+import type { JsonModelClient } from "@lightrsi/runtime-core";
 import { openClawProductSurfaceConfigAdapter } from "./tokenpilot/host-config-adapter.js";
 import { createOpenClawProductSurfaceBridge } from "./tokenpilot/openclaw-command-bridge.js";
 import {
   createOpenClawContextCleanerCommandHandler,
   formatOpenClawCleanUsage,
+  loadOpenClawContextCleanerConfig,
 } from "./tokenpilot/context-cleaner-command.js";
 
-export function registerTokenPilotCommand(api: any, logger: { debug?: (...args: unknown[]) => void }): void {
+function cleanerAgentId(ctx: any): string {
+  const candidates = [ctx?.agentId, ctx?.agent_id, ctx?.ctx?.AgentId, ctx?.ctx?.agentId];
+  return candidates.find((value) => typeof value === "string" && value.trim())?.trim() ?? "main";
+}
+
+function createOpenClawCleanerModelClient(api: any, ctx: any): JsonModelClient | undefined {
+  const subagent = api?.runtime?.subagent;
+  if (typeof subagent?.complete !== "function") return undefined;
+  return {
+    async request(input) {
+      const result = await subagent.complete.call(subagent, {
+        agentId: cleanerAgentId(ctx),
+        message: input.userPayload,
+        extraSystemPrompt: input.systemPrompt,
+        timeoutMs: 60_000,
+      });
+      return { text: String(result?.text ?? "") };
+    },
+  };
+}
+
+export function registerTokenPilotCommand(
+  api: any,
+  logger: { debug?: (...args: unknown[]) => void; warn?: (...args: unknown[]) => void },
+): void {
   if (typeof api.registerCommand !== "function") {
     logger.debug?.("[plugin-runtime] registerCommand unavailable; /tokenpilot not registered.");
     return;
@@ -20,7 +46,9 @@ export function registerTokenPilotCommand(api: any, logger: { debug?: (...args: 
     identity: TOKENPILOT_PRODUCT_SURFACE_IDENTITY,
   });
   const cleanHandler = createOpenClawContextCleanerCommandHandler({
-    loadConfig: bridge.loadConfig,
+    loadConfig: () => loadOpenClawContextCleanerConfig(api),
+    logger: { warn: (message) => logger.warn?.(message) },
+    createModelClient: (ctx) => createOpenClawCleanerModelClient(api, ctx),
   });
 
   for (const alias of TOKENPILOT_PRODUCT_SURFACE_IDENTITY.aliases) {

--- a/components/adapters/openclaw/src/commands/tokenpilot-command.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot-command.ts
@@ -1,8 +1,11 @@
-import { registerProductSurfaceCommands } from "@lightrsi/product-surface";
+import { createProductSurfaceCommandHandler, parseCommandAction } from "@lightrsi/product-surface";
 import { TOKENPILOT_PRODUCT_SURFACE_IDENTITY } from "@lightrsi/tokenpilot";
 import { openClawProductSurfaceConfigAdapter } from "./tokenpilot/host-config-adapter.js";
 import { createOpenClawProductSurfaceBridge } from "./tokenpilot/openclaw-command-bridge.js";
-import { createOpenClawCommandRegistrar } from "./tokenpilot/openclaw-command-registrar.js";
+import {
+  createOpenClawContextCleanerCommandHandler,
+  formatOpenClawCleanUsage,
+} from "./tokenpilot/context-cleaner-command.js";
 
 export function registerTokenPilotCommand(api: any, logger: { debug?: (...args: unknown[]) => void }): void {
   if (typeof api.registerCommand !== "function") {
@@ -10,11 +13,32 @@ export function registerTokenPilotCommand(api: any, logger: { debug?: (...args: 
     return;
   }
 
-  registerProductSurfaceCommands({
-    registrar: createOpenClawCommandRegistrar(api),
-    bridge: createOpenClawProductSurfaceBridge(api),
+  const bridge = createOpenClawProductSurfaceBridge(api);
+  const sharedHandler = createProductSurfaceCommandHandler({
+    bridge,
     configAdapter: openClawProductSurfaceConfigAdapter,
     identity: TOKENPILOT_PRODUCT_SURFACE_IDENTITY,
   });
+  const cleanHandler = createOpenClawContextCleanerCommandHandler({
+    loadConfig: bridge.loadConfig,
+  });
+
+  for (const alias of TOKENPILOT_PRODUCT_SURFACE_IDENTITY.aliases) {
+    api.registerCommand({
+      name: alias.name,
+      description: alias.description,
+      acceptsArgs: true,
+      async handler(ctx: any) {
+        const rawArgs = typeof ctx?.args === "string" ? ctx.args : "";
+        const { action, rest } = parseCommandAction(rawArgs);
+        if (action === "clean") return cleanHandler(ctx, rest);
+        const result = await sharedHandler(ctx);
+        if (!action || action === "help") {
+          return { ...result, text: `${result.text}\n\n${formatOpenClawCleanUsage()}` };
+        }
+        return result;
+      },
+    });
+  }
   logger.debug?.("[plugin-runtime] Registered /tokenpilot, /lightrsi, and /tp commands.");
 }

--- a/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.test.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.test.ts
@@ -123,7 +123,13 @@ test("native clean analyzes the current OpenClaw session without applying change
   assert.equal(analyzedSessionId, "session-demo");
   assert.equal(approved, false);
   assert.match(result.text, /Context clean plan: ctxclean-demo/);
-  assert.match(result.text, /\[-\] task-active/);
+  assert.match(result.text, /```text\n/);
+  assert.match(result.text, /TASK\s+DESCRIPTION\s+SIZE\s+SHARE\s+ADVICE\s+RISK \/ REASONS/);
+  assert.match(result.text, /100 tok\s+83\.3%\s+clean\s+low/);
+  assert.match(result.text, /Task details:/);
+  assert.match(result.text, /Recommended selection estimate: 100 tok/);
+  assert.match(result.text, /1\. task-done - Completed task/);
+  assert.match(result.text, /Apply selected tasks: \/lightrsi clean --plan ctxclean-demo --select/);
   assert.match(result.text, /No changes applied/);
 });
 
@@ -145,7 +151,9 @@ test("native clean forwards only the explicit plan task selection", async () => 
   assert.equal(approvedPlanId, "ctxclean-demo");
   assert.deepEqual(approvedTaskIds, ["task-done"]);
   assert.match(result.text, /Context clean applied/);
-  assert.match(result.text, /Released: 100 tok/);
+  assert.match(result.text, /Applied savings: 100 tok/);
+  assert.match(result.text, /Fallback count: 0/);
+  assert.match(result.text, /Apply timing: immediate\./);
 });
 
 test("native clean reads status and cancels through the canonical backend", async () => {
@@ -180,8 +188,32 @@ test("native clean reads status and cancels through the canonical backend", asyn
   assert.equal(statusPlanId, "ctxclean-demo");
   assert.equal(cancelledPlanId, "ctxclean-demo");
   assert.match(status.text, /Context clean applied/);
+  assert.match(status.text, /Applied savings: 100 tok/);
+  assert.match(status.text, /Apply timing: immediate\./);
   assert.match(cancelled.text, /Context clean cancelled/);
-  assert.match(cancelled.text, /Recommendation fallback: used/);
+  assert.match(cancelled.text, /Fallback count: 1/);
+});
+
+test("native clean distinguishes scheduled savings from applied savings", async () => {
+  const scheduledReceipt: ContextCleanReceipt = {
+    ...appliedReceipt,
+    status: "scheduled",
+    appliedSavedTokens: undefined,
+    appliedSavedChars: undefined,
+    evidence: undefined,
+  };
+  const result = await handleOpenClawContextCleanCommand({
+    ctx: {},
+    rawArgs: "--status ctxclean-demo",
+    backend: backend({ async readReceipt() { return scheduledReceipt; } }),
+  });
+
+  assert.match(result.text, /Context clean scheduled/);
+  assert.match(result.text, /Estimated savings: 100 tok/);
+  assert.match(result.text, /Scheduled savings: 100 tok/);
+  assert.match(result.text, /Applied savings: not applied/);
+  assert.match(result.text, /Fallback count: 0/);
+  assert.match(result.text, /Apply timing: next Host request\./);
 });
 
 test("native command registration preserves aliases and exposes clean help", async () => {

--- a/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.test.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.test.ts
@@ -1,13 +1,21 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import type { ContextCleanPlan, ContextCleanReceipt } from "@lightrsi/cleaner";
+import {
+  analyzeContextCleanRecommendations,
+  type ContextCleanPlan,
+  type ContextCleanReceipt,
+} from "@lightrsi/cleaner";
+import type { JsonModelClient } from "@lightrsi/runtime-core";
 
 import {
+  createOpenClawCleanRecommendationProvider,
   createOpenClawContextCleanerCommandHandler,
   handleOpenClawContextCleanCommand,
+  loadOpenClawContextCleanerConfig,
 } from "./context-cleaner-command.js";
 import { registerTokenPilotCommand } from "../tokenpilot-command.js";
+import { normalizeConfig } from "../../context-stack/integration/config-normalize.js";
 
 const plan: ContextCleanPlan = {
   schemaVersion: 1,
@@ -196,6 +204,71 @@ test("native command registration preserves aliases and exposes clean help", asy
   assert.match(cleanHelp.text, /\/lightrsi clean --plan/);
   const generalHelp = await command.handler({ args: "help" });
   assert.match(generalHelp.text, /Context Cleaner:/);
+});
+
+test("native clean reads current OpenClaw config without the removed runtime loader", async () => {
+  const currentConfig = { plugins: { entries: { tokenpilot: { enabled: true } } } };
+  assert.equal(loadOpenClawContextCleanerConfig({ config: currentConfig }), currentConfig);
+});
+
+test("native clean retains the legacy OpenClaw config loader fallback", async () => {
+  const legacyConfig = { plugins: { entries: {} } };
+  const legacyConfigApi = {
+    marker: "legacy",
+    loadConfig(this: { marker: string }) {
+      assert.equal(this.marker, "legacy");
+      return legacyConfig;
+    },
+  };
+
+  assert.equal(
+    await loadOpenClawContextCleanerConfig({ runtime: { config: legacyConfigApi } }),
+    legacyConfig,
+  );
+});
+
+test("native clean fails closed when OpenClaw exposes no config surface", () => {
+  assert.throws(
+    () => loadOpenClawContextCleanerConfig({}),
+    /clean_config_unavailable/,
+  );
+});
+
+test("native clean recommendations use the Host-managed model without API credentials", async () => {
+  let requests = 0;
+  const modelClient: JsonModelClient = {
+    async request() {
+      requests += 1;
+      return {
+        text: JSON.stringify({
+          tasks: [{
+            taskId: "task-done",
+            label: "Completed task",
+            description: "Finished implementation work",
+            summary: "done",
+            recommendation: "clean",
+            reasonCodes: ["task_completed"],
+            confidence: 0.95,
+          }],
+        }),
+      };
+    },
+  };
+  const provider = createOpenClawCleanRecommendationProvider(
+    normalizeConfig({ taskStateEstimator: { enabled: false } }),
+    modelClient,
+  );
+
+  assert.ok(provider);
+  const result = await analyzeContextCleanRecommendations({
+    tasks: [plan.tasks[0]!],
+    provider,
+  });
+
+  assert.equal(requests, 1);
+  assert.equal(result.fallbackUsed, false);
+  assert.equal(result.tasks[0]?.recommendation, "clean");
+  assert.equal(result.tasks[0]?.selectable, true);
 });
 
 test("native clean handler returns actionable usage for invalid arguments", async () => {

--- a/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.test.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.test.ts
@@ -1,0 +1,209 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import type { ContextCleanPlan, ContextCleanReceipt } from "@lightrsi/cleaner";
+
+import {
+  createOpenClawContextCleanerCommandHandler,
+  handleOpenClawContextCleanCommand,
+} from "./context-cleaner-command.js";
+import { registerTokenPilotCommand } from "../tokenpilot-command.js";
+
+const plan: ContextCleanPlan = {
+  schemaVersion: 1,
+  planId: "ctxclean-demo",
+  hostId: "openclaw",
+  sessionId: "session-demo",
+  baseRevision: "revision-a",
+  usedTokens: 120,
+  usedChars: 480,
+  protectedTokens: 20,
+  protectedChars: 80,
+  unassignedTokens: 0,
+  unassignedChars: 0,
+  tokenCountMode: "exact",
+  tokenCountMethod: "fixture",
+  tasks: [
+    {
+      taskId: "task-done",
+      label: "Completed task",
+      description: "Finished implementation work",
+      summary: "done",
+      lifecycleState: "completed",
+      itemIds: ["item-1"],
+      itemDigests: { "item-1": "digest-1" },
+      tokenCount: 100,
+      charCount: 400,
+      tokenPercent: 83.3,
+      recommendation: "clean",
+      reasonCodes: ["task_completed"],
+      selectable: true,
+    },
+    {
+      taskId: "task-active",
+      label: "Active task",
+      description: "Current work must stay",
+      summary: "active",
+      lifecycleState: "active",
+      itemIds: ["item-2"],
+      itemDigests: { "item-2": "digest-2" },
+      tokenCount: 20,
+      charCount: 80,
+      tokenPercent: 16.7,
+      recommendation: "protected",
+      reasonCodes: ["deterministic_protection"],
+      selectable: false,
+    },
+  ],
+  createdAt: "2026-09-09T00:00:00.000Z",
+};
+
+const appliedReceipt: ContextCleanReceipt = {
+  schemaVersion: 1,
+  planId: plan.planId,
+  hostId: "openclaw",
+  sessionId: plan.sessionId,
+  status: "applied",
+  selectedTaskIds: ["task-done"],
+  estimatedSavedTokens: 100,
+  estimatedSavedChars: 400,
+  appliedSavedTokens: 100,
+  appliedSavedChars: 400,
+  tokenCountMode: "exact",
+  deferredTaskIds: [],
+  reasons: [],
+  updatedAt: "2026-09-09T00:00:01.000Z",
+  fallbackUsed: false,
+  evidence: {
+    previousRevision: "revision-a",
+    nextRevision: "revision-b",
+    operationIds: ["operation-1"],
+    itemIds: ["item-1"],
+  },
+};
+
+function backend(overrides: Record<string, unknown> = {}) {
+  return {
+    stateDir: "C:/state",
+    async analyze() { return plan; },
+    async readPlan() { return plan; },
+    async approve() { return appliedReceipt; },
+    async readReceipt() { return appliedReceipt; },
+    async cancel() { return { ...appliedReceipt, status: "cancelled" }; },
+    ...overrides,
+  } as any;
+}
+
+test("native clean analyzes the current OpenClaw session without applying changes", async () => {
+  let analyzedSessionId = "";
+  let approved = false;
+  const result = await handleOpenClawContextCleanCommand({
+    ctx: { sessionId: "session-demo" },
+    rawArgs: "",
+    backend: backend({
+      async analyze(sessionId: string) {
+        analyzedSessionId = sessionId;
+        return plan;
+      },
+      async approve() {
+        approved = true;
+        return appliedReceipt;
+      },
+    }),
+  });
+
+  assert.equal(analyzedSessionId, "session-demo");
+  assert.equal(approved, false);
+  assert.match(result.text, /Context clean plan: ctxclean-demo/);
+  assert.match(result.text, /\[-\] task-active/);
+  assert.match(result.text, /No changes applied/);
+});
+
+test("native clean forwards only the explicit plan task selection", async () => {
+  let approvedPlanId = "";
+  let approvedTaskIds: string[] = [];
+  const result = await handleOpenClawContextCleanCommand({
+    ctx: {},
+    rawArgs: "--plan ctxclean-demo --select task-done",
+    backend: backend({
+      async approve(planId: string, taskIds: string[]) {
+        approvedPlanId = planId;
+        approvedTaskIds = taskIds;
+        return appliedReceipt;
+      },
+    }),
+  });
+
+  assert.equal(approvedPlanId, "ctxclean-demo");
+  assert.deepEqual(approvedTaskIds, ["task-done"]);
+  assert.match(result.text, /Context clean applied/);
+  assert.match(result.text, /Released: 100 tok/);
+});
+
+test("native clean reads status and cancels through the canonical backend", async () => {
+  let statusPlanId = "";
+  let cancelledPlanId = "";
+  const cleanBackend = backend({
+    async readReceipt(planId: string) {
+      statusPlanId = planId;
+      return appliedReceipt;
+    },
+    async cancel(planId: string) {
+      cancelledPlanId = planId;
+      return {
+        ...appliedReceipt,
+        status: "cancelled",
+        appliedSavedTokens: undefined,
+        appliedSavedChars: undefined,
+        fallbackUsed: true,
+        evidence: undefined,
+        reasons: ["cancelled_by_user"],
+      };
+    },
+  });
+
+  const status = await handleOpenClawContextCleanCommand({
+    ctx: {}, rawArgs: "--status ctxclean-demo", backend: cleanBackend,
+  });
+  const cancelled = await handleOpenClawContextCleanCommand({
+    ctx: {}, rawArgs: "--cancel ctxclean-demo", backend: cleanBackend,
+  });
+
+  assert.equal(statusPlanId, "ctxclean-demo");
+  assert.equal(cancelledPlanId, "ctxclean-demo");
+  assert.match(status.text, /Context clean applied/);
+  assert.match(cancelled.text, /Context clean cancelled/);
+  assert.match(cancelled.text, /Recommendation fallback: used/);
+});
+
+test("native command registration preserves aliases and exposes clean help", async () => {
+  const registered: Array<{ name: string; handler(ctx: any): Promise<{ text: string }> }> = [];
+  const api = {
+    registerCommand(spec: any) { registered.push(spec); },
+    runtime: {
+      config: {
+        loadConfig: async () => ({}),
+        writeConfigFile: async () => undefined,
+      },
+    },
+  };
+  registerTokenPilotCommand(api, {});
+
+  assert.deepEqual(registered.map((spec) => spec.name), ["tokenpilot", "lightrsi", "tp"]);
+  const command = registered.find((spec) => spec.name === "lightrsi");
+  assert.ok(command);
+  const cleanHelp = await command.handler({ args: "clean --help" });
+  assert.match(cleanHelp.text, /\/lightrsi clean --plan/);
+  const generalHelp = await command.handler({ args: "help" });
+  assert.match(generalHelp.text, /Context Cleaner:/);
+});
+
+test("native clean handler returns actionable usage for invalid arguments", async () => {
+  const handler = createOpenClawContextCleanerCommandHandler({
+    loadConfig: async () => ({}),
+    createBackend: () => backend(),
+  });
+  const result = await handler({}, "--select task-done");
+  assert.match(result.text, /Context clean error: clean_plan_missing/);
+  assert.match(result.text, /\/lightrsi clean --status/);
+});

--- a/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.ts
@@ -16,6 +16,7 @@ import { ensureOpenClawCleanerTaskRegistry } from "../../context-cleaner/task-re
 import { normalizeConfig } from "../../context-stack/integration/config-normalize.js";
 import type { NormalizedPluginRuntimeConfig } from "../../context-stack/integration/config-types.js";
 import { resolveSessionIdFromCommandScope } from "../../session/command-scope-map.js";
+import { renderOpenClawCleanPlan } from "./context-cleaner-renderer.js";
 import { pluginConfigRecord } from "./host-config-adapter.js";
 
 type OpenClawCleanBackend = {
@@ -117,30 +118,6 @@ function count(tokens: number | null, chars: number): string {
   return tokens === null ? `${chars} chars` : `${tokens} tok`;
 }
 
-function renderPlan(plan: ContextCleanPlan): string {
-  const lines = [
-    `Context clean plan: ${plan.planId}`,
-    `Host/session: ${plan.hostId} / ${plan.sessionId}`,
-    `Context usage: ${count(plan.usedTokens, plan.usedChars)} (${plan.tokenCountMode})`,
-    "",
-    "Selectable tasks:",
-  ];
-  if (plan.tasks.length === 0) lines.push("- (none)");
-  for (const task of plan.tasks) {
-    const marker = task.selectable ? "[ ]" : "[-]";
-    const reasons = task.reasonCodes.length > 0 ? `; ${task.reasonCodes.join(", ")}` : "";
-    lines.push(
-      `- ${marker} ${task.taskId} | ${task.lifecycleState} | ${count(task.tokenCount, task.charCount)} | ${task.recommendation}${reasons}`,
-      `  ${task.description || task.label}`,
-    );
-  }
-  lines.push(
-    "",
-    `No changes applied. To clean selected tasks: /lightrsi clean --plan ${plan.planId} --select <task-id[,task-id...]>`,
-  );
-  return lines.join("\n");
-}
-
 function renderReceipt(receipt: ContextCleanReceipt): string {
   const lines = [
     `Context clean ${receipt.status}: ${receipt.planId}`,
@@ -148,13 +125,19 @@ function renderReceipt(receipt: ContextCleanReceipt): string {
     `Estimated savings: ${count(receipt.estimatedSavedTokens, receipt.estimatedSavedChars)}`,
   ];
   if (receipt.status === "applied") {
-    lines.push(`Released: ${count(receipt.appliedSavedTokens, receipt.appliedSavedChars)}`);
+    lines.push(`Applied savings: ${count(receipt.appliedSavedTokens, receipt.appliedSavedChars)}`);
+    lines.push(`Fallback count: ${receipt.fallbackUsed ? 1 : 0}`);
+    lines.push("Apply timing: immediate.");
   } else if (receipt.status === "scheduled") {
+    lines.push(`Scheduled savings: ${count(receipt.estimatedSavedTokens, receipt.estimatedSavedChars)}`);
+    lines.push("Applied savings: not applied");
+    lines.push(`Fallback count: ${receipt.fallbackUsed ? 1 : 0}`);
     lines.push("Apply timing: next Host request.");
+  } else {
+    lines.push(`Fallback count: ${receipt.fallbackUsed ? 1 : 0}`);
   }
   if (receipt.deferredTaskIds.length > 0) lines.push(`Deferred tasks: ${receipt.deferredTaskIds.join(", ")}`);
   if (receipt.reasons.length > 0) lines.push(`Reasons: ${receipt.reasons.join(", ")}`);
-  if (receipt.fallbackUsed) lines.push("Recommendation fallback: used");
   return lines.join("\n");
 }
 
@@ -273,7 +256,7 @@ export async function handleOpenClawContextCleanCommand(params: {
     ?? resolveSessionIdFromCommandScope(params.backend.stateDir, params.ctx, params.ctx?.commandBody)
     ?? directSessionId(params.ctx);
   if (!sessionId) throw new Error("clean_session_missing; use --session <session-id>");
-  return { text: renderPlan(await params.backend.analyze(sessionId)) };
+  return { text: renderOpenClawCleanPlan(await params.backend.analyze(sessionId)) };
 }
 
 export function createOpenClawContextCleanerCommandHandler(params: {

--- a/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.ts
@@ -6,11 +6,15 @@ import {
   readContextCleanPlan,
   type ContextCleanPlan,
   type ContextCleanReceipt,
+  type ContextCleanRecommendationProvider,
   type ContextCleanerHostBridge,
 } from "@lightrsi/cleaner";
+import type { JsonModelClient } from "@lightrsi/runtime-core";
 
 import { createOpenClawContextCleanerBridge } from "../../context-cleaner/index.js";
+import { ensureOpenClawCleanerTaskRegistry } from "../../context-cleaner/task-registry-bootstrap.js";
 import { normalizeConfig } from "../../context-stack/integration/config-normalize.js";
+import type { NormalizedPluginRuntimeConfig } from "../../context-stack/integration/config-types.js";
 import { resolveSessionIdFromCommandScope } from "../../session/command-scope-map.js";
 import { pluginConfigRecord } from "./host-config-adapter.js";
 
@@ -31,6 +35,24 @@ type ParsedCleanArgs = {
   cancel: boolean;
   help: boolean;
 };
+
+export function loadOpenClawContextCleanerConfig(
+  api: any,
+): Record<string, unknown> | Promise<Record<string, unknown>> {
+  const currentConfig = api?.config;
+  if (currentConfig && typeof currentConfig === "object" && !Array.isArray(currentConfig)) {
+    return currentConfig as Record<string, unknown>;
+  }
+
+  const legacyConfigApi = api?.runtime?.config;
+  if (typeof legacyConfigApi?.loadConfig === "function") {
+    return legacyConfigApi.loadConfig.call(legacyConfigApi) as
+      | Record<string, unknown>
+      | Promise<Record<string, unknown>>;
+  }
+
+  throw new Error("clean_config_unavailable");
+}
 
 export function formatOpenClawCleanUsage(): string {
   return [
@@ -140,7 +162,29 @@ function storeFailure(operation: string, reasons: string[]): never {
   throw new Error(`${operation}:${reasons.join(",") || "unknown"}`);
 }
 
-export function createOpenClawCleanBackend(currentConfig: Record<string, unknown>): OpenClawCleanBackend {
+export function createOpenClawCleanRecommendationProvider(
+  normalized: NormalizedPluginRuntimeConfig,
+  modelClient?: JsonModelClient,
+): ContextCleanRecommendationProvider | undefined {
+  const config = {
+    baseUrl: normalized.taskStateEstimator.baseUrl,
+    apiKey: normalized.taskStateEstimator.apiKey,
+    model: normalized.taskStateEstimator.model,
+    requestTimeoutMs: normalized.taskStateEstimator.requestTimeoutMs,
+  };
+  if (modelClient) {
+    return createApiContextCleanRecommendationProvider(config, () => modelClient);
+  }
+  return normalized.taskStateEstimator.enabled
+    ? createApiContextCleanRecommendationProvider(config)
+    : undefined;
+}
+
+export function createOpenClawCleanBackend(
+  currentConfig: Record<string, unknown>,
+  logger?: { warn?: (message: string) => void },
+  modelClient?: JsonModelClient,
+): OpenClawCleanBackend {
   const normalized = normalizeConfig(pluginConfigRecord(currentConfig));
   const stateDir = normalized.stateDir.trim();
   if (!stateDir) throw new Error("clean_state_dir_missing");
@@ -150,14 +194,7 @@ export function createOpenClawCleanBackend(currentConfig: Record<string, unknown
     controlPlane,
     config: { replacementMode: normalized.eviction.replacementMode },
   });
-  const provider = normalized.taskStateEstimator.enabled
-    ? createApiContextCleanRecommendationProvider({
-        baseUrl: normalized.taskStateEstimator.baseUrl,
-        apiKey: normalized.taskStateEstimator.apiKey,
-        model: normalized.taskStateEstimator.model,
-        requestTimeoutMs: normalized.taskStateEstimator.requestTimeoutMs,
-      })
-    : undefined;
+  const provider = createOpenClawCleanRecommendationProvider(normalized, modelClient);
 
   async function readPlan(planId: string): Promise<ContextCleanPlan | undefined> {
     const result = await readContextCleanPlan({ stateDir, planId });
@@ -168,6 +205,13 @@ export function createOpenClawCleanBackend(currentConfig: Record<string, unknown
   return {
     stateDir,
     async analyze(sessionId) {
+      await ensureOpenClawCleanerTaskRegistry({
+        currentConfig,
+        normalized,
+        sessionId,
+        logger,
+        modelClient,
+      });
       return (await analyzeContextCleanSession({ stateDir, bridge, sessionId, provider })).plan;
     },
     readPlan,
@@ -235,13 +279,22 @@ export async function handleOpenClawContextCleanCommand(params: {
 export function createOpenClawContextCleanerCommandHandler(params: {
   loadConfig(): Promise<Record<string, unknown>> | Record<string, unknown>;
   createBackend?: (currentConfig: Record<string, unknown>) => OpenClawCleanBackend;
+  logger?: { warn?: (message: string) => void };
+  createModelClient?: (ctx: any) => JsonModelClient | undefined;
 }) {
   return async (ctx: any, rawArgs: string): Promise<{ text: string }> => {
     if (["--help", "-h"].includes(rawArgs.trim())) {
       return { text: formatOpenClawCleanUsage() };
     }
     try {
-      const backend = (params.createBackend ?? createOpenClawCleanBackend)(await params.loadConfig());
+      const currentConfig = await params.loadConfig();
+      const backend = params.createBackend
+        ? params.createBackend(currentConfig)
+        : createOpenClawCleanBackend(
+            currentConfig,
+            params.logger,
+            params.createModelClient?.(ctx),
+          );
       return await handleOpenClawContextCleanCommand({ ctx, rawArgs, backend });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-command.ts
@@ -1,0 +1,251 @@
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  analyzeContextCleanSession,
+  createApiContextCleanRecommendationProvider,
+  createContextCleanerControlPlane,
+  readContextCleanPlan,
+  type ContextCleanPlan,
+  type ContextCleanReceipt,
+  type ContextCleanerHostBridge,
+} from "@lightrsi/cleaner";
+
+import { createOpenClawContextCleanerBridge } from "../../context-cleaner/index.js";
+import { normalizeConfig } from "../../context-stack/integration/config-normalize.js";
+import { resolveSessionIdFromCommandScope } from "../../session/command-scope-map.js";
+import { pluginConfigRecord } from "./host-config-adapter.js";
+
+type OpenClawCleanBackend = {
+  stateDir: string;
+  analyze(sessionId: string): Promise<ContextCleanPlan>;
+  readPlan(planId: string): Promise<ContextCleanPlan | undefined>;
+  approve(planId: string, selectedTaskIds: string[]): Promise<ContextCleanReceipt>;
+  readReceipt(planId: string): Promise<ContextCleanReceipt | undefined>;
+  cancel(planId: string): Promise<ContextCleanReceipt>;
+};
+
+type ParsedCleanArgs = {
+  sessionId?: string;
+  planId?: string;
+  selectedTaskIds?: string[];
+  status: boolean;
+  cancel: boolean;
+  help: boolean;
+};
+
+export function formatOpenClawCleanUsage(): string {
+  return [
+    "Context Cleaner:",
+    "  /lightrsi clean [--session <session-id>]",
+    "  /lightrsi clean --plan <plan-id> --select <task-id[,task-id...>]",
+    "  /lightrsi clean --status <plan-id>",
+    "  /lightrsi clean --cancel <plan-id>",
+    "The first command only analyzes. Cleaning requires an explicit task selection.",
+  ].join("\n");
+}
+
+function parseCleanArgs(rawArgs: string): ParsedCleanArgs {
+  const args = rawArgs.trim() ? rawArgs.trim().split(/\s+/) : [];
+  const parsed: ParsedCleanArgs = { status: false, cancel: false, help: false };
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--session" || argument === "--plan" || argument === "--select") {
+      const value = args[++index]?.trim();
+      if (!value || value.startsWith("--")) throw new Error(`clean_${argument.slice(2)}_missing`);
+      if (argument === "--session") {
+        if (parsed.sessionId) throw new Error("clean_session_duplicate");
+        parsed.sessionId = value;
+      } else if (argument === "--plan") {
+        if (parsed.planId) throw new Error("clean_plan_duplicate");
+        parsed.planId = value;
+      } else {
+        if (parsed.selectedTaskIds) throw new Error("clean_selection_duplicate_argument");
+        parsed.selectedTaskIds = value.split(",").map((taskId) => taskId.trim()).filter(Boolean);
+      }
+      continue;
+    }
+    if (argument === "--status" || argument === "--cancel") {
+      const field = argument === "--status" ? "status" : "cancel";
+      if (parsed[field]) throw new Error(`clean_${field}_duplicate`);
+      parsed[field] = true;
+      const possiblePlanId = args[index + 1]?.trim();
+      if (possiblePlanId && !possiblePlanId.startsWith("--")) {
+        index += 1;
+        if (parsed.planId && parsed.planId !== possiblePlanId) throw new Error("clean_plan_conflict");
+        parsed.planId = possiblePlanId;
+      }
+      continue;
+    }
+    if (argument === "--help" || argument === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    throw new Error(`clean_argument_unknown:${argument}`);
+  }
+
+  if (parsed.help && args.length > 1) throw new Error("clean_help_conflict");
+  const actions = Number(parsed.selectedTaskIds !== undefined) + Number(parsed.status) + Number(parsed.cancel);
+  if (actions > 1) throw new Error("clean_action_conflict");
+  if (actions > 0 && !parsed.planId) throw new Error("clean_plan_missing");
+  if (parsed.planId && actions === 0) throw new Error("clean_action_missing");
+  if (parsed.planId && parsed.sessionId) throw new Error("clean_session_plan_conflict");
+  return parsed;
+}
+
+function count(tokens: number | null, chars: number): string {
+  return tokens === null ? `${chars} chars` : `${tokens} tok`;
+}
+
+function renderPlan(plan: ContextCleanPlan): string {
+  const lines = [
+    `Context clean plan: ${plan.planId}`,
+    `Host/session: ${plan.hostId} / ${plan.sessionId}`,
+    `Context usage: ${count(plan.usedTokens, plan.usedChars)} (${plan.tokenCountMode})`,
+    "",
+    "Selectable tasks:",
+  ];
+  if (plan.tasks.length === 0) lines.push("- (none)");
+  for (const task of plan.tasks) {
+    const marker = task.selectable ? "[ ]" : "[-]";
+    const reasons = task.reasonCodes.length > 0 ? `; ${task.reasonCodes.join(", ")}` : "";
+    lines.push(
+      `- ${marker} ${task.taskId} | ${task.lifecycleState} | ${count(task.tokenCount, task.charCount)} | ${task.recommendation}${reasons}`,
+      `  ${task.description || task.label}`,
+    );
+  }
+  lines.push(
+    "",
+    `No changes applied. To clean selected tasks: /lightrsi clean --plan ${plan.planId} --select <task-id[,task-id...]>`,
+  );
+  return lines.join("\n");
+}
+
+function renderReceipt(receipt: ContextCleanReceipt): string {
+  const lines = [
+    `Context clean ${receipt.status}: ${receipt.planId}`,
+    `Selected tasks: ${receipt.selectedTaskIds.length > 0 ? receipt.selectedTaskIds.join(", ") : "(none)"}`,
+    `Estimated savings: ${count(receipt.estimatedSavedTokens, receipt.estimatedSavedChars)}`,
+  ];
+  if (receipt.status === "applied") {
+    lines.push(`Released: ${count(receipt.appliedSavedTokens, receipt.appliedSavedChars)}`);
+  } else if (receipt.status === "scheduled") {
+    lines.push("Apply timing: next Host request.");
+  }
+  if (receipt.deferredTaskIds.length > 0) lines.push(`Deferred tasks: ${receipt.deferredTaskIds.join(", ")}`);
+  if (receipt.reasons.length > 0) lines.push(`Reasons: ${receipt.reasons.join(", ")}`);
+  if (receipt.fallbackUsed) lines.push("Recommendation fallback: used");
+  return lines.join("\n");
+}
+
+function storeFailure(operation: string, reasons: string[]): never {
+  throw new Error(`${operation}:${reasons.join(",") || "unknown"}`);
+}
+
+export function createOpenClawCleanBackend(currentConfig: Record<string, unknown>): OpenClawCleanBackend {
+  const normalized = normalizeConfig(pluginConfigRecord(currentConfig));
+  const stateDir = normalized.stateDir.trim();
+  if (!stateDir) throw new Error("clean_state_dir_missing");
+  const controlPlane = createContextCleanerControlPlane({ stateDir });
+  const bridge: ContextCleanerHostBridge = createOpenClawContextCleanerBridge({
+    stateDir,
+    controlPlane,
+    config: { replacementMode: normalized.eviction.replacementMode },
+  });
+  const provider = normalized.taskStateEstimator.enabled
+    ? createApiContextCleanRecommendationProvider({
+        baseUrl: normalized.taskStateEstimator.baseUrl,
+        apiKey: normalized.taskStateEstimator.apiKey,
+        model: normalized.taskStateEstimator.model,
+        requestTimeoutMs: normalized.taskStateEstimator.requestTimeoutMs,
+      })
+    : undefined;
+
+  async function readPlan(planId: string): Promise<ContextCleanPlan | undefined> {
+    const result = await readContextCleanPlan({ stateDir, planId });
+    if (result.bypassed) storeFailure("clean_plan_unavailable", result.reasons);
+    return result.value?.plan;
+  }
+
+  return {
+    stateDir,
+    async analyze(sessionId) {
+      return (await analyzeContextCleanSession({ stateDir, bridge, sessionId, provider })).plan;
+    },
+    readPlan,
+    async approve(planId, selectedTaskIds) {
+      if (selectedTaskIds.length === 0) throw new Error("clean_selection_empty");
+      if (new Set(selectedTaskIds).size !== selectedTaskIds.length) {
+        throw new Error("clean_selection_duplicate_task");
+      }
+      const plan = await readPlan(planId);
+      if (!plan) throw new Error(`clean_plan_missing:${planId}`);
+      const tasksById = new Map(plan.tasks.map((task) => [task.taskId, task]));
+      const selectedTasks = selectedTaskIds.map((taskId) => {
+        const task = tasksById.get(taskId);
+        if (!task) throw new Error(`clean_selection_unknown_task:${taskId}`);
+        if (!task.selectable) throw new Error(`clean_selection_task_protected:${taskId}`);
+        return { taskId, itemIds: [...task.itemIds], itemDigests: { ...task.itemDigests } };
+      });
+      return bridge.executeApprovedClean({
+        schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+        cleanPlanId: plan.planId,
+        hostId: plan.hostId,
+        sessionId: plan.sessionId,
+        baseRevision: plan.baseRevision,
+        approvedAt: new Date().toISOString(),
+        selectedTasks,
+      });
+    },
+    readReceipt: (planId) => bridge.readCleanReceipt(planId),
+    cancel: (planId) => bridge.cancelCleanPlan(planId),
+  };
+}
+
+function directSessionId(ctx: any): string | undefined {
+  const candidates = [ctx?.sessionId, ctx?.session_id, ctx?.ctx?.SessionId, ctx?.ctx?.sessionId];
+  for (const candidate of candidates) {
+    const value = typeof candidate === "string" ? candidate.trim() : "";
+    if (value && !value.startsWith("agent:")) return value;
+  }
+  return undefined;
+}
+
+export async function handleOpenClawContextCleanCommand(params: {
+  ctx: any;
+  rawArgs: string;
+  backend: OpenClawCleanBackend;
+}): Promise<{ text: string }> {
+  const parsed = parseCleanArgs(params.rawArgs);
+  if (parsed.help) return { text: formatOpenClawCleanUsage() };
+  if (parsed.planId) {
+    if (parsed.status) {
+      const receipt = await params.backend.readReceipt(parsed.planId);
+      return { text: receipt ? renderReceipt(receipt) : `Context clean receipt not found: ${parsed.planId}` };
+    }
+    if (parsed.cancel) return { text: renderReceipt(await params.backend.cancel(parsed.planId)) };
+    return { text: renderReceipt(await params.backend.approve(parsed.planId, parsed.selectedTaskIds!)) };
+  }
+
+  const sessionId = parsed.sessionId
+    ?? resolveSessionIdFromCommandScope(params.backend.stateDir, params.ctx, params.ctx?.commandBody)
+    ?? directSessionId(params.ctx);
+  if (!sessionId) throw new Error("clean_session_missing; use --session <session-id>");
+  return { text: renderPlan(await params.backend.analyze(sessionId)) };
+}
+
+export function createOpenClawContextCleanerCommandHandler(params: {
+  loadConfig(): Promise<Record<string, unknown>> | Record<string, unknown>;
+  createBackend?: (currentConfig: Record<string, unknown>) => OpenClawCleanBackend;
+}) {
+  return async (ctx: any, rawArgs: string): Promise<{ text: string }> => {
+    if (["--help", "-h"].includes(rawArgs.trim())) {
+      return { text: formatOpenClawCleanUsage() };
+    }
+    try {
+      const backend = (params.createBackend ?? createOpenClawCleanBackend)(await params.loadConfig());
+      return await handleOpenClawContextCleanCommand({ ctx, rawArgs, backend });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { text: `Context clean error: ${message}\n\n${formatOpenClawCleanUsage()}` };
+    }
+  };
+}

--- a/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-renderer.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/context-cleaner-renderer.ts
@@ -1,0 +1,136 @@
+import type { ContextCleanPlan } from "@lightrsi/cleaner";
+
+function count(tokens: number | null, chars: number): string {
+  return tokens === null ? `${chars} chars` : `${tokens} tok`;
+}
+
+function codePointWidth(value: string): number {
+  const code = value.codePointAt(0) ?? 0;
+  if (code >= 0x300 && code <= 0x36f) return 0;
+  return code >= 0x1100 && (
+    code <= 0x115f
+    || code === 0x2329
+    || code === 0x232a
+    || (code >= 0x2e80 && code <= 0xa4cf && code !== 0x303f)
+    || (code >= 0xac00 && code <= 0xd7a3)
+    || (code >= 0xf900 && code <= 0xfaff)
+    || (code >= 0xfe10 && code <= 0xfe19)
+    || (code >= 0xfe30 && code <= 0xfe6f)
+    || (code >= 0xff00 && code <= 0xff60)
+    || (code >= 0xffe0 && code <= 0xffe6)
+    || (code >= 0x1f300 && code <= 0x1faff)
+    || (code >= 0x20000 && code <= 0x3fffd)
+  ) ? 2 : 1;
+}
+
+function displayWidth(value: string): number {
+  return [...value].reduce((width, character) => width + codePointWidth(character), 0);
+}
+
+function truncate(value: string, width: number): string {
+  if (displayWidth(value) <= width) return value;
+  const target = Math.max(0, width - 1);
+  let result = "";
+  let used = 0;
+  for (const character of value) {
+    const next = codePointWidth(character);
+    if (used + next > target) break;
+    result += character;
+    used += next;
+  }
+  return `${result}…`;
+}
+
+function cell(value: string, width: number): string {
+  const clipped = truncate(value, width);
+  return `${clipped}${" ".repeat(Math.max(0, width - displayWidth(clipped)))}`;
+}
+
+function share(plan: ContextCleanPlan, task: ContextCleanPlan["tasks"][number]): string {
+  if (task.tokenPercent !== null) return `${task.tokenPercent.toFixed(1)}%`;
+  return plan.usedChars > 0 ? `${(task.charCount / plan.usedChars * 100).toFixed(1)}% chars` : "-";
+}
+
+function risk(task: ContextCleanPlan["tasks"][number]): string {
+  if (!task.selectable || task.recommendation === "protected") return "blocked";
+  return task.recommendation === "clean" ? "low" : "caution";
+}
+
+function estimateRecommended(plan: ContextCleanPlan): { tokens: number | null; chars: number } {
+  const tasks = plan.tasks.filter(
+    (task) => task.selectable && task.recommendation === "clean",
+  );
+  return {
+    tokens: tasks.length === 0
+      ? (plan.usedTokens === null ? null : 0)
+      : tasks.every((task) => task.tokenCount !== null)
+        ? tasks.reduce((total, task) => total + (task.tokenCount ?? 0), 0)
+        : null,
+    chars: tasks.reduce((total, task) => total + task.charCount, 0),
+  };
+}
+
+export function renderOpenClawCleanPlan(plan: ContextCleanPlan): string {
+  // Keep the native OpenClaw Markdown response inside a typical 120-column
+  // TUI. Full task ids, descriptions, and reasons remain available below.
+  const widths = [3, 18, 22, 11, 11, 9, 18];
+  const format = (row: string[]): string => row
+    .map((value, index) => cell(value, widths[index]!))
+    .join("  ")
+    .trimEnd();
+  const rows = plan.tasks.map((task) => format([
+    task.selectable ? "[ ]" : "[-]",
+    task.taskId,
+    task.description || task.label,
+    count(task.tokenCount, task.charCount),
+    share(plan, task),
+    task.recommendation,
+    `${risk(task)}${task.reasonCodes.length > 0 ? `: ${task.reasonCodes.join(",")}` : ""}`,
+  ]));
+  const recommended = estimateRecommended(plan);
+  const selectable = plan.tasks.filter((task) => task.selectable);
+  const usage = plan.contextWindowTokens !== undefined
+    && plan.contextWindowTokens > 0
+    && plan.usedTokens !== null
+    ? `${plan.usedTokens} / ${plan.contextWindowTokens} tok (${(
+        plan.usedTokens / plan.contextWindowTokens * 100
+      ).toFixed(1)}%)`
+    : count(plan.usedTokens, plan.usedChars);
+
+  return [
+    `Context clean plan: ${plan.planId}`,
+    `Host/session: ${plan.hostId} / ${plan.sessionId}`,
+    `Context usage: ${usage} (${plan.tokenCountMode})`,
+    `Protected context: ${count(plan.protectedTokens, plan.protectedChars)}`,
+    `Unassigned context: ${count(plan.unassignedTokens, plan.unassignedChars)}`,
+    "",
+    "```text",
+    format(["", "TASK", "DESCRIPTION", "SIZE", "SHARE", "ADVICE", "RISK / REASONS"]),
+    format(widths.map((width) => "-".repeat(width))),
+    ...(rows.length > 0 ? rows : ["(no attributed tasks)"]),
+    "```",
+    "",
+    "Task details:",
+    ...(plan.tasks.length > 0
+      ? plan.tasks.map((task) => `- ${task.taskId}: ${task.description || task.label}`)
+      : ["- (none)"]),
+    "",
+    "Reason codes:",
+    ...(plan.tasks.length > 0
+      ? plan.tasks.map((task) => `- ${task.taskId}: ${task.reasonCodes.join(", ") || "(none)"}`)
+      : ["- (none)"]),
+    "",
+    `Recommended selection estimate: ${count(recommended.tokens, recommended.chars)}`,
+    "",
+    "Selectable tasks:",
+    "None selected by default.",
+    ...(selectable.length > 0
+      ? selectable.map((task, index) => `${index + 1}. ${task.taskId} - ${task.label}`)
+      : ["(none)"]),
+    "",
+    "Choose task IDs explicitly after reviewing this plan.",
+    "",
+    "No changes applied.",
+    `Apply selected tasks: /lightrsi clean --plan ${plan.planId} --select <task-id[,task-id...]>`,
+  ].join("\n");
+}

--- a/components/adapters/openclaw/src/commands/tokenpilot/host-config-adapter.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/host-config-adapter.ts
@@ -56,7 +56,7 @@ export const openClawProductSurfaceConfigAdapter: ProductSurfaceConfigAdapter = 
   ensurePluginEntry,
   resolveStateDir,
   setRuntimeHostDefaults(config) {
-    setNestedValue(config, CONTEXT_ENGINE_SLOT_ROOT, "layered-context");
+    setNestedValue(config, CONTEXT_ENGINE_SLOT_ROOT, "tokenpilot");
     const pluginCfg = ensurePluginConfig(config);
     setNestedValue(pluginCfg, ["contextEngine", "enabled"], true);
   },

--- a/components/adapters/openclaw/src/commands/tokenpilot/openclaw-doctor.test.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/openclaw-doctor.test.ts
@@ -14,7 +14,7 @@ function baseConfig(stateRoot: string): Record<string, unknown> {
     plugins: {
       allow: ["tokenpilot"],
       slots: {
-        contextEngine: "layered-context",
+        contextEngine: "tokenpilot",
       },
       entries: {
         tokenpilot: {
@@ -57,7 +57,7 @@ test("inspectOpenClawDoctor passes when release install invariants are present",
     const report = inspectOpenClawDoctor(baseConfig(join(root, ".openclaw")));
     assert.equal(report.ok, true);
     assert.equal(report.checks.every((check) => check.ok), true);
-    assert.match(formatOpenClawDoctorReport(report), /plugins\.slots\.contextEngine: layered-context/);
+    assert.match(formatOpenClawDoctorReport(report), /plugins\.slots\.contextEngine: tokenpilot/);
     assert.doesNotMatch(formatOpenClawDoctorReport(report), /Suggested fixes:/);
   } finally {
     delete process.env.OPENCLAW_STATE_DIR;
@@ -84,7 +84,7 @@ test("inspectOpenClawDoctor accepts a legacy state dir when the canonical dir ha
       plugins: {
         allow: ["tokenpilot"],
         slots: {
-          contextEngine: "layered-context",
+          contextEngine: "tokenpilot",
         },
         entries: {
           tokenpilot: {

--- a/components/adapters/openclaw/src/commands/tokenpilot/openclaw-doctor.ts
+++ b/components/adapters/openclaw/src/commands/tokenpilot/openclaw-doctor.ts
@@ -121,7 +121,7 @@ export function inspectOpenClawDoctor(currentConfig?: Record<string, unknown>): 
     },
     {
       key: "contextEngineSlot",
-      ok: contextEngineSlot === "layered-context",
+      ok: contextEngineSlot === "tokenpilot",
       detail: `plugins.slots.contextEngine: ${contextEngineSlot || "(unset)"}`,
     },
     {

--- a/components/adapters/openclaw/src/context-cleaner/bridge.test.ts
+++ b/components/adapters/openclaw/src/context-cleaner/bridge.test.ts
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+
+import {
+  analyzeContextCleanSession,
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  createContextCleanerControlPlane,
+  type ContextCleanPlan,
+  type ContextCleanReceipt,
+  type ExecuteApprovedContextCleanParams,
+} from "@lightrsi/cleaner";
+import {
+  createEmptySessionTaskRegistry,
+  loadCanonicalState,
+  persistSessionTaskRegistry,
+  saveCanonicalState,
+} from "@lightrsi/history";
+import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
+
+import { pluginStateSubdir } from "@lightrsi/artifact-store";
+import { createOpenClawContextCleanerBridge } from "./bridge.js";
+
+const SESSION_ID = "openclaw-clean-session";
+const NOW = "2026-08-31T00:01:00.000Z";
+
+function task(taskId: string, lifecycle: "active" | "evictable") {
+  return {
+    taskId,
+    title: taskId,
+    objective: `Objective for ${taskId}`,
+    lifecycle,
+    ...(lifecycle === "evictable" ? { evictableReason: "completed" } : {}),
+    completionEvidence: lifecycle === "evictable" ? ["delivered"] : [],
+    unresolvedQuestions: [],
+    span: {
+      firstTurnAbsId: `${taskId}-turn-1`,
+      lastTurnAbsId: `${taskId}-turn-1`,
+      supportingTurnAbsIds: [`${taskId}-turn-1`],
+      lastEstimatorTurnAbsId: `${taskId}-turn-1`,
+    },
+  };
+}
+
+function message(messageId: string, taskId: string, content: string, role = "assistant") {
+  return {
+    messageId,
+    role,
+    content,
+    details: {
+      contextSafe: {
+        taskIds: [taskId],
+        turnAbsId: `${taskId}-turn-1`,
+      },
+    },
+  };
+}
+
+async function seed(stateDir: string): Promise<void> {
+  await saveCanonicalState(stateDir, {
+    version: 1,
+    sessionId: SESSION_ID,
+    messages: [
+      message("completed-user", "task-completed", "Investigate the completed issue", "user"),
+      message("completed-answer", "task-completed", "The completed task delivered a detailed final result."),
+      message("active-user", "task-active", "Continue the active task", "user"),
+    ],
+    seenMessageIds: ["completed-user", "completed-answer", "active-user"],
+    updatedAt: "2026-08-31T00:00:00.000Z",
+  });
+  const registry = createEmptySessionTaskRegistry(SESSION_ID);
+  registry.tasks = {
+    "task-completed": task("task-completed", "evictable"),
+    "task-active": task("task-active", "active"),
+  };
+  registry.completedTaskIds = ["task-completed"];
+  registry.evictableTaskIds = ["task-completed"];
+  registry.activeTaskIds = ["task-active"];
+  await persistSessionTaskRegistry(stateDir, registry);
+}
+
+function approval(plan: ContextCleanPlan): ExecuteApprovedContextCleanParams {
+  const selected = plan.tasks.find((entry) => entry.taskId === "task-completed");
+  assert.ok(selected?.selectable);
+  return {
+    schemaVersion: CONTEXT_CLEAN_SCHEMA_VERSION,
+    cleanPlanId: plan.planId,
+    hostId: "openclaw",
+    sessionId: plan.sessionId,
+    baseRevision: plan.baseRevision,
+    approvedAt: NOW,
+    selectedTasks: [{
+      taskId: selected.taskId,
+      itemIds: [...selected.itemIds],
+      itemDigests: { ...selected.itemDigests },
+    }],
+  };
+}
+
+async function analyzed(stateDir: string) {
+  const controlPlane = createContextCleanerControlPlane({ stateDir, now: () => NOW });
+  const bridge = createOpenClawContextCleanerBridge({
+    stateDir,
+    controlPlane,
+    config: { replacementMode: "drop", now: () => NOW },
+  });
+  const result = await analyzeContextCleanSession({
+    stateDir,
+    bridge,
+    sessionId: SESSION_ID,
+  });
+  return { bridge, controlPlane, plan: result.plan };
+}
+
+test("lists canonical sessions and exposes a chars-only cleaner snapshot", async (context) => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-catalog-"));
+  context.after(() => rm(stateDir, { recursive: true, force: true }));
+  await seed(stateDir);
+  const { bridge } = await analyzed(stateDir);
+
+  assert.deepEqual(await bridge.listSessions(), [{
+    sessionId: SESSION_ID,
+    updatedAt: "2026-08-31T00:00:00.000Z",
+  }]);
+  const snapshot = await bridge.readCleanSnapshot(SESSION_ID);
+  assert.equal(snapshot.hostId, "openclaw");
+  assert.equal(snapshot.tokenCountMode, "chars_only");
+  assert.equal(snapshot.tokenCountMethod, "utf16_chars");
+  assert.equal(snapshot.items.length, 3);
+});
+
+test("applies an approved plan immediately, archives first, and persists an applied receipt", async (context) => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-apply-"));
+  context.after(() => rm(stateDir, { recursive: true, force: true }));
+  await seed(stateDir);
+  const { bridge, plan } = await analyzed(stateDir);
+  const request = approval(plan);
+
+  const receipt = await bridge.executeApprovedClean(request);
+
+  assert.equal(receipt.status, "applied");
+  if (receipt.status !== "applied") return;
+  assert.equal(receipt.appliedSavedTokens, null);
+  assert.ok(receipt.appliedSavedChars > 0);
+  assert.equal(receipt.evidence.previousRevision, plan.baseRevision);
+  assert.notEqual(receipt.evidence.nextRevision, plan.baseRevision);
+  assert.deepEqual(receipt.selectedTaskIds, ["task-completed"]);
+  assert.ok(receipt.evidence.itemIds.includes("completed-user"));
+
+  const state = await loadCanonicalState(stateDir, SESSION_ID);
+  assert.deepEqual(state?.messages.map((entry) => entry.messageId), ["active-user"]);
+  const archiveDir = pluginStateSubdir(stateDir, "canonical-eviction", "task");
+  assert.ok((await readdir(archiveDir)).some((name) => name.endsWith(".json")));
+  assert.equal((await bridge.readCleanReceipt(plan.planId))?.status, "applied");
+
+  const replayed = await bridge.executeApprovedClean(request);
+  assert.deepEqual(replayed, receipt);
+});
+
+test("marks a plan stale when canonical state changes after analysis", async (context) => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-stale-"));
+  context.after(() => rm(stateDir, { recursive: true, force: true }));
+  await seed(stateDir);
+  const { bridge, plan } = await analyzed(stateDir);
+  const state = await loadCanonicalState(stateDir, SESSION_ID);
+  assert.ok(state);
+  state.messages.push(message("new-active", "task-active", "A newer active turn", "user"));
+  state.seenMessageIds.push("new-active");
+  state.updatedAt = "2026-08-31T00:02:00.000Z";
+  await saveCanonicalState(stateDir, state);
+
+  const receipt = await bridge.executeApprovedClean(approval(plan));
+
+  assert.equal(receipt.status, "stale");
+  assert.ok(receipt.reasons.some((reason) => reason.includes("revision")));
+  assert.equal((await loadCanonicalState(stateDir, SESSION_ID))?.messages.length, 4);
+});
+
+test("serializes competing cleaner applies before scheduling either mutation", async (context) => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-lock-"));
+  context.after(() => rm(stateDir, { recursive: true, force: true }));
+  await seed(stateDir);
+  const { bridge, plan } = await analyzed(stateDir);
+  const key = createHash("sha256").update(SESSION_ID).digest("hex");
+  const lockDir = join(stateDir, "context-cleaner", "openclaw-locks");
+  await mkdir(lockDir, { recursive: true });
+  await writeFile(join(lockDir, `${key}.lock`), JSON.stringify({ pid: 1 }), "utf8");
+
+  await assert.rejects(
+    bridge.executeApprovedClean(approval(plan)),
+    /openclaw_clean_session_busy/,
+  );
+  assert.equal((await bridge.readCleanReceipt(plan.planId))?.status, "analyzed");
+});
+
+test("recovers an applied receipt when canonical persistence completed before receipt commit", async (context) => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-recovery-"));
+  context.after(() => rm(stateDir, { recursive: true, force: true }));
+  await seed(stateDir);
+  const { bridge, controlPlane, plan } = await analyzed(stateDir);
+  const request = approval(plan);
+  const scheduled = await controlPlane.executeApprovedClean(request);
+  assert.equal(scheduled.status, "scheduled");
+  if (scheduled.status !== "scheduled") return;
+
+  const before = await bridge.readCleanSnapshot(SESSION_ID);
+  const nextState = await loadCanonicalState(stateDir, SESSION_ID);
+  assert.ok(nextState);
+  nextState.messages = nextState.messages.filter((entry) => entry.messageId === "active-user");
+  nextState.updatedAt = "2026-08-31T00:03:00.000Z";
+  await saveCanonicalState(stateDir, nextState);
+  const after = await bridge.readCleanSnapshot(SESSION_ID);
+  const applied: ContextCleanReceipt = {
+    ...scheduled,
+    status: "applied",
+    appliedSavedTokens: null,
+    appliedSavedChars: 80,
+    fallbackUsed: false,
+    evidence: {
+      previousRevision: before.revision,
+      nextRevision: after.revision,
+      operationIds: ["recovered-operation"],
+      itemIds: ["completed-user", "completed-answer"],
+    },
+  };
+  const key = createHash("sha256").update(plan.planId).digest("hex");
+  const intentFile = join(stateDir, "context-cleaner", "openclaw-apply", `${key}.json`);
+  await writeJsonFileAtomic(intentFile, {
+    version: 1,
+    planId: plan.planId,
+    sessionId: SESSION_ID,
+    previousRevision: before.revision,
+    nextRevision: after.revision,
+    receipt: applied,
+  });
+
+  const recovered = await bridge.readCleanReceipt(plan.planId);
+
+  assert.deepEqual(recovered, applied);
+  await assert.rejects(readFile(intentFile, "utf8"), { code: "ENOENT" });
+});

--- a/components/adapters/openclaw/src/context-cleaner/bridge.ts
+++ b/components/adapters/openclaw/src/context-cleaner/bridge.ts
@@ -1,0 +1,549 @@
+import { createHash } from "node:crypto";
+import { mkdir, open, readFile, stat, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import {
+  CONTEXT_CLEAN_SCHEMA_VERSION,
+  createContextCleanerHostExecutionBridge,
+  type ContextCleanerControlPlane,
+  type ContextCleanerHostBridge,
+  type ContextCleanReceipt,
+  type ContextCleanScheduledReceipt,
+  type ExecuteApprovedContextCleanParams,
+} from "@lightrsi/cleaner";
+import {
+  loadCanonicalState,
+  loadSessionTaskRegistry,
+  canonicalStatePath,
+  type CanonicalTranscriptState,
+} from "@lightrsi/history";
+import { writeJsonFileAtomic } from "@lightrsi/host-adapter";
+
+import {
+  createOpenClawReferenceBackend,
+  type OpenClawReferenceBackendRequest,
+} from "../context-rewrite/reference-backend.js";
+import { appendTaskStateTrace } from "../trace/io.js";
+import { asRecord, extractPathLike, safeId } from "../context-stack/integration/config-types.js";
+import { contentToText } from "../context-stack/integration/runtime-event-text.js";
+import {
+  canonicalMessageTaskIds,
+  dedupeStrings,
+  ensureContextSafeDetails,
+  extractToolMessageText,
+  isToolResultLikeMessage,
+  messageToolCallId,
+} from "../context-stack/integration/runtime-tooling.js";
+import { listOpenClawCleanerSessions } from "./session-catalog.js";
+
+const OPENCLAW_HOST_ID = "openclaw";
+
+type OpenClawCleanerConfig = {
+  replacementMode?: "pointer_stub" | "drop";
+  now?: () => string;
+};
+
+type OpenClawApplyIntent = {
+  version: 1;
+  planId: string;
+  sessionId: string;
+  previousRevision: string;
+  nextRevision: string;
+  receipt: ContextCleanReceipt;
+};
+
+function intentPath(stateDir: string, planId: string): string {
+  const key = createHash("sha256").update(planId).digest("hex");
+  return join(stateDir, "context-cleaner", "openclaw-apply", `${key}.json`);
+}
+
+function sessionLockPath(stateDir: string, sessionId: string): string {
+  const key = createHash("sha256").update(sessionId).digest("hex");
+  return join(stateDir, "context-cleaner", "openclaw-locks", `${key}.lock`);
+}
+
+async function withSessionLock<T>(params: {
+  stateDir: string;
+  sessionId: string;
+  action(): Promise<T>;
+}): Promise<T> {
+  const path = sessionLockPath(params.stateDir, params.sessionId);
+  await mkdir(dirname(path), { recursive: true });
+  let handle;
+  try {
+    try {
+      handle = await open(path, "wx");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const ageMs = Date.now() - (await stat(path)).mtimeMs;
+      if (ageMs <= 5 * 60_000) throw new Error("openclaw_clean_session_busy");
+      await unlink(path);
+      handle = await open(path, "wx");
+    }
+    await handle.writeFile(JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }));
+    return await params.action();
+  } finally {
+    await handle?.close().catch(() => undefined);
+    if (handle) await unlink(path).catch(() => undefined);
+  }
+}
+
+async function readIntent(stateDir: string, planId: string): Promise<OpenClawApplyIntent | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(intentPath(stateDir, planId), "utf8")) as OpenClawApplyIntent;
+    if (parsed?.version !== 1
+      || parsed.planId !== planId
+      || typeof parsed.sessionId !== "string"
+      || typeof parsed.previousRevision !== "string"
+      || typeof parsed.nextRevision !== "string"
+      || !parsed.receipt
+      || parsed.receipt.planId !== planId
+      || parsed.receipt.status !== "applied") {
+      throw new Error("openclaw_clean_apply_intent_invalid");
+    }
+    return parsed;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+async function saveIntent(stateDir: string, intent: OpenClawApplyIntent): Promise<void> {
+  const path = intentPath(stateDir, intent.planId);
+  await mkdir(dirname(path), { recursive: true });
+  await writeJsonFileAtomic(path, intent);
+}
+
+async function removeIntent(stateDir: string, planId: string): Promise<void> {
+  await unlink(intentPath(stateDir, planId)).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== "ENOENT") throw error;
+  });
+}
+
+function canonicalTimestamp(value: string): boolean {
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function isScheduledReceipt(
+  receipt: ContextCleanReceipt,
+): receipt is ContextCleanScheduledReceipt {
+  return receipt.status === "scheduled";
+}
+
+function uniqueStrings(values: readonly string[]): string[] | undefined {
+  const normalized = values.map((value) => value.trim());
+  return normalized.every(Boolean) && new Set(normalized).size === normalized.length
+    ? normalized
+    : undefined;
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  const expected = [...left].sort();
+  const actual = [...right].sort();
+  return expected.length === actual.length
+    && expected.every((value, index) => value === actual[index]);
+}
+
+function validNonNegativeInteger(value: unknown): boolean {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function validateReceipt(params: {
+  receipt: ContextCleanReceipt;
+  planId: string;
+  sessionId?: string;
+  selectedTaskIds?: string[];
+}): ContextCleanReceipt {
+  const { receipt } = params;
+  if (receipt.schemaVersion !== CONTEXT_CLEAN_SCHEMA_VERSION
+    || receipt.hostId !== OPENCLAW_HOST_ID
+    || receipt.planId !== params.planId
+    || (params.sessionId !== undefined && receipt.sessionId !== params.sessionId)
+    || !canonicalTimestamp(receipt.updatedAt)
+    || !uniqueStrings(receipt.selectedTaskIds)
+    || !uniqueStrings(receipt.deferredTaskIds)
+    || (receipt.estimatedSavedTokens !== null
+      && !validNonNegativeInteger(receipt.estimatedSavedTokens))
+    || !validNonNegativeInteger(receipt.estimatedSavedChars)) {
+    throw new Error("openclaw_clean_receipt_mismatch");
+  }
+  if (params.selectedTaskIds
+    && !sameStrings(receipt.selectedTaskIds, params.selectedTaskIds)) {
+    throw new Error("openclaw_clean_receipt_mismatch");
+  }
+  if (receipt.status === "applied") {
+    if (receipt.fallbackUsed
+      || (receipt.appliedSavedTokens !== null
+        && !validNonNegativeInteger(receipt.appliedSavedTokens))
+      || !validNonNegativeInteger(receipt.appliedSavedChars)
+      || !receipt.evidence.previousRevision.trim()
+      || !receipt.evidence.nextRevision.trim()
+      || !uniqueStrings(receipt.evidence.operationIds)?.length
+      || !uniqueStrings(receipt.evidence.itemIds)?.length) {
+      throw new Error("openclaw_clean_receipt_mismatch");
+    }
+  } else {
+    const record = receipt as unknown as Record<string, unknown>;
+    if (Object.hasOwn(record, "appliedSavedTokens")
+      || Object.hasOwn(record, "appliedSavedChars")) {
+      throw new Error("openclaw_clean_receipt_mismatch");
+    }
+  }
+  return receipt;
+}
+
+function validateApproval(request: ExecuteApprovedContextCleanParams): string[] {
+  if (request.schemaVersion !== CONTEXT_CLEAN_SCHEMA_VERSION) {
+    throw new Error("openclaw_clean_approval_schema_mismatch");
+  }
+  if (request.hostId !== OPENCLAW_HOST_ID) {
+    throw new Error("openclaw_clean_approval_host_mismatch");
+  }
+  if (!request.cleanPlanId.trim()
+    || !request.sessionId.trim()
+    || !request.baseRevision.trim()
+    || !canonicalTimestamp(request.approvedAt)
+    || request.selectedTasks.length === 0) {
+    throw new Error("openclaw_clean_approval_invalid");
+  }
+  const taskIds = uniqueStrings(request.selectedTasks.map((task) => task.taskId));
+  if (!taskIds) throw new Error("openclaw_clean_approval_invalid");
+  const claimedItemIds = new Set<string>();
+  for (const task of request.selectedTasks) {
+    const itemIds = uniqueStrings(task.itemIds);
+    if (!itemIds || itemIds.length === 0 || Object.keys(task.itemDigests).length !== itemIds.length) {
+      throw new Error("openclaw_clean_approval_targets_invalid");
+    }
+    for (const itemId of itemIds) {
+      if (claimedItemIds.has(itemId) || !task.itemDigests[itemId]?.trim()) {
+        throw new Error("openclaw_clean_approval_targets_invalid");
+      }
+      claimedItemIds.add(itemId);
+    }
+  }
+  return taskIds;
+}
+
+function createRequest(params: {
+  stateDir: string;
+  state: CanonicalTranscriptState;
+  replacementMode: "pointer_stub" | "drop";
+}): OpenClawReferenceBackendRequest {
+  return {
+    stateDir: params.stateDir,
+    sessionId: params.state.sessionId,
+    state: params.state,
+    evictionEnabled: true,
+    evictionPolicy: "model_scored",
+    evictionMinBlockChars: 0,
+    evictionReplacementMode: params.replacementMode,
+    helpers: {
+      appendTaskStateTrace,
+      asRecord,
+      canonicalMessageTaskIds: (message) => canonicalMessageTaskIds(message, asRecord),
+      contentToText,
+      dedupeStrings,
+      ensureContextSafeDetails,
+      extractPathLike,
+      extractToolMessageText,
+      isToolResultLikeMessage,
+      messageToolCallId,
+      safeId,
+      logger: { info: () => undefined },
+    },
+  };
+}
+
+function terminalReceipt(params: {
+  scheduled: ContextCleanScheduledReceipt;
+  status: "stale" | "failed";
+  reasons: string[];
+  now: () => string;
+}): ContextCleanReceipt {
+  return {
+    ...params.scheduled,
+    status: params.status,
+    reasons: params.reasons.length > 0 ? params.reasons : [`openclaw_clean_${params.status}`],
+    updatedAt: params.now(),
+  };
+}
+
+function targetItemIds(params: {
+  operationIds: readonly string[];
+  mutationPlan: { operations: Array<{ id: string; targetItemIds: string[] }> };
+}): string[] {
+  const applied = new Set(params.operationIds);
+  return dedupeStrings(params.mutationPlan.operations
+    .filter((operation) => applied.has(operation.id))
+    .flatMap((operation) => operation.targetItemIds));
+}
+
+export function createOpenClawContextCleanerBridge(params: {
+  stateDir: string;
+  controlPlane: ContextCleanerControlPlane;
+  config?: OpenClawCleanerConfig;
+}): ContextCleanerHostBridge {
+  if (!params.stateDir.trim()) throw new Error("openclaw_clean_state_dir_missing");
+  const now = params.config?.now ?? (() => new Date().toISOString());
+  const replacementMode = params.config?.replacementMode === "drop" ? "drop" : "pointer_stub";
+  const backend = createOpenClawReferenceBackend();
+
+  async function readState(sessionId: string): Promise<CanonicalTranscriptState> {
+    const state = await loadCanonicalState(params.stateDir, sessionId);
+    if (!state) throw new Error("openclaw_clean_session_not_found");
+    if (!canonicalTimestamp(state.updatedAt)) throw new Error("openclaw_clean_snapshot_timestamp_invalid");
+    return state;
+  }
+
+  async function readSnapshot(sessionId: string) {
+    const state = await readState(sessionId);
+    const request = createRequest({ stateDir: params.stateDir, state, replacementMode });
+    const { adapterMetadata: _adapterMetadata, ...snapshot } = await backend.readSnapshot({
+      sessionId,
+      request,
+    });
+    return {
+      ...snapshot,
+      capturedAt: state.updatedAt,
+      tokenCountMode: "chars_only" as const,
+      tokenCountMethod: "utf16_chars",
+    };
+  }
+
+  const executionBridge = createContextCleanerHostExecutionBridge({
+    stateDir: params.stateDir,
+    hostId: OPENCLAW_HOST_ID,
+    async readExecutionSnapshot(sessionId) {
+      const [snapshot, registry] = await Promise.all([
+        readSnapshot(sessionId),
+        loadSessionTaskRegistry(params.stateDir, sessionId),
+      ]);
+      return {
+        snapshot,
+        activeTaskIds: registry.activeTaskIds,
+        evictableTaskIds: registry.evictableTaskIds,
+      };
+    },
+  });
+
+  async function record(receipt: ContextCleanReceipt): Promise<ContextCleanReceipt> {
+    const stored = await executionBridge.recordCleanReceipt(receipt);
+    if (stored.bypassed) {
+      throw new Error(`openclaw_clean_receipt_store_failed:${stored.reasons.join(",")}`);
+    }
+    return receipt;
+  }
+
+  async function recoverIntent(
+    scheduled: ContextCleanScheduledReceipt,
+  ): Promise<ContextCleanReceipt | undefined> {
+    const intent = await readIntent(params.stateDir, scheduled.planId);
+    if (!intent) return undefined;
+    if (intent.sessionId !== scheduled.sessionId) {
+      throw new Error("openclaw_clean_apply_intent_identity_mismatch");
+    }
+    const state = await readState(scheduled.sessionId);
+    const current = await backend.readSnapshot({
+      sessionId: scheduled.sessionId,
+      request: createRequest({ stateDir: params.stateDir, state, replacementMode }),
+    });
+    if (current.revision === intent.nextRevision) {
+      const receipt = await record(intent.receipt);
+      await removeIntent(params.stateDir, scheduled.planId);
+      return receipt;
+    }
+    if (current.revision === intent.previousRevision) {
+      await removeIntent(params.stateDir, scheduled.planId);
+      return undefined;
+    }
+    await removeIntent(params.stateDir, scheduled.planId);
+    return record(terminalReceipt({
+      scheduled,
+      status: "stale",
+      reasons: ["openclaw_clean_revision_stale"],
+      now,
+    }));
+  }
+
+  return {
+    hostId: OPENCLAW_HOST_ID,
+    rewriteMode: "canonical",
+    listSessions() {
+      return listOpenClawCleanerSessions(params.stateDir);
+    },
+    readCleanSnapshot: readSnapshot,
+    async executeApprovedClean(request) {
+      const selectedTaskIds = validateApproval(request);
+      return withSessionLock({
+        stateDir: params.stateDir,
+        sessionId: request.sessionId,
+        action: async () => {
+          const scheduled = validateReceipt({
+            receipt: await params.controlPlane.executeApprovedClean(request),
+            planId: request.cleanPlanId,
+            sessionId: request.sessionId,
+            selectedTaskIds,
+          });
+          if (!isScheduledReceipt(scheduled)) {
+            await removeIntent(params.stateDir, request.cleanPlanId).catch(() => undefined);
+            return scheduled;
+          }
+
+          const recovered = await recoverIntent(scheduled);
+          if (recovered) return recovered;
+
+      const prepared = await executionBridge.prepareScheduledClean({
+        cleanPlanId: request.cleanPlanId,
+        sessionId: request.sessionId,
+        baseRevision: request.baseRevision,
+        selectedTaskIds,
+      });
+      if (prepared.outcome === "terminal") return prepared.receipt;
+      if (prepared.outcome !== "ready") {
+        const stale = prepared.reasons.some((reason) =>
+          reason.includes("stale") || reason.includes("revision") || reason.includes("state_changed"));
+        return record(terminalReceipt({
+          scheduled,
+          status: stale ? "stale" : "failed",
+          reasons: prepared.reasons,
+          now,
+        }));
+      }
+
+      const state = await readState(request.sessionId);
+      const backendRequest = createRequest({ stateDir: params.stateDir, state, replacementMode });
+      const snapshot = await backend.readSnapshot({ sessionId: request.sessionId, request: backendRequest });
+      if (snapshot.revision !== request.baseRevision) {
+        return record(terminalReceipt({
+          scheduled,
+          status: "stale",
+          reasons: ["openclaw_clean_revision_stale"],
+          now,
+        }));
+      }
+
+      const applied = await backend.apply({
+        snapshot,
+        plan: prepared.execution.mutationPlan,
+        request: backendRequest,
+      });
+      if (!applied.result.applied || !applied.result.changed) {
+        return record(terminalReceipt({
+          scheduled,
+          status: applied.result.fallbackUsed ? "failed" : "stale",
+          reasons: applied.result.fallbackUsed
+            ? ["openclaw_clean_canonical_rewrite_failed"]
+            : ["openclaw_clean_no_applicable_targets"],
+          now,
+        }));
+      }
+
+      const appliedTaskIds = applied.result.details?.appliedTaskIds ?? [];
+      const deferredTaskIds = selectedTaskIds.filter((taskId) => !appliedTaskIds.includes(taskId));
+      const receipt: ContextCleanReceipt = {
+        ...scheduled,
+        status: "applied",
+        appliedSavedTokens: null,
+        appliedSavedChars: applied.result.savedChars,
+        deferredTaskIds,
+        reasons: deferredTaskIds.length > 0 ? ["openclaw_clean_targets_deferred"] : [],
+        updatedAt: now(),
+        fallbackUsed: false,
+        evidence: {
+          previousRevision: applied.result.previousRevision,
+          nextRevision: applied.result.nextRevision,
+          operationIds: [...applied.result.appliedOperationIds],
+          itemIds: targetItemIds({
+            operationIds: applied.result.appliedOperationIds,
+            mutationPlan: prepared.execution.mutationPlan,
+          }),
+        },
+      };
+      await saveIntent(params.stateDir, {
+        version: 1,
+        planId: scheduled.planId,
+        sessionId: scheduled.sessionId,
+        previousRevision: applied.result.previousRevision,
+        nextRevision: applied.result.nextRevision,
+        receipt,
+      });
+
+      const latest = await readState(request.sessionId);
+      const latestSnapshot = await backend.readSnapshot({
+        sessionId: request.sessionId,
+        request: createRequest({ stateDir: params.stateDir, state: latest, replacementMode }),
+      });
+      if (latestSnapshot.revision !== request.baseRevision) {
+        await removeIntent(params.stateDir, scheduled.planId);
+        return record(terminalReceipt({
+          scheduled,
+          status: "stale",
+          reasons: ["openclaw_clean_revision_stale"],
+          now,
+        }));
+      }
+
+      await writeJsonFileAtomic(
+        canonicalStatePath(params.stateDir, request.sessionId),
+        applied.request.state,
+      );
+      const storedReceipt = await record(receipt);
+      await removeIntent(params.stateDir, scheduled.planId).catch(() => undefined);
+      return storedReceipt;
+        },
+      });
+    },
+    async readCleanReceipt(planId) {
+      if (!planId.trim()) throw new Error("openclaw_clean_plan_id_invalid");
+      const receipt = await params.controlPlane.readCleanReceipt(planId);
+      if (!receipt) return undefined;
+      const validated = validateReceipt({ receipt, planId });
+      if (!isScheduledReceipt(validated)) return validated;
+      try {
+        return await withSessionLock({
+          stateDir: params.stateDir,
+          sessionId: validated.sessionId,
+          action: async () => {
+            const current = await params.controlPlane.readCleanReceipt(planId);
+            if (!current) return undefined;
+            const latest = validateReceipt({ receipt: current, planId });
+            if (!isScheduledReceipt(latest)) return latest;
+            return await recoverIntent(latest) ?? latest;
+          },
+        });
+      } catch (error) {
+        if ((error as Error).message === "openclaw_clean_session_busy") return validated;
+        throw error;
+      }
+    },
+    async cancelCleanPlan(planId) {
+      if (!planId.trim()) throw new Error("openclaw_clean_plan_id_invalid");
+      const current = await params.controlPlane.readCleanReceipt(planId);
+      if (!current) {
+        return validateReceipt({
+          receipt: await params.controlPlane.cancelCleanPlan(planId),
+          planId,
+        });
+      }
+      const validated = validateReceipt({ receipt: current, planId });
+      return withSessionLock({
+        stateDir: params.stateDir,
+        sessionId: validated.sessionId,
+        action: async () => {
+          const latestValue = await params.controlPlane.readCleanReceipt(planId);
+          if (!latestValue) throw new Error("openclaw_clean_receipt_missing");
+          const latest = validateReceipt({ receipt: latestValue, planId });
+          if (isScheduledReceipt(latest)) {
+            const recovered = await recoverIntent(latest);
+            if (recovered) return recovered;
+          }
+          return validateReceipt({
+            receipt: await params.controlPlane.cancelCleanPlan(planId),
+            planId,
+          });
+        },
+      });
+    },
+  };
+}

--- a/components/adapters/openclaw/src/context-cleaner/index.ts
+++ b/components/adapters/openclaw/src/context-cleaner/index.ts
@@ -1,0 +1,2 @@
+export * from "./bridge.js";
+export * from "./session-catalog.js";

--- a/components/adapters/openclaw/src/context-cleaner/session-catalog.ts
+++ b/components/adapters/openclaw/src/context-cleaner/session-catalog.ts
@@ -1,0 +1,52 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  canonicalStateDir,
+  type CanonicalTranscriptState,
+} from "@lightrsi/history";
+import type { ContextCleanerSession } from "@lightrsi/cleaner";
+
+function isCanonicalState(value: unknown): value is CanonicalTranscriptState {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const state = value as Partial<CanonicalTranscriptState>;
+  return state.version === 1
+    && typeof state.sessionId === "string"
+    && Boolean(state.sessionId.trim())
+    && Array.isArray(state.messages)
+    && Array.isArray(state.seenMessageIds)
+    && typeof state.updatedAt === "string"
+    && Number.isFinite(Date.parse(state.updatedAt));
+}
+
+export async function listOpenClawCleanerSessions(
+  stateDir: string,
+): Promise<ContextCleanerSession[]> {
+  const root = canonicalStateDir(stateDir);
+  let names: string[];
+  try {
+    names = await readdir(root);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+
+  const sessions = await Promise.all(names
+    .filter((name) => name.endsWith(".json"))
+    .map(async (name): Promise<ContextCleanerSession | undefined> => {
+      try {
+        const parsed: unknown = JSON.parse(await readFile(join(root, name), "utf8"));
+        if (!isCanonicalState(parsed)) return undefined;
+        return { sessionId: parsed.sessionId, updatedAt: parsed.updatedAt };
+      } catch {
+        return undefined;
+      }
+    }));
+
+  return sessions
+    .filter((session): session is ContextCleanerSession => session !== undefined)
+    .sort((left, right) => {
+      const byTime = Date.parse(right.updatedAt ?? "") - Date.parse(left.updatedAt ?? "");
+      return byTime || left.sessionId.localeCompare(right.sessionId);
+    });
+}

--- a/components/adapters/openclaw/src/context-cleaner/task-registry-bootstrap.test.ts
+++ b/components/adapters/openclaw/src/context-cleaner/task-registry-bootstrap.test.ts
@@ -260,3 +260,83 @@ test("cleaner task bootstrap uses a Host-managed model client without provider c
     await rm(stateDir, { recursive: true, force: true });
   }
 });
+
+test("cleaner task bootstrap keeps first-seen historical tasks emitted as evictable", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-first-seen-evictable-"));
+  const sessionId = "session-cleaner-first-seen-evictable";
+  const taskA = `${sessionId}:t1-task`;
+  const taskB = `${sessionId}:t2-task`;
+  const taskC = `${sessionId}:t3-task`;
+  try {
+    const messages = [
+      { role: "user", content: "Task A" },
+      { role: "assistant", content: "Task A is complete." },
+      { role: "user", content: "Task B" },
+      { role: "assistant", content: "Task B is complete." },
+      { role: "user", content: "Task C" },
+      { role: "assistant", content: "Task C is blocked pending approval." },
+    ];
+    await saveCanonicalState(stateDir, {
+      version: 1,
+      sessionId,
+      messages,
+      seenMessageIds: messages.map((_, index) => `m${index + 1}`),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const registry = await ensureOpenClawCleanerTaskRegistry({
+      currentConfig: {
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      },
+      normalized: normalizeConfig({ stateDir }),
+      sessionId,
+      modelClient: {
+        async request() {
+          return {
+            text: JSON.stringify({
+              baseVersion: 0,
+              taskUpdates: [
+                {
+                  taskId: taskA,
+                  objective: "Complete Task A.",
+                  lifecycle: "evictable",
+                  coveredTurnAbsIds: [`${sessionId}:t1`],
+                  completionEvidence: ["Task A is complete."],
+                  unresolvedQuestions: [],
+                  evictableReason: "The session moved on to Task B.",
+                },
+                {
+                  taskId: taskB,
+                  objective: "Complete Task B.",
+                  lifecycle: "evictable",
+                  coveredTurnAbsIds: [`${sessionId}:t2`],
+                  completionEvidence: ["Task B is complete."],
+                  unresolvedQuestions: [],
+                  evictableReason: "The session moved on to Task C.",
+                },
+                {
+                  taskId: taskC,
+                  objective: "Complete Task C after approval.",
+                  lifecycle: "blocked",
+                  coveredTurnAbsIds: [`${sessionId}:t3`],
+                  completionEvidence: [],
+                  unresolvedQuestions: ["Approval is pending."],
+                  currentSubgoal: "Wait for approval.",
+                },
+              ],
+            }),
+          };
+        },
+      },
+    });
+
+    assert.deepEqual(Object.keys(registry.tasks), [taskA, taskB, taskC]);
+    assert.deepEqual(registry.evictableTaskIds, [taskA, taskB]);
+    assert.equal(registry.tasks[taskC]?.lifecycle, "blocked");
+    assert.deepEqual(registry.turnToTaskIds[`${sessionId}:t1`], [taskA]);
+    assert.deepEqual(registry.turnToTaskIds[`${sessionId}:t2`], [taskB]);
+    assert.deepEqual(registry.turnToTaskIds[`${sessionId}:t3`], [taskC]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/components/adapters/openclaw/src/context-cleaner/task-registry-bootstrap.test.ts
+++ b/components/adapters/openclaw/src/context-cleaner/task-registry-bootstrap.test.ts
@@ -1,0 +1,262 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  createEmptySessionTaskRegistry,
+  loadCanonicalState,
+  listRawSemanticTurnSeqs,
+  persistSessionTaskRegistry,
+  saveCanonicalState,
+} from "@lightrsi/history";
+
+import { normalizeConfig } from "../context-stack/integration/config-normalize.js";
+import { ensureOpenClawCleanerTaskRegistry } from "./task-registry-bootstrap.js";
+
+test("cleaner bootstraps task state from canonical runtime messages", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-task-bootstrap-"));
+  const sessionId = "session-cleaner-bootstrap";
+  try {
+    const messages = [
+      { role: "user", content: "task one" },
+      { role: "assistant", content: "task one complete" },
+      { role: "user", content: "task two" },
+      { role: "assistant", content: "task two complete" },
+      { role: "user", content: "task three" },
+      { role: "assistant", content: "task three complete" },
+    ];
+    await saveCanonicalState(stateDir, {
+      version: 1,
+      sessionId,
+      messages,
+      seenMessageIds: messages.map((_, index) => `m${index + 1}`),
+      updatedAt: new Date().toISOString(),
+    });
+
+    let receivedPolicyConfig: any;
+    const registry = await ensureOpenClawCleanerTaskRegistry({
+      currentConfig: {
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      },
+      normalized: normalizeConfig({ stateDir }),
+      sessionId,
+      dependencies: {
+        detectUpstreamConfig: async () => ({
+          providerId: "deepseek",
+          baseUrl: "https://api.example.test/v1",
+          apiKey: "test-key",
+          apiFamily: "openai-completions",
+          models: [{
+            id: "deepseek-v4-flash",
+            name: "DeepSeek V4 Flash",
+            reasoning: false,
+            input: ["text"],
+            contextWindow: 1_000_000,
+            maxTokens: 8_192,
+          }],
+        }),
+        createPolicyModule: ((config: any) => {
+          receivedPolicyConfig = config;
+          return {
+            name: "test-policy",
+            async beforeBuild(context: any) {
+              const next = createEmptySessionTaskRegistry(sessionId);
+              next.version = 1;
+              next.tasks["task-one"] = {
+                taskId: "task-one",
+                title: "Task one",
+                objective: "Complete task one",
+                lifecycle: "evictable",
+                evictableReason: "A newer task replaced it.",
+                completionEvidence: ["Delivered task one"],
+                unresolvedQuestions: [],
+                span: {
+                  firstTurnAbsId: `${sessionId}:t1`,
+                  lastTurnAbsId: `${sessionId}:t1`,
+                  supportingTurnAbsIds: [`${sessionId}:t1`],
+                  lastEstimatorTurnAbsId: `${sessionId}:t3`,
+                },
+              };
+              next.evictableTaskIds = ["task-one"];
+              next.turnToTaskIds = {
+                [`${sessionId}:t1`]: ["task-one"],
+                [`${sessionId}:t2`]: ["task-one"],
+                [`${sessionId}:t3`]: ["task-one"],
+              };
+              next.lastProcessedTurnSeq = 3;
+              await persistSessionTaskRegistry(stateDir, next);
+              return context;
+            },
+          };
+        }) as any,
+      },
+    });
+
+    assert.deepEqual(await listRawSemanticTurnSeqs(stateDir, sessionId), [1, 2, 3]);
+    assert.equal(receivedPolicyConfig.taskStateEstimator.enabled, true);
+    assert.equal(receivedPolicyConfig.taskStateEstimator.batchTurns, 3);
+    assert.equal(receivedPolicyConfig.taskStateEstimator.model, "deepseek-v4-flash");
+    assert.deepEqual(registry.evictableTaskIds, ["task-one"]);
+    const annotated = await loadCanonicalState(stateDir, sessionId);
+    assert.deepEqual(
+      annotated?.messages.map((message) => message.details?.contextSafe?.taskIds),
+      messages.map(() => ["task-one"]),
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("cleaner task bootstrap fails closed when no model provider is available", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-task-bootstrap-fallback-"));
+  const sessionId = "session-cleaner-no-provider";
+  try {
+    await saveCanonicalState(stateDir, {
+      version: 1,
+      sessionId,
+      messages: [{ role: "user", content: "unfinished work" }],
+      seenMessageIds: ["m1"],
+      updatedAt: new Date().toISOString(),
+    });
+    const registry = await ensureOpenClawCleanerTaskRegistry({
+      currentConfig: {},
+      normalized: normalizeConfig({ stateDir }),
+      sessionId,
+      dependencies: { detectUpstreamConfig: async () => null },
+    });
+    assert.deepEqual(registry.tasks, {});
+    assert.deepEqual(registry.evictableTaskIds, []);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("cleaner task bootstrap classifies only turns added after an existing registry", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-task-bootstrap-incremental-"));
+  const sessionId = "session-cleaner-incremental";
+  try {
+    const messages = [
+      { role: "user", content: "task one" },
+      { role: "assistant", content: "task one complete" },
+      { role: "user", content: "task two" },
+      { role: "assistant", content: "task two complete" },
+      { role: "user", content: "task three" },
+      { role: "assistant", content: "task three complete" },
+    ];
+    await saveCanonicalState(stateDir, {
+      version: 1,
+      sessionId,
+      messages,
+      seenMessageIds: messages.map((_, index) => `m${index + 1}`),
+      updatedAt: new Date().toISOString(),
+    });
+    const existing = createEmptySessionTaskRegistry(sessionId);
+    existing.version = 1;
+    existing.lastProcessedTurnSeq = 1;
+    existing.tasks["task-one"] = {
+      taskId: "task-one",
+      title: "Task one",
+      objective: "Complete task one",
+      lifecycle: "completed",
+      completionEvidence: ["Delivered task one"],
+      unresolvedQuestions: [],
+      span: {
+        firstTurnAbsId: `${sessionId}:t1`,
+        lastTurnAbsId: `${sessionId}:t1`,
+        supportingTurnAbsIds: [`${sessionId}:t1`],
+        lastEstimatorTurnAbsId: `${sessionId}:t1`,
+      },
+    };
+    existing.completedTaskIds = ["task-one"];
+    existing.turnToTaskIds = { [`${sessionId}:t1`]: ["task-one"] };
+    await persistSessionTaskRegistry(stateDir, existing);
+
+    let receivedBatchTurns = 0;
+    await ensureOpenClawCleanerTaskRegistry({
+      currentConfig: { agents: { defaults: { model: "deepseek/deepseek-v4-flash" } } },
+      normalized: normalizeConfig({ stateDir }),
+      sessionId,
+      dependencies: {
+        detectUpstreamConfig: async () => ({
+          providerId: "deepseek",
+          baseUrl: "https://api.example.test/v1",
+          apiKey: "test-key",
+          apiFamily: "openai-completions",
+          models: [{
+            id: "deepseek-v4-flash",
+            name: "DeepSeek V4 Flash",
+            reasoning: false,
+            input: ["text"],
+            contextWindow: 1_000_000,
+            maxTokens: 8_192,
+          }],
+        }),
+        createPolicyModule: ((config: any) => {
+          receivedBatchTurns = config.taskStateEstimator.batchTurns;
+          return { name: "test-policy", async beforeBuild(context: any) { return context; } };
+        }) as any,
+      },
+    });
+
+    assert.equal(receivedBatchTurns, 2);
+    assert.deepEqual(await listRawSemanticTurnSeqs(stateDir, sessionId), [1, 2, 3]);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("cleaner task bootstrap uses a Host-managed model client without provider config", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "openclaw-cleaner-host-model-"));
+  const sessionId = "session-cleaner-host-model";
+  const taskId = `${sessionId}:t1-task`;
+  try {
+    await saveCanonicalState(stateDir, {
+      version: 1,
+      sessionId,
+      messages: [
+        { role: "user", content: "Write a small sorting example." },
+        { role: "assistant", content: "Delivered the example and explanation." },
+      ],
+      seenMessageIds: ["m1", "m2"],
+      updatedAt: new Date().toISOString(),
+    });
+
+    const registry = await ensureOpenClawCleanerTaskRegistry({
+      currentConfig: {
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      },
+      normalized: normalizeConfig({ stateDir }),
+      sessionId,
+      modelClient: {
+        async request() {
+          return {
+            text: JSON.stringify({
+              baseVersion: 0,
+              taskUpdates: [{
+                taskId,
+                title: "Sorting example",
+                objective: "Write a small sorting example.",
+                lifecycle: "completed",
+                coveredTurnAbsIds: [`${sessionId}:t1`],
+                completionEvidence: ["Delivered the example and explanation."],
+                unresolvedQuestions: [],
+              }],
+            }),
+          };
+        },
+      },
+    });
+
+    assert.equal(registry.tasks[taskId]?.lifecycle, "completed");
+    assert.equal(registry.lastProcessedTurnSeq, 1);
+    const annotated = await loadCanonicalState(stateDir, sessionId);
+    assert.deepEqual(
+      annotated?.messages.map((message) => message.details?.contextSafe?.taskIds),
+      [[taskId], [taskId]],
+    );
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});

--- a/components/adapters/openclaw/src/context-cleaner/task-registry-bootstrap.ts
+++ b/components/adapters/openclaw/src/context-cleaner/task-registry-bootstrap.ts
@@ -1,0 +1,200 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  annotateCanonicalMessagesWithTaskAnchors,
+  loadCanonicalState,
+  loadSessionTaskRegistry,
+  saveCanonicalState,
+  type SessionTaskRegistry,
+} from "@lightrsi/history";
+import {
+  contextSafeRecovery,
+  MEMORY_FAULT_RECOVER_TOOL_NAME,
+} from "@lightrsi/artifact-store";
+import type { RuntimeModuleRuntime, RuntimeTurnContext } from "@lightrsi/kernel";
+import {
+  createApiTaskStateEstimator,
+  createPolicyModule,
+  type JsonModelClient,
+} from "@lightrsi/tokenpilot";
+
+import { syncRawSemanticTurnsFromMessages } from "../context-stack/page-out-api.js";
+import { buildPolicyModuleConfigFromPluginConfig } from "../context-stack/integration/policy-config-bridge.js";
+import { detectUpstreamConfig } from "../context-stack/integration/upstream-config.js";
+import type { UpstreamConfig } from "../context-stack/integration/upstream-types.js";
+import type { NormalizedPluginRuntimeConfig } from "../context-stack/integration/config-types.js";
+import { contentToText } from "../context-stack/integration/runtime-event-text.js";
+import {
+  dedupeStrings,
+  ensureContextSafeDetails,
+} from "../context-stack/integration/runtime-tooling.js";
+
+const NO_MODEL_RUNTIME: RuntimeModuleRuntime = {
+  async callModel() {
+    throw new Error("cleaner task-state bootstrap does not use the module runtime model");
+  },
+};
+
+type CleanerTaskRegistryBootstrapLogger = {
+  warn?: (message: string) => void;
+};
+
+function asRecord(value: unknown): Record<string, any> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, any>
+    : undefined;
+}
+
+function configuredModelRef(config: Record<string, unknown>): string {
+  const agents = asRecord(config.agents);
+  const defaults = asRecord(agents?.defaults);
+  const model = defaults?.model;
+  if (typeof model === "string") return model.trim();
+  return typeof asRecord(model)?.primary === "string"
+    ? String(asRecord(model)?.primary).trim()
+    : "";
+}
+
+function providerAndModel(config: Record<string, unknown>): {
+  providerId?: string;
+  modelId?: string;
+} {
+  const ref = configuredModelRef(config);
+  const separator = ref.indexOf("/");
+  if (separator <= 0 || separator === ref.length - 1) return {};
+  return {
+    providerId: ref.slice(0, separator),
+    modelId: ref.slice(separator + 1),
+  };
+}
+
+async function persistTaskAnchors(
+  stateDir: string,
+  sessionId: string,
+  registry: SessionTaskRegistry,
+): Promise<void> {
+  const latest = await loadCanonicalState(stateDir, sessionId);
+  if (!latest) return;
+  const annotated = annotateCanonicalMessagesWithTaskAnchors(
+    latest.messages,
+    registry,
+    asRecord,
+    dedupeStrings,
+    ensureContextSafeDetails,
+  );
+  if (!annotated.changed) return;
+  await saveCanonicalState(stateDir, {
+    ...latest,
+    messages: annotated.messages,
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+export async function ensureOpenClawCleanerTaskRegistry(params: {
+  currentConfig: Record<string, unknown>;
+  normalized: NormalizedPluginRuntimeConfig;
+  sessionId: string;
+  modelClient?: JsonModelClient;
+  logger?: CleanerTaskRegistryBootstrapLogger;
+  dependencies?: {
+    detectUpstreamConfig?: typeof detectUpstreamConfig;
+    createPolicyModule?: typeof createPolicyModule;
+  };
+}): Promise<SessionTaskRegistry> {
+  const current = await loadSessionTaskRegistry(params.normalized.stateDir, params.sessionId);
+  const state = await loadCanonicalState(params.normalized.stateDir, params.sessionId);
+  if (!state || state.messages.length === 0) return current;
+
+  try {
+    const semantic = await syncRawSemanticTurnsFromMessages(
+      params.normalized.stateDir,
+      params.sessionId,
+      state.messages,
+      {
+        contentToText,
+        contextSafeRecovery: (details) => contextSafeRecovery(details, asRecord),
+        memoryFaultRecoverToolName: MEMORY_FAULT_RECOVER_TOOL_NAME,
+      },
+    );
+    if (semantic.turnCount === 0) return current;
+    const pendingTurnCount = Math.max(0, semantic.turnCount - current.lastProcessedTurnSeq);
+    if (pendingTurnCount === 0) {
+      await persistTaskAnchors(params.normalized.stateDir, params.sessionId, current);
+      return current;
+    }
+
+    const preferred = providerAndModel(params.currentConfig);
+    const upstream: UpstreamConfig | null = params.modelClient
+      ? null
+      : await (params.dependencies?.detectUpstreamConfig ?? detectUpstreamConfig)(
+          { warn: (message) => params.logger?.warn?.(message) },
+          { preferredProviderId: preferred.providerId },
+        );
+    if (!params.modelClient && !upstream) {
+      params.logger?.warn?.("[context-cleaner] task registry bootstrap skipped: provider unavailable");
+      return current;
+    }
+
+    const model = upstream && preferred.providerId === upstream.providerId
+      && preferred.modelId
+      && upstream.models.some((candidate) => candidate.id === preferred.modelId)
+      ? preferred.modelId
+      : upstream?.models[0]?.id
+        ?? preferred.modelId
+        ?? params.normalized.taskStateEstimator.model
+        ?? "host-default";
+    if (!model) {
+      params.logger?.warn?.("[context-cleaner] task registry bootstrap skipped: model unavailable");
+      return current;
+    }
+
+    const estimatorConfig: NormalizedPluginRuntimeConfig = {
+      ...params.normalized,
+      taskStateEstimator: {
+        ...params.normalized.taskStateEstimator,
+        enabled: true,
+        ...(upstream ? { baseUrl: upstream.baseUrl, apiKey: upstream.apiKey } : {}),
+        model,
+        // An explicit clean request should classify the complete imported
+        // session in one bounded estimator call instead of waiting for the
+        // normal rolling batch threshold.
+        batchTurns: pendingTurnCount,
+      },
+    };
+    const policy = (params.dependencies?.createPolicyModule ?? createPolicyModule)(
+      buildPolicyModuleConfigFromPluginConfig(estimatorConfig, upstream),
+      params.modelClient
+        ? {
+            createTaskStateEstimator: (config) => createApiTaskStateEstimator(
+              config,
+              () => params.modelClient!,
+            ),
+          }
+        : undefined,
+    );
+    const context: RuntimeTurnContext = {
+      sessionId: params.sessionId,
+      sessionMode: "single",
+      provider: upstream?.providerId ?? preferred.providerId ?? "openclaw",
+      model,
+      apiFamily: upstream?.apiFamily === "anthropic-messages"
+        ? "anthropic-messages"
+        : upstream?.apiFamily === "openai-completions"
+          ? "openai-completions"
+          : upstream?.apiFamily === "openai-responses"
+            ? "openai-responses"
+            : "other",
+      prompt: "",
+      segments: [],
+      budget: { maxInputTokens: 1_000_000, reserveOutputTokens: 16_384 },
+    };
+    await policy.beforeBuild?.(context, NO_MODEL_RUNTIME);
+    const registry = await loadSessionTaskRegistry(params.normalized.stateDir, params.sessionId);
+    await persistTaskAnchors(params.normalized.stateDir, params.sessionId, registry);
+    return registry;
+  } catch (error) {
+    params.logger?.warn?.(
+      `[context-cleaner] task registry bootstrap failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return current;
+  }
+}

--- a/components/adapters/openclaw/src/context-stack/integration/context-engine.test.ts
+++ b/components/adapters/openclaw/src/context-stack/integration/context-engine.test.ts
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { loadCanonicalState } from "@lightrsi/history";
 
 import { createPluginContextEngine } from "./context-engine.js";
 
-function createDeps(transcriptEntries: any[]) {
+function createDeps(transcriptEntries: any[] | null) {
   const traceStages: string[] = [];
   return {
     traceStages,
@@ -33,6 +34,75 @@ function createDeps(transcriptEntries: any[]) {
   };
 }
 
+test("context engine persists runtime messages when the transcript path is unavailable", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "tokenpilot-context-engine-runtime-fallback-"));
+  try {
+    const { deps } = createDeps(null);
+    const engine = createPluginContextEngine({
+      stateDir,
+      moduleEnablement: { stabilizer: false, reduction: false, eviction: false },
+      modules: { eviction: false },
+      eviction: { enabled: false },
+      memory: { enabled: false, autoDistill: false },
+      taskStateEstimator: { evidenceMode: "three_state" },
+    }, {}, deps);
+
+    await engine.assemble({
+      sessionId: "runtime-session",
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+    });
+
+    const state = await loadCanonicalState(stateDir, "runtime-session");
+    assert.deepEqual(state?.messages, [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ]);
+    assert.equal(state?.seenMessageIds.length, 2);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("context engine declares fenced turns and commits them idempotently", async () => {
+  const stateDir = await mkdtemp(join(tmpdir(), "tokenpilot-context-engine-commit-turn-"));
+  try {
+    const { deps } = createDeps(null);
+    const engine = createPluginContextEngine({
+      stateDir,
+      moduleEnablement: { stabilizer: false, reduction: false, eviction: false },
+      modules: { eviction: false },
+      eviction: { enabled: false },
+      memory: { enabled: false, autoDistill: false },
+      taskStateEstimator: { evidenceMode: "three_state" },
+    }, {}, deps);
+
+    assert.deepEqual(engine.info.transcriptSemantics, {
+      currentTurnFence: "before-current-turn-entry-v1",
+      turnAdvancementIdempotency: "atomic-idempotent-v1",
+    });
+
+    const params = {
+      advancementKey: "advance-1",
+      sessionId: "committed-session",
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+    };
+    assert.deepEqual(await engine.commitTurn(params), { status: "committed" });
+    assert.deepEqual(await engine.commitTurn(params), { status: "duplicate" });
+
+    const state = await loadCanonicalState(stateDir, params.sessionId);
+    assert.deepEqual(state?.messages, params.messages);
+    assert.equal(state?.seenMessageIds.length, 2);
+  } finally {
+    await rm(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("context engine skips eviction rewrite and traces when eviction is disabled", async () => {
   const stateDir = await mkdtemp(join(tmpdir(), "tokenpilot-context-engine-disabled-"));
   try {
@@ -48,6 +118,7 @@ test("context engine skips eviction rewrite and traces when eviction is disabled
       taskStateEstimator: { evidenceMode: "three_state" },
     }, {}, deps);
 
+    assert.equal(engine.info.id, "tokenpilot");
     const assembled = await engine.assemble({ sessionId: "session-disabled", messages: [] });
 
     assert.deepEqual(assembled.messages, [{ role: "user", content: "hello" }]);

--- a/components/adapters/openclaw/src/context-stack/integration/context-engine.ts
+++ b/components/adapters/openclaw/src/context-stack/integration/context-engine.ts
@@ -1,6 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { rewriteCanonicalState, syncCanonicalStateFromTranscript } from "../page-out/canonical-rewrite-adapter.js";
-import { estimateMessagesChars, saveCanonicalState } from "@lightrsi/history";
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import {
+  rewriteCanonicalState,
+  syncCanonicalStateFromTranscript,
+} from "../page-out/canonical-rewrite-adapter.js";
+import {
+  appendCanonicalTranscript,
+  estimateMessagesChars,
+  saveCanonicalState,
+} from "@lightrsi/history";
 import { appendModuleObservation } from "@lightrsi/product-surface";
 import { enqueueEvictedTasksForProceduralMemory } from "./procedural-memory.js";
 import { runHistoryEvictionIfEnabled } from "./history-eviction-runner.js";
@@ -11,11 +21,16 @@ export function createPluginContextEngine(cfg: any, logger: any, deps: any) {
   const canonicalMessageTaskIdsBound = (message: Record<string, unknown>): string[] =>
     deps.canonicalMessageTaskIds(message, deps.asRecord);
 
-  async function syncAndEvict(sessionId: string) {
+  async function syncAndEvict(
+    sessionId: string,
+    runtimeMessages: any[] = [],
+    runtimeMessageIdPrefix = "runtime",
+  ) {
     const context: {
       synced?: Awaited<ReturnType<typeof syncCanonicalStateFromTranscript>>;
       eviction?: Awaited<ReturnType<typeof runHistoryEvictionIfEnabled>>;
     } = {};
+    let transcriptAvailable = false;
     const historyModuleExecutions = await runHistoryModules({
       context,
       modules: [
@@ -29,10 +44,52 @@ export function createPluginContextEngine(cfg: any, logger: any, deps: any) {
               getMessage: (entry: any) => entry.message,
               helpers: {
                 appendTaskStateTrace: deps.appendTaskStateTrace,
-                readTranscriptEntriesForSession: deps.readTranscriptEntriesForSession,
+                readTranscriptEntriesForSession: async (currentSessionId: string) => {
+                  const entries = await deps.readTranscriptEntriesForSession(currentSessionId);
+                  transcriptAvailable = entries !== null;
+                  return entries;
+                },
                 stableIdForEntry: deps.transcriptMessageStableId,
               },
             });
+            // OpenClaw may supply a runtime-scoped session id that has no
+            // matching on-disk transcript filename. The Context Engine already
+            // receives the effective messages, so use them as the canonical
+            // input fallback instead of returning a non-persisted empty state.
+            if (!transcriptAvailable && runtimeMessages.length > 0) {
+              const runtimeEntries = runtimeMessages.map((message, index) => {
+                const record = message && typeof message === "object"
+                  ? message as Record<string, unknown>
+                  : { role: "unknown", content: String(message ?? "") };
+                const nativeId = [record.id, record.messageId, record.message_id]
+                  .find((value) => typeof value === "string" && value.trim().length > 0);
+                const row: {
+                  id?: string;
+                  timestamp?: string;
+                  message: Record<string, unknown>;
+                } = {
+                  ...(nativeId ? { id: String(nativeId) } : {}),
+                  timestamp: typeof record.timestamp === "string" ? record.timestamp : undefined,
+                  message: record,
+                };
+                return {
+                  ...row,
+                  id: row.id
+                    ?? `${runtimeMessageIdPrefix}:${index}:${deps.transcriptMessageStableId(row)}`,
+                };
+              });
+              const appended = appendCanonicalTranscript(
+                context.synced.state,
+                runtimeEntries,
+                sessionId,
+                (entry) => entry.message,
+                (entry) => deps.transcriptMessageStableId(entry),
+              );
+              context.synced = {
+                state: appended.state,
+                changed: context.synced.changed || appended.changed,
+              };
+            }
             return context.synced;
           },
         },
@@ -127,19 +184,68 @@ export function createPluginContextEngine(cfg: any, logger: any, deps: any) {
     };
   }
 
+  async function reserveTurnCommit(params: {
+    advancementKey: string;
+    sessionId: string;
+    messages: any[];
+  }): Promise<boolean> {
+    const safeSessionId = params.sessionId.replace(/[^a-zA-Z0-9._-]+/g, "_") || "session";
+    const keyHash = createHash("sha256").update(params.advancementKey).digest("hex");
+    const path = join(
+      cfg.stateDir,
+      "tokenpilot",
+      "context-engine-turns",
+      safeSessionId,
+      `${keyHash}.json`,
+    );
+    await mkdir(dirname(path), { recursive: true });
+    try {
+      await writeFile(path, JSON.stringify({
+        version: 1,
+        advancementKey: params.advancementKey,
+        sessionId: params.sessionId,
+        messages: params.messages,
+        committedAt: new Date().toISOString(),
+      }), { encoding: "utf8", flag: "wx" });
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+      throw error;
+    }
+  }
+
   return {
     info: {
-      id: "layered-context",
+      id: "tokenpilot",
       name: "Layered Context Engine",
+      transcriptSemantics: {
+        currentTurnFence: "before-current-turn-entry-v1",
+        turnAdvancementIdempotency: "atomic-idempotent-v1",
+      },
     },
     async ingest() {
       return { ingested: false };
     },
     async afterTurn(params: { sessionId: string; messages: any[] }) {
+      // Accepted turns are durably advanced by commitTurn. afterTurn only
+      // reconciles host transcript state and runs post-turn modules.
       await syncAndEvict(params.sessionId);
     },
+    async commitTurn(params: {
+      advancementKey: string;
+      sessionId: string;
+      messages: any[];
+    }) {
+      const committed = await reserveTurnCommit(params);
+      const keyHash = createHash("sha256").update(params.advancementKey).digest("hex");
+      // Always reconcile the canonical mirror, including on a host retry. If a
+      // process stopped after the durable marker was written, the retry repairs
+      // the mirror while still reporting the advancement as a duplicate.
+      await syncAndEvict(params.sessionId, params.messages, `turn:${keyHash}`);
+      return { status: committed ? "committed" as const : "duplicate" as const };
+    },
     async assemble(params: { sessionId: string; messages: any[]; tokenBudget?: number }) {
-      const result = await syncAndEvict(params.sessionId);
+      const result = await syncAndEvict(params.sessionId, params.messages);
       const estimatedChars = estimateMessagesChars(result.state.messages, deps.contentToText);
       return {
         messages: result.state.messages,
@@ -147,7 +253,7 @@ export function createPluginContextEngine(cfg: any, logger: any, deps: any) {
       };
     },
     async compact(params: { sessionId: string; messages?: any[]; force?: boolean }) {
-      const result = await syncAndEvict(params.sessionId);
+      const result = await syncAndEvict(params.sessionId, params.messages ?? []);
       return {
         ok: true,
         compacted: result.changed,

--- a/components/adapters/openclaw/src/context-stack/page-out-api.ts
+++ b/components/adapters/openclaw/src/context-stack/page-out-api.ts
@@ -3,6 +3,7 @@ export {
   inferObservationPayloadKind,
   readTranscriptEntriesForSession,
   readTranscriptMessagesForSession,
+  syncRawSemanticTurnsFromMessages,
   syncRawSemanticTurnsFromTranscript,
   transcriptMessageStableId,
   type StructuredTurnObservation,

--- a/components/adapters/openclaw/src/context-stack/page-out/transcript-sync.ts
+++ b/components/adapters/openclaw/src/context-stack/page-out/transcript-sync.ts
@@ -24,6 +24,23 @@ export async function syncRawSemanticTurnsFromTranscript(
   if (!messages || messages.length === 0) {
     return { changed: false, turnCount: 0, updatedTurnSeqs: [] };
   }
+  return syncRawSemanticTurnsFromMessages(stateDir, sessionId, messages, helpers);
+}
+
+/**
+ * Projects an already-authoritative runtime message list into the shared raw
+ * semantic turn store. OpenClaw 2026.9 may keep the live transcript in SQLite,
+ * so a Context Engine cannot assume that a legacy JSONL transcript exists.
+ */
+export async function syncRawSemanticTurnsFromMessages(
+  stateDir: string,
+  sessionId: string,
+  messages: any[],
+  helpers: TranscriptHelpers,
+): Promise<{ changed: boolean; turnCount: number; updatedTurnSeqs: number[] }> {
+  if (!messages || messages.length === 0) {
+    return { changed: false, turnCount: 0, updatedTurnSeqs: [] };
+  }
   let turnCount = 0;
   for (const message of messages) {
     if (String(message?.role ?? "").toLowerCase() === "user") {

--- a/components/adapters/openclaw/src/index.ts
+++ b/components/adapters/openclaw/src/index.ts
@@ -72,11 +72,13 @@ import { __testHooks, contextSafeRecovery, proxyRuntimeHelpers } from "./plugin-
 import { createWorkspaceHintStore } from "./plugin-workspace-hints.js";
 import { createOpenClawStatePathResolver } from "./context-stack/integration/host-adapter.js";
 import { initializeOpenClawTokenPilotPreset } from "./preset.js";
+import { createOpenClawContextCleanerBridge } from "./context-cleaner/index.js";
 
 module.exports = {
   id: "tokenpilot",
   name: "TokenPilot Runtime Optimizer",
   __testHooks,
+  createOpenClawContextCleanerBridge,
 
   register(api: any) {
     initializeOpenClawTokenPilotPreset();

--- a/components/adapters/openclaw/src/index.ts
+++ b/components/adapters/openclaw/src/index.ts
@@ -77,6 +77,10 @@ import { createOpenClawContextCleanerBridge } from "./context-cleaner/index.js";
 module.exports = {
   id: "tokenpilot",
   name: "TokenPilot Runtime Optimizer",
+  description: "Token-efficiency runtime plugin for OpenClaw with pluggable routing and optimization hooks.",
+  // OpenClaw 2026.9+ reads the exclusive slot from openclaw.plugin.json.
+  // Keep the entry-level kind as a compatibility fallback for older hosts.
+  kind: "context-engine",
   __testHooks,
   createOpenClawContextCleanerBridge,
 

--- a/components/adapters/openclaw/src/plugin-register-hooks.ts
+++ b/components/adapters/openclaw/src/plugin-register-hooks.ts
@@ -148,7 +148,7 @@ export function registerLayeredContextEngine(params: {
   if (!cfg.contextEngine.enabled) return;
 
   if (typeof api.registerContextEngine === "function") {
-    api.registerContextEngine("layered-context", () => createPluginContextEngine(cfg, logger, {
+    api.registerContextEngine("tokenpilot", () => createPluginContextEngine(cfg, logger, {
       appendTaskStateTrace,
       appendEvictionVisualSnapshot,
       readTranscriptEntriesForSession,

--- a/components/adapters/openclaw/src/release-package.test.ts
+++ b/components/adapters/openclaw/src/release-package.test.ts
@@ -13,6 +13,17 @@ const tarCommand = process.platform === "win32"
   ? join(process.env.SystemRoot ?? "C:\\Windows", "System32", "tar.exe")
   : "tar";
 
+test("release installer uses OpenClaw managed installation for capability consent", async () => {
+  const script = await readFile(join(packageDir, "scripts", "install_release.sh"), "utf8");
+  assert.match(
+    script,
+    /openclaw_cmd plugins install "\$\{archive_path\}" --force --accept-capabilities/,
+  );
+  assert.doesNotMatch(script, /tar -xzf "\$\{archive_path\}"/);
+  assert.match(script, /tokenpilot_cfg\["proxyAutostart"\] = False/);
+  assert.match(script, /slots\["contextEngine"\] = "tokenpilot"/);
+});
+
 test("release package loads without monorepo workspace dependencies", async () => {
   const extractDir = await mkdtemp(join(tmpdir(), "tokenpilot-release-smoke-"));
   let archivePath = "";
@@ -34,10 +45,15 @@ test("release package loads without monorepo workspace dependencies", async () =
     assert.equal(manifest.name, "@lightrsi/openclaw-adapter");
     assert.equal(manifest.dependencies, undefined);
     assert.equal(manifest.devDependencies, undefined);
+    const pluginManifest = JSON.parse(
+      await readFile(join(installedDir, "openclaw.plugin.json"), "utf8"),
+    );
+    assert.equal(pluginManifest.kind, "context-engine");
 
     const require = createRequire(__filename);
     const plugin = require(join(installedDir, "dist", "index.js"));
     assert.equal(plugin.id, "tokenpilot");
+    assert.equal(plugin.kind, "context-engine");
     assert.equal(typeof plugin.register, "function");
 
     const hooks = plugin.__testHooks;

--- a/components/packages/features/cleaner/src/orchestrator.ts
+++ b/components/packages/features/cleaner/src/orchestrator.ts
@@ -40,8 +40,17 @@ export type AnalyzeContextCleanSessionParams = {
   loadRegistry?: (stateDir: string, sessionId: string) => Promise<SessionTaskRegistry>;
 };
 
-function canonicalPlanId(plan: Omit<ContextCleanPlan, "planId">): string {
-  const digest = createHash("sha256").update(JSON.stringify(plan)).digest("hex").slice(0, 24);
+function canonicalPlanId(
+  plan: Omit<ContextCleanPlan, "planId">,
+  analysis: { fallbackUsed: boolean; reasons: string[] },
+): string {
+  // The analyzed receipt is immutable state associated with the plan id too.
+  // Include its recommendation outcome so two analyses that produce the same
+  // task view but different fallback evidence cannot alias the same plan.
+  const digest = createHash("sha256")
+    .update(JSON.stringify({ plan, analysis }))
+    .digest("hex")
+    .slice(0, 24);
   return `ctxclean-${digest}`;
 }
 
@@ -132,7 +141,10 @@ export async function analyzeContextCleanSession(
   };
   const plan: ContextCleanPlan = {
     ...planWithoutId,
-    planId: canonicalPlanId(planWithoutId),
+    planId: canonicalPlanId(planWithoutId, {
+      fallbackUsed: recommended.fallbackUsed,
+      reasons: recommended.reasons,
+    }),
   };
   const saved = await saveContextCleanPlan({ stateDir: params.stateDir, plan });
   if (saved.bypassed) throwStoreFailure("clean_analysis_plan_store_failed", saved.reasons);

--- a/components/packages/features/cleaner/tests/orchestrator.test.ts
+++ b/components/packages/features/cleaner/tests/orchestrator.test.ts
@@ -216,6 +216,39 @@ test("missing recommendation provider fails closed without making tasks unsafe",
   }
 });
 
+test("analysis identity includes fallback evidence when the task view is unchanged", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-analysis-identity-"));
+  try {
+    const unavailable = await analyzeContextCleanSession({
+      stateDir: root,
+      bridge: bridge(),
+      sessionId: "session-1",
+      async loadRegistry() { return registry(); },
+    });
+    const failedProvider: ContextCleanRecommendationProvider = {
+      async recommend() { throw new Error("provider failed"); },
+    };
+    const failed = await analyzeContextCleanSession({
+      stateDir: root,
+      bridge: bridge(),
+      sessionId: "session-1",
+      provider: failedProvider,
+      async loadRegistry() { return registry(); },
+    });
+
+    assert.deepEqual(failed.plan.tasks, unavailable.plan.tasks);
+    assert.notEqual(failed.plan.planId, unavailable.plan.planId);
+    assert.deepEqual(unavailable.reasons, ["recommendation_provider_unavailable"]);
+    assert.deepEqual(failed.reasons, ["recommendation_provider_failed"]);
+    assert.equal(
+      (await readContextCleanReceipt({ stateDir: root, planId: failed.plan.planId })).value?.fallbackUsed,
+      true,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("cancelling a chars-only plan preserves null token accounting and char savings", async () => {
   const root = await mkdtemp(join(tmpdir(), "lightrsi-clean-cancel-chars-"));
   try {

--- a/components/packages/features/eviction/src/task-state-estimator.ts
+++ b/components/packages/features/eviction/src/task-state-estimator.ts
@@ -5,7 +5,10 @@ import type {
   TaskStateEstimatorInput,
   TaskStateEstimatorOutput,
 } from "./types.js";
-import { createApiJsonModelClient } from "./json-model-client.js";
+import {
+  createApiJsonModelClient,
+  type JsonModelClient,
+} from "./json-model-client.js";
 
 function truncateText(value: string, maxChars = 600): string {
   const text = value.trim();
@@ -292,14 +295,15 @@ function parseEstimatorOutput(
 
 export function createApiTaskStateEstimator(
   cfg: TaskStateEstimatorApiConfig,
+  createClient?: (config: TaskStateEstimatorApiConfig) => JsonModelClient,
 ): TaskStateEstimator {
-  if (!cfg.baseUrl || !cfg.apiKey || !cfg.model) {
+  if (!createClient && (!cfg.baseUrl || !cfg.apiKey || !cfg.model)) {
     throw new Error("task-state estimator requires baseUrl, apiKey, and model");
   }
   const evictionLookaheadTurns = Math.max(1, cfg.evictionLookaheadTurns ?? 3);
   const lifecycleMode = cfg.lifecycleMode === "decoupled" ? "decoupled" : "coupled";
   const evidenceMode = cfg.evidenceMode === "two_state" ? "two_state" : "three_state";
-  const client = createApiJsonModelClient(cfg);
+  const client = (createClient ?? createApiJsonModelClient)(cfg);
   return {
     async estimate(input: TaskStateEstimatorInput): Promise<TaskStateEstimatorOutput> {
       const response = await client.request({

--- a/components/packages/features/eviction/tests/task-state-estimator.test.ts
+++ b/components/packages/features/eviction/tests/task-state-estimator.test.ts
@@ -137,3 +137,25 @@ test("task-state estimator leaves null provider cost unknown", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("task-state estimator accepts a Host-managed JSON model client without provider secrets", async () => {
+  let systemPrompt = "";
+  let userPayload = "";
+  const estimator = createApiTaskStateEstimator(
+    { lifecycleMode: "coupled", evidenceMode: "three_state" },
+    () => ({
+      async request(input) {
+        systemPrompt = input.systemPrompt;
+        userPayload = input.userPayload;
+        return {
+          text: JSON.stringify({ baseVersion: 1, taskUpdates: [] }),
+        };
+      },
+    }),
+  );
+
+  const output = await estimator.estimate(estimatorInput);
+  assert.deepEqual(output, { baseVersion: 1, taskUpdates: [], usage: undefined });
+  assert.match(systemPrompt, /task-state estimator/);
+  assert.equal(JSON.parse(userPayload).registry.version, 1);
+});

--- a/components/presets/tokenpilot/src/policy.ts
+++ b/components/presets/tokenpilot/src/policy.ts
@@ -433,6 +433,7 @@ function buildPatchFromTaskUpdates(
   toTurnSeqInclusive: number,
   options?: {
     allowActiveToEvictable?: boolean;
+    allowNewToEvictable?: boolean;
     collapseCompletedIntoEvictable?: boolean;
   },
 ): {
@@ -473,6 +474,7 @@ function buildPatchFromTaskUpdates(
     const fromHasCompletionEvidence = hasCompletionEvidence(previous);
     const toHasCompletionEvidence = mergedCompletionEvidence.length > 0;
     const allowActiveToEvictable = options?.allowActiveToEvictable === true;
+    const allowNewToEvictable = options?.allowNewToEvictable === true;
     const collapseCompletedIntoEvictable = options?.collapseCompletedIntoEvictable === true;
 
     if (toLifecycle === "completed" && !toHasCompletionEvidence) {
@@ -486,7 +488,7 @@ function buildPatchFromTaskUpdates(
     }
     if (toLifecycle === "evictable") {
       if (!allowActiveToEvictable) {
-        if (fromLifecycle === "active" || !previous) {
+        if (fromLifecycle === "active") {
           rejectedUpdates.push({
             taskId,
             ...(fromLifecycle ? { from: fromLifecycle } : {}),
@@ -495,7 +497,10 @@ function buildPatchFromTaskUpdates(
           });
           continue;
         }
-        if (fromLifecycle !== "completed" && fromLifecycle !== "evictable") {
+        if (
+          (!previous && !allowNewToEvictable)
+          || (previous && fromLifecycle !== "completed" && fromLifecycle !== "evictable")
+        ) {
           rejectedUpdates.push({
             taskId,
             ...(fromLifecycle ? { from: fromLifecycle } : {}),
@@ -1592,6 +1597,12 @@ async function maybeRunTaskStateEstimator(
       estimatorWindow.toTurnSeqInclusive,
       {
         allowActiveToEvictable: evidenceMode === "two_state",
+        // A batched estimator can discover an already-finished historical task
+        // for the first time after the session has moved on. The estimator
+        // prompt permits that task to be emitted directly as evictable when it
+        // carries completion evidence; rejecting it here silently drops its
+        // turn attribution from the registry.
+        allowNewToEvictable: config.taskStateEstimator.lifecycleMode === "coupled",
         collapseCompletedIntoEvictable: evidenceMode === "two_state",
       },
     );

--- a/components/presets/tokenpilot/src/policy.ts
+++ b/components/presets/tokenpilot/src/policy.ts
@@ -83,6 +83,10 @@ export type PolicyModuleConfig = {
   stateDir?: string;
 };
 
+export type PolicyModuleDependencies = {
+  createTaskStateEstimator?: (config: TaskStateEstimatorApiConfig) => TaskStateEstimator;
+};
+
 export type PolicyCacheHealthMode = "warm" | "uncertain" | "cold";
 
 export type PolicyOnlineConfigSnapshot = {
@@ -1708,14 +1712,19 @@ async function maybeRunTaskStateEstimator(
   }
 }
 
-export function createPolicyModule(cfg: PolicyModuleConfig = {}): RuntimeModule {
+export function createPolicyModule(
+  cfg: PolicyModuleConfig = {},
+  dependencies: PolicyModuleDependencies = {},
+): RuntimeModule {
   const config = normalizeConfig(cfg);
   const stateBySession = new Map<string, PolicySessionState>();
   let taskStateEstimator: TaskStateEstimator | null = null;
   let estimatorCreationError: string | null = null;
   if (config.taskStateEstimator.enabled) {
     try {
-      taskStateEstimator = createApiTaskStateEstimator(config.taskStateEstimator);
+      taskStateEstimator = (dependencies.createTaskStateEstimator ?? createApiTaskStateEstimator)(
+        config.taskStateEstimator,
+      );
     } catch (error) {
       estimatorCreationError = error instanceof Error ? error.message : String(error);
     }

--- a/components/products/cli/src/hosts/factory.ts
+++ b/components/products/cli/src/hosts/factory.ts
@@ -4,7 +4,7 @@ import type { CliHostPathOverrides } from "../context-store.js";
 import { registerCleanCommandBackendResolver } from "../clean.js";
 import { createClaudeCodeCleanCommandBackend, createClaudeCodeCliBridge } from "./claude-code.js";
 import { createCodexCleanCommandBackend, createCodexCliBridge } from "./codex.js";
-import { createOpenClawCliBridge } from "./openclaw.js";
+import { createOpenClawCleanCommandBackend, createOpenClawCliBridge } from "./openclaw.js";
 import {
   CLI_HOSTS,
   getCliHostRegistration,
@@ -57,6 +57,7 @@ export function registerBuiltInCliHostProducts(): void {
   registerCleanCommandBackendResolver(({ hostId, pathOverrides }) => {
     if (hostId === "codex") return createCodexCleanCommandBackend(pathOverrides);
     if (hostId === "claude-code") return createClaudeCodeCleanCommandBackend(pathOverrides);
+    if (hostId === "openclaw") return createOpenClawCleanCommandBackend();
     return undefined;
   });
 }

--- a/components/products/cli/src/hosts/openclaw.ts
+++ b/components/products/cli/src/hosts/openclaw.ts
@@ -10,8 +10,14 @@ import {
   readRecentOpenClawCacheAuditRecordsForSession,
 } from "../../../../adapters/openclaw/src/cache-audit.js";
 import { resolveOpenClawConfigPath } from "../../../../adapters/openclaw/src/context-stack/integration/openclaw-paths.js";
-import { openClawProductSurfaceConfigAdapter, resolveStateDir } from "../../../../adapters/openclaw/src/commands/tokenpilot/host-config-adapter.js";
+import {
+  openClawProductSurfaceConfigAdapter,
+  pluginConfigRecord,
+  resolveStateDir,
+} from "../../../../adapters/openclaw/src/commands/tokenpilot/host-config-adapter.js";
 import { formatOpenClawDoctorReport, inspectOpenClawDoctor } from "../../../../adapters/openclaw/src/commands/tokenpilot/openclaw-doctor.js";
+import { normalizeConfig } from "../../../../adapters/openclaw/src/context-stack/integration/config-normalize.js";
+import { createOpenClawContextCleanerBridge } from "../../../../adapters/openclaw/src/context-cleaner/index.js";
 import { buildSessionReportResult, resolveConfiguredPreferredSessionId } from "./shared.js";
 import {
   ensureDetachedVisualDaemon,
@@ -20,6 +26,8 @@ import {
   singleHostVisualMetaPath,
   singleHostVisualPidPath,
 } from "./visual-daemon.js";
+import type { CleanCommandBackend } from "../clean.js";
+import { createHostCleanCommandBackend } from "./cleaner.js";
 
 function normalizeSessionId(value: unknown): string | undefined {
   const text = typeof value === "string" ? value.trim() : "";
@@ -34,6 +42,30 @@ async function loadConfig(): Promise<Record<string, unknown>> {
   } catch {
     return {};
   }
+}
+
+export async function createOpenClawCleanCommandBackend(): Promise<CleanCommandBackend | undefined> {
+  const config = await loadConfig();
+  const stateDir = resolveStateDir(config);
+  if (!stateDir) return undefined;
+  const normalized = normalizeConfig(pluginConfigRecord(config));
+  return createHostCleanCommandBackend({
+    stateDir,
+    recommendationEnabled: normalized.taskStateEstimator.enabled,
+    recommendationConfig: {
+      baseUrl: normalized.taskStateEstimator.baseUrl,
+      apiKey: normalized.taskStateEstimator.apiKey,
+      model: normalized.taskStateEstimator.model,
+      requestTimeoutMs: normalized.taskStateEstimator.requestTimeoutMs,
+    },
+    createBridge(controlPlane) {
+      return createOpenClawContextCleanerBridge({
+        stateDir,
+        controlPlane,
+        config: { replacementMode: normalized.eviction.replacementMode },
+      });
+    },
+  });
 }
 
 async function writeConfig(nextConfig: Record<string, unknown>): Promise<void> {

--- a/components/products/cli/tests/clean-host-registration.test.ts
+++ b/components/products/cli/tests/clean-host-registration.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -81,8 +81,9 @@ test("Host backend recovers frozen item targets from the stored plan", async () 
   }
 });
 
-test("built-in lookup creates Codex and Claude backends but leaves OpenClaw for its PR", async () => {
+test("built-in lookup creates Codex, Claude, and OpenClaw cleaner backends", async () => {
   const root = await mkdtemp(join(tmpdir(), "lightrsi-cli-clean-lookup-"));
+  const originalOpenClawConfigPath = process.env.OPENCLAW_CONFIG_PATH;
   try {
     const codexConfigPath = join(root, "codex-tokenpilot.json");
     const claudeConfigPath = join(root, "claude-tokenpilot.json");
@@ -95,6 +96,20 @@ test("built-in lookup creates Codex and Claude backends but leaves OpenClaw for 
       upstreamBaseUrl: "https://api.anthropic.com/v1/messages",
       taskStateEstimator: { enabled: false },
     }), "utf8");
+    const openClawConfigPath = join(root, "openclaw.json");
+    process.env.OPENCLAW_CONFIG_PATH = openClawConfigPath;
+    await writeFile(openClawConfigPath, JSON.stringify({
+      plugins: {
+        entries: {
+          tokenpilot: {
+            config: {
+              stateDir: join(root, "openclaw-state"),
+              taskStateEstimator: { enabled: false },
+            },
+          },
+        },
+      },
+    }), "utf8");
 
     registerBuiltInCliHostProducts();
     assert.ok(await resolveCleanCommandBackend({
@@ -105,8 +120,10 @@ test("built-in lookup creates Codex and Claude backends but leaves OpenClaw for 
       hostId: "claude-code",
       pathOverrides: { tokenPilotConfigPath: claudeConfigPath },
     }));
-    assert.equal(await resolveCleanCommandBackend({ hostId: "openclaw" }), undefined);
+    assert.ok(await resolveCleanCommandBackend({ hostId: "openclaw" }));
   } finally {
+    if (originalOpenClawConfigPath === undefined) delete process.env.OPENCLAW_CONFIG_PATH;
+    else process.env.OPENCLAW_CONFIG_PATH = originalOpenClawConfigPath;
     await rm(root, { recursive: true, force: true });
   }
 });
@@ -134,6 +151,109 @@ test("real Codex clean dispatch reaches the registered backend", async () => {
     else process.env.USERPROFILE = originalUserProfile;
     if (originalConfigPath === undefined) delete process.env.TOKENPILOT_CODEX_CONFIG;
     else process.env.TOKENPILOT_CODEX_CONFIG = originalConfigPath;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("real OpenClaw clean dispatch applies a canonical plan immediately", async () => {
+  const root = await mkdtemp(join(tmpdir(), "lightrsi-cli-openclaw-clean-dispatch-"));
+  const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const originalSmokeHome = process.env.LIGHTRSI_SMOKE_HOME;
+  try {
+    const stateDir = join(root, "openclaw-state");
+    const configPath = join(root, "openclaw.json");
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    process.env.HOME = root;
+    process.env.USERPROFILE = root;
+    process.env.LIGHTRSI_SMOKE_HOME = root;
+    await writeFile(configPath, JSON.stringify({
+      plugins: { entries: { tokenpilot: { config: {
+        stateDir,
+        eviction: { replacementMode: "drop" },
+        taskStateEstimator: { enabled: false },
+      } } } },
+    }), "utf8");
+
+    const sessionId = "openclaw-cli-clean-session";
+    const canonicalDir = join(stateDir, "tokenpilot", "canonical-state");
+    await mkdir(canonicalDir, { recursive: true });
+    await writeFile(join(canonicalDir, `${sessionId}.json`), JSON.stringify({
+      version: 1,
+      sessionId,
+      messages: [
+        {
+          messageId: "completed-item",
+          role: "assistant",
+          content: "Completed OpenClaw task with enough context to release.",
+          details: { contextSafe: { taskIds: ["task-completed"], turnAbsId: "turn-1" } },
+        },
+        {
+          messageId: "active-item",
+          role: "user",
+          content: "Current task must remain.",
+          details: { contextSafe: { taskIds: ["task-active"], turnAbsId: "turn-2" } },
+        },
+      ],
+      seenMessageIds: ["completed-item", "active-item"],
+      updatedAt: "2026-08-31T00:00:00.000Z",
+    }), "utf8");
+    const registryDir = join(stateDir, "task-state", sessionId);
+    await mkdir(registryDir, { recursive: true });
+    const task = (taskId: string, lifecycle: string, turn: string) => ({
+      taskId,
+      title: taskId,
+      objective: taskId,
+      lifecycle,
+      completionEvidence: lifecycle === "evictable" ? ["delivered"] : [],
+      unresolvedQuestions: [],
+      span: {
+        firstTurnAbsId: turn,
+        lastTurnAbsId: turn,
+        supportingTurnAbsIds: [turn],
+        lastEstimatorTurnAbsId: turn,
+      },
+    });
+    await writeFile(join(registryDir, "registry.json"), JSON.stringify({
+      sessionId,
+      version: 1,
+      tasks: {
+        "task-completed": task("task-completed", "evictable", "turn-1"),
+        "task-active": task("task-active", "active", "turn-2"),
+      },
+      activeTaskIds: ["task-active"],
+      completedTaskIds: ["task-completed"],
+      evictableTaskIds: ["task-completed"],
+      taskToBlockIds: {},
+      blockToTaskIds: {},
+      turnToTaskIds: {},
+      lastProcessedTurnSeq: 2,
+    }), "utf8");
+
+    registerBuiltInCliHostProducts();
+    const backend = await resolveCleanCommandBackend({ hostId: "openclaw" });
+    assert.ok(backend);
+    const analyzed = await backend.analyze(sessionId);
+    const result = await dispatchCli([
+      "openclaw",
+      "clean",
+      "--plan",
+      analyzed.planId,
+      "--select",
+      "task-completed",
+    ]);
+    assert.match(result.text, /Context clean applied/);
+    assert.match(result.text, /Released:/);
+  } finally {
+    if (originalConfigPath === undefined) delete process.env.OPENCLAW_CONFIG_PATH;
+    else process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originalUserProfile;
+    if (originalSmokeHome === undefined) delete process.env.LIGHTRSI_SMOKE_HOME;
+    else process.env.LIGHTRSI_SMOKE_HOME = originalSmokeHome;
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/components/products/cli/tests/dispatch.test.ts
+++ b/components/products/cli/tests/dispatch.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { after } from "node:test";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -7,10 +7,24 @@ import { indexCodexHostSessionAlias } from "../../../adapters/codex/src/session-
 import { readCliContextState } from "../src/context-store.js";
 import { dispatchCli } from "../src/dispatch.js";
 
+const originalUserProfile = process.env.USERPROFILE;
+
+function setTestHome(path: string): void {
+  process.env.HOME = path;
+  // os.homedir() uses USERPROFILE on Windows, while HOME is used on POSIX.
+  // Keep both isolated so these process-global CLI tests never read real state.
+  process.env.USERPROFILE = path;
+}
+
+after(() => {
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+});
+
 test("dispatch supports context inspection and use host flow", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-dispatch-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const context0 = await dispatchCli(["context"]);
     assert.match(context0.text, /lastActiveHost: \(unset\)/);
@@ -36,7 +50,7 @@ test("dispatch supports context inspection and use host flow", async () => {
 test("dispatch routes codex host commands through the shared CLI bridge", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-codex-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const codexHome = join(dir, ".codex");
     await rm(codexHome, { recursive: true, force: true });
@@ -69,7 +83,7 @@ test("dispatch remembers custom codex config paths for later host commands witho
   const originalCodexConfigPath = process.env.CODEX_CONFIG_PATH;
   const originalHooksConfigPath = process.env.CODEX_HOOKS_CONFIG_PATH;
   const originalTokenPilotConfigPath = process.env.TOKENPILOT_CODEX_CONFIG;
-  process.env.HOME = join(dir, "real-home");
+  setTestHome(join(dir, "real-home"));
   process.env.CODEX_CONFIG_PATH = join(dir, "isolated", "config.toml");
   process.env.CODEX_HOOKS_CONFIG_PATH = join(dir, "isolated", "hooks.json");
   process.env.TOKENPILOT_CODEX_CONFIG = join(dir, "isolated", "tokenpilot.json");
@@ -118,7 +132,7 @@ test("dispatch remembers custom codex config paths for later host commands witho
 test("dispatch routes claude-code host commands through the shared CLI bridge", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-claude-code-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const status = await dispatchCli(["claude-code", "status"]);
     assert.match(status.text, /TokenPilot Claude Code status:/);
@@ -148,7 +162,7 @@ test("dispatch remembers custom claude-code config paths for later host commands
   const originalSettingsPath = process.env.CLAUDE_CODE_SETTINGS_PATH;
   const originalMcpConfigPath = process.env.CLAUDE_CODE_MCP_CONFIG_PATH;
   const originalTokenPilotConfigPath = process.env.TOKENPILOT_CLAUDE_CODE_CONFIG;
-  process.env.HOME = join(dir, "real-home");
+  setTestHome(join(dir, "real-home"));
   process.env.CLAUDE_CODE_SETTINGS_PATH = join(dir, "isolated", "settings.json");
   process.env.CLAUDE_CODE_MCP_CONFIG_PATH = join(dir, "isolated", ".claude.json");
   process.env.TOKENPILOT_CLAUDE_CODE_CONFIG = join(dir, "isolated", "tokenpilot.json");
@@ -184,7 +198,7 @@ test("dispatch remembers custom claude-code config paths for later host commands
 test("dispatch uses the default host and latest resolved codex session for hostless report", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-codex-default-report-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const stateDir = join(dir, ".codex", "tokenpilot-state", "tokenpilot");
     await mkdir(join(stateDir, "ux-effects", "sessions"), { recursive: true });
@@ -241,7 +255,7 @@ test("dispatch uses the default host and latest resolved codex session for hostl
 test("dispatch hostless report prefers the host with the latest stats over lastActiveHost", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-report-latest-host-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const codexStateDir = join(dir, ".codex", "tokenpilot-state", "tokenpilot");
     const claudeStateDir = join(dir, ".claude", "tokenpilot-state", "tokenpilot");
@@ -328,7 +342,7 @@ test("dispatch hostless report prefers the host with the latest stats over lastA
 test("dispatch explicit host report does not fallback to another host", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-report-explicit-host-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const codexStateDir = join(dir, ".codex", "tokenpilot-state", "tokenpilot");
     await mkdir(join(codexStateDir, "ux-effects", "sessions"), { recursive: true });
@@ -374,7 +388,7 @@ test("dispatch explicit host report does not fallback to another host", async ()
 test("dispatch canonicalizes pinned codex host session ids before persisting CLI context", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-codex-canonical-context-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const stateDir = join(dir, ".codex", "tokenpilot-state", "tokenpilot");
     await mkdir(join(stateDir, "session-state"), { recursive: true });
@@ -399,7 +413,7 @@ test("dispatch canonicalizes pinned codex host session ids before persisting CLI
 test("dispatch uses the pinned default claude-code session for hostless visual", async () => {
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-claude-default-visual-"));
   const originalHome = process.env.HOME;
-  process.env.HOME = dir;
+  setTestHome(dir);
   try {
     const stateDir = join(dir, ".claude", "tokenpilot-state", "tokenpilot");
     await mkdir(join(stateDir, "session-state", "sessions"), { recursive: true });
@@ -459,7 +473,7 @@ test("dispatch keeps top-level visual multi-host even when a default host is sel
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-default-host-visual-"));
   const originalHome = process.env.HOME;
   const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
-  process.env.HOME = dir;
+  setTestHome(dir);
   process.env.OPENCLAW_CONFIG_PATH = join(dir, ".openclaw", "openclaw.json");
   try {
     const openclawStateDir = join(dir, ".openclaw", "tokenpilot-state", "tokenpilot");
@@ -486,7 +500,7 @@ test("dispatch keeps top-level visual multi-host even when a default host is sel
             },
           },
           slots: {
-            contextEngine: "layered-context",
+            contextEngine: "tokenpilot",
           },
         },
       }, null, 2)}\n`,
@@ -558,7 +572,7 @@ test("dispatch uses the default openclaw host and latest session for hostless re
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-openclaw-default-report-"));
   const originalHome = process.env.HOME;
   const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
-  process.env.HOME = dir;
+  setTestHome(dir);
   process.env.OPENCLAW_CONFIG_PATH = join(dir, ".openclaw", "openclaw.json");
   try {
     const stateDir = join(dir, ".openclaw", "tokenpilot-state", "tokenpilot");
@@ -577,7 +591,7 @@ test("dispatch uses the default openclaw host and latest session for hostless re
             },
           },
           slots: {
-            contextEngine: "layered-context",
+            contextEngine: "tokenpilot",
           },
         },
       }, null, 2)}\n`,
@@ -629,7 +643,7 @@ test("dispatch exposes standalone lightrsi visual when no default host is select
   const dir = await mkdtemp(join(tmpdir(), "lightrsi-cli-standalone-visual-"));
   const originalHome = process.env.HOME;
   const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
-  process.env.HOME = dir;
+  setTestHome(dir);
   process.env.OPENCLAW_CONFIG_PATH = join(dir, ".openclaw", "openclaw.json");
   try {
     const openclawStateDir = join(dir, ".openclaw", "tokenpilot-state", "tokenpilot");
@@ -656,7 +670,7 @@ test("dispatch exposes standalone lightrsi visual when no default host is select
             },
           },
           slots: {
-            contextEngine: "layered-context",
+            contextEngine: "tokenpilot",
           },
         },
       }, null, 2)}\n`,

--- a/components/products/cli/tests/openclaw-host.test.ts
+++ b/components/products/cli/tests/openclaw-host.test.ts
@@ -75,7 +75,7 @@ test("openclaw CLI bridge resolves explicit session stats and missing aggregate 
             },
           },
           slots: {
-            contextEngine: "layered-context",
+            contextEngine: "tokenpilot",
           },
         },
       }, null, 2)}\n`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,6 +133,9 @@ importers:
       '@lightrsi/artifact-store':
         specifier: workspace:*
         version: link:../../packages/foundation/artifact-store
+      '@lightrsi/cleaner':
+        specifier: workspace:*
+        version: link:../../packages/features/cleaner
       '@lightrsi/eviction':
         specifier: workspace:*
         version: link:../../packages/features/eviction


### PR DESCRIPTION
## Summary

Add the OpenClaw canonical Context Cleaner backend and register it with the CLI.

This PR enables approved OpenClaw clean plans to be safely applied to canonical session state. Unlike asynchronous Codex and Claude Code scheduling, the OpenClaw reference backend applies an approved plan immediately and records an `applied` receipt.

## What changed

### OpenClaw Context Cleaner backend

- Add canonical OpenClaw session discovery and snapshot loading.
- Convert OpenClaw session context into the shared Cleaner snapshot format.
- Validate the clean plan before applying it:
  - host and session identity
  - expected revision
  - approved task selection
  - stable item IDs and content digests
  - protected active/current/unresolved tasks
  - system and developer messages
  - tool-call closure
- Reuse the existing OpenClaw reference eviction backend instead of introducing a second deletion implementation.
- Archive selected context before mutating canonical state.
- Persist the rewritten canonical state atomically.
- Record:
  - previous and next revisions
  - applied operation IDs
  - target item IDs
  - actual saved characters
  - fallback evidence
- Preserve idempotent apply behavior.

### Concurrency and recovery

- Add a session-level cross-process lock to serialize competing apply and cancel operations.
- Reject stale plans when the canonical revision has changed.
- Persist an adapter apply intent before canonical mutation.
- Recover the final Cleaner receipt after a crash between canonical state commit and receipt commit.
- Allow `clean --status` to complete this recovery.
- Prevent cancellation from reporting `cancelled` after the canonical mutation has already been applied.

### CLI integration

- Register the OpenClaw Cleaner backend in the CLI Host factory.
- Reuse the existing OpenClaw plugin configuration and `stateDir`.
- Reuse the task-state estimator provider configuration.
- Support the canonical commands:

```bash
lightrsi openclaw clean --session <session-id>
lightrsi openclaw clean --plan <plan-id> --select <task-id,...>
lightrsi openclaw clean --status <plan-id>
lightrsi openclaw clean --cancel <plan-id>
```

### Package and documentation updates

- Export `createOpenClawContextCleanerBridge` from the OpenClaw adapter.
- Add `@lightrsi/cleaner` to the OpenClaw adapter dependencies.
- Update the workspace lockfile.
- Document the OpenClaw analyze/select flow and immediate `applied` semantics.

## Safety

- Active, current and unresolved tasks remain protected.
- System and developer messages cannot be directly removed.
- Tool-call groups are validated as a closure.
- Plans retain stable item IDs and content digests.
- Stale revisions are rejected before mutation.
- Canonical context is archived before rewriting.
- The existing canonical eviction implementation remains the only deletion backend.
- This PR does not change Codex or Claude Code runtime behavior.
- This PR does not change frozen eviction semantics or the recommendation algorithm.

## Validation

Passed:

- Cleaner test suite: **79/79**
- CLI test suite: **37/37**
- OpenClaw affected Cleaner/reference/cross-host tests: **22/22**
- OpenClaw Context Cleaner bridge tests: **5/5**
  - session discovery and snapshot loading
  - immediate apply, archive, receipt and idempotence
  - stale revision rejection
  - concurrent apply serialization
  - crash/restart receipt recovery through status
- OpenClaw and CLI type checks
- OpenClaw and CLI builds
- Package-boundary validation: **18 packages / 71 internal edges**
- `git diff --check`

The built CLI was also tested against an isolated OpenClaw state directory with the actual commands for:

- analyze
- approve and apply
- status
- cancel
- cancelled-plan status

The smoke test confirmed that the selected completed task was removed while the active task was preserved.

## Environment note

The complete legacy OpenClaw suite was not fully green in the current Windows environment. The remaining failures are in pre-existing reduction, global-state, temporary-path and release-environment tests outside the files changed by this PR.

The release-package test could not complete because the default `bash` points to WSL without an installed distribution; the Git Bash packaging/install step also did not complete. Both production bundles built successfully, and all affected Context Cleaner, CLI and OpenClaw reference suites passed.

## Commits

- `0541406 feat(openclaw): apply approved clean plans`
- `806f341 feat(cli): register openclaw cleaner backend`

## Review notes

The following shared/common files need owner review:

- `components/products/cli/src/hosts/openclaw.ts`
- `components/products/cli/src/hosts/factory.ts`
- `components/products/cli/tests/clean-host-registration.test.ts`
- `components/adapters/openclaw/package.json`
- `pnpm-lock.yaml`

## Follow-up fixes

- Persist OpenClaw canonical session state required by Context Cleaner.
- Bootstrap the shared task registry from native OpenClaw conversations.
- Reuse OpenClaw Host-managed inference for task-state estimation and Cleaner recommendations without duplicating API credentials.
- Fix immutable plan identity conflicts when fallback evidence changes.
- Fix release installation under WSL and Windows CLI test isolation.

## Verification

- Cleaner: 80/80 tests passed
- Eviction: 47/47 tests passed
- TokenPilot: 7/7 tests passed
- OpenClaw adapter: 141/141 tests passed
- CLI: 37/37 tests passed
- All relevant typechecks passed

## Real OpenClaw smoke test

Verified the native command flow:

1. `/lightrsi clean`
2. Explicit task selection with `--plan` and `--select`
3. `/lightrsi clean --status`
4. Re-analysis after apply

Observed result:

- Context before: 86,428 chars
- Applied savings: 1,947 chars
- Context after: 84,481 chars
- Active and recent tasks remained protected